### PR TITLE
Display the reference genome

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,8 +1,10 @@
 [ignore]
+node_modules/
 
 [include]
 
 [libs]
 lib
+types
 
 [options]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,8 +12,17 @@ module.exports = function(grunt) {
     },
     watch: {
       flow: {
-        files: ['src/**/*.js', 'test/**/*.js'],
+        files: [
+          'src/**/*.js',
+          'test/**/*.js',
+          'lib/**/*.js',
+          'types/**/*.js'
+        ],
         tasks: ['flow:app:status']
+      },
+      flowProd: {
+        files: ['<%= watch.flow.files %>'],
+        tasks: ['flow:app:status', 'prod']
       }
     },
     browserify: {
@@ -52,8 +61,9 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-flow-type-check');
   grunt.loadNpmTasks('grunt-mocha-phantomjs');
 
-  grunt.registerTask('watchFlow', ['flow:app:start', 'watch']);
-  grunt.registerTask('prod', ['flow:app', 'browserify:dist']);
+  grunt.registerTask('watchFlow', ['flow:app:start', 'watch:flow']);
+  grunt.registerTask('watchFlowProd', ['flow:app:start', 'watch:flowProd']);
+  grunt.registerTask('prod', ['browserify:dist']);
   grunt.registerTask('browsertests', ['browserify:test']);
   grunt.registerTask('test', ['browsertests', 'mocha_phantomjs']);
 };

--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ Interactive in-browser track viewer
     npm install
     grunt prod
 
-Then open `playground.html` in your browser of choice.
+To play with the demo, you'll need [RangeHTTPServer][rs], which adds support
+for byte range requests to SimpleHTTPServer:
+
+    pip install rangehttpserver
+    python -m RangeHTTPServer
+
+Then open `http://localhost:8000/playground.html` in your browser of choice.
 
 ## Development
 
@@ -24,3 +30,9 @@ Run the tests in a real browser:
 To iterate on code while running the type checker:
 
     grunt watchFlow
+
+To continuously regenerate the combined JS, run:
+
+    grunt watchFlowProd
+
+[rs]: https://github.com/danvk/RangeHTTPServer

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/danvk/pileup.js",
   "dependencies": {
     "q": "^1.1.2",
+    "react": "^0.12.2",
     "underscore": "^1.7.0"
   },
   "devDependencies": {

--- a/playground.html
+++ b/playground.html
@@ -1,1 +1,2 @@
+<div id="root"></div>
 <script src="build/all.js"></script>

--- a/src/Controls.js
+++ b/src/Controls.js
@@ -1,0 +1,44 @@
+/**
+ * Controls for zooming to particular ranges of the genome.
+ * @flow
+ */
+
+var React = require('react'),
+    types = require('./types');
+
+var Controls = React.createClass({
+  propTypes: {
+    range: types.GenomeRange,
+    contigList: React.PropTypes.arrayOf(React.PropTypes.string),
+    // XXX: can we be more specific than this with Flow?
+    onChange: React.PropTypes.func.isRequired
+  },
+  handleChange: function(e: SyntheticEvent) {
+    var range = {
+      contig: this.refs.contig.getDOMNode().value,
+      start: Number(this.refs.start.getDOMNode().value),
+      stop: Number(this.refs.stop.getDOMNode().value)
+    };
+    // XXX this should be a type error w/o the Number() above, but it isn't.
+    this.props.onChange(range);
+  },
+  render: function(): any {
+    var contigOptions = this.props.contigList
+        ? this.props.contigList.map((contig, i) => <option key={i}>{contig}</option>)
+        : null;
+
+    return (
+      <div className='controls'>
+        Contig:
+        <select ref='contig' onChange={this.handleChange}>
+          {contigOptions}
+        </select>
+        <input ref='start' type='text' />
+        <input ref='stop' type='text'  />
+        <button onClick={this.handleChange}>Update</button>
+      </div>
+    );
+  }
+});
+
+module.exports = Controls;

--- a/src/GenomeTrack.js
+++ b/src/GenomeTrack.js
@@ -1,0 +1,38 @@
+/**
+ * A track which displays a reference genome.
+ * @flow
+ */
+
+var React = require('react'),
+    types = require('./types');
+
+var GenomeTrack = React.createClass({
+  propTypes: {
+    range: types.GenomeRange,
+    basePairs: React.PropTypes.string
+  },
+  render: function(): any {
+    if (!this.props.range) {
+      return <EmptyTrack />;
+    }
+    var range = this.props.range;
+    var rangeLength = range.limit - range.start;
+    if (rangeLength > 200) {
+      return <EmptyTrack />;
+    }
+
+    if (!this.props.basePairs) {
+      return <div>no data</div>;
+    }
+
+    return <div>{this.props.basePairs}</div>;
+  }
+});
+
+var EmptyTrack = React.createClass({
+  render: function() {
+    return <div>Zoom in to see bases</div>
+  }
+});
+
+module.exports = GenomeTrack;

--- a/src/GenomeTrack.js
+++ b/src/GenomeTrack.js
@@ -12,10 +12,10 @@ var GenomeTrack = React.createClass({
     basePairs: React.PropTypes.string
   },
   render: function(): any {
-    if (!this.props.range) {
+    var range = this.props.range;
+    if (!range) {
       return <EmptyTrack />;
     }
-    var range = this.props.range;
     var rangeLength = range.limit - range.start;
     if (rangeLength > 200) {
       return <EmptyTrack />;

--- a/src/Root.js
+++ b/src/Root.js
@@ -16,7 +16,7 @@ var Root = React.createClass({
   },
   getInitialState: function(): any {
     return {
-      contigList: ['1', '2', '3'],
+      contigList: [],
       range: null,
       basePairs: null
     }

--- a/src/Root.js
+++ b/src/Root.js
@@ -1,0 +1,51 @@
+/**
+ * Root of the React component tree.
+ * @flow
+ */
+
+var React = require('react'),
+    Controls = require('./Controls'),
+    GenomeTrack = require('./GenomeTrack'),
+    types = require('./types'),
+    // TODO: make this an "import type" when react-tools 0.13.0 is out.
+    TwoBit = require('./TwoBit');
+
+var Root = React.createClass({
+  propTypes: {
+    referenceSource: React.PropTypes.object.isRequired
+  },
+  getInitialState: function(): any {
+    return {
+      contigList: ['1', '2', '3'],
+      range: null,
+      basePairs: null
+    }
+  },
+  componentDidMount: function() {
+    // Note: flow is unable to infer this type through `this.propTypes`.
+    var ref: TwoBit = this.props.referenceSource;
+    ref.getContigList().then(contigList => {
+      this.setState({contigList});
+    });
+  },
+  handleRangeChange: function(newRange: GenomeRange) {
+    this.setState({range: newRange, basePairs: null});
+    var ref = this.props.referenceSource;
+    ref.getFeaturesInRange(newRange.contig, newRange.start, newRange.stop)
+       .then(basePairs => {
+         this.setState({basePairs});
+       });
+  },
+  render: function(): any {
+    return (
+      <div>
+        <Controls contigList={this.state.contigList}
+                  onChange={this.handleRangeChange} />
+        <GenomeTrack range={this.state.range}
+                     basePairs={this.state.basePairs} />
+      </div>
+    );
+  }
+});
+
+module.exports = Root;

--- a/src/TwoBit.js
+++ b/src/TwoBit.js
@@ -176,7 +176,7 @@ class TwoBit {
   getFeaturesInRange(contig: string, start: number, stop: number): Q.Promise<string> {
     start--;  // switch to zero-based indices
     stop--;
-    return this.getSequenceHeader(contig).then(header => {
+    return this._getSequenceHeader(contig).then(header => {
       var dnaOffset = header.offset + header.dnaOffsetFromHeader;
       var offset = Math.floor(dnaOffset + start/4);
       var byteLength = Math.ceil((stop - start + 1) / 4) + 1;
@@ -188,7 +188,12 @@ class TwoBit {
     });
   }
 
-  getSequenceHeader(contig: string): Q.Promise<SequenceRecord> {
+  // Returns a list of contig names.
+  getContigList(): Q.Promise<string[]> {
+    return this.header.then(header => header.sequences.map(seq => seq.name));
+  }
+
+  _getSequenceHeader(contig: string): Q.Promise<SequenceRecord> {
     return this.header.then(header => {
       var maybeSeq = _.findWhere(header.sequences, {name: contig}) ||
                      _.findWhere(header.sequences, {name: 'chr' + contig});

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,12 @@
 /* @flow */
-var TwoBit = require('./TwoBit');
+var React = require('react'),
+    TwoBit = require('./TwoBit'),
+    Root = require('./Root');
 
 var startMs = Date.now();
 // var genome = new TwoBit('http://www.biodalliance.org/datasets/hg19.2bit');
 var genome = new TwoBit('http://localhost:8000/hg19.2bit');
+
 genome.getFeaturesInRange('chr22', 19178140, 19178170).then(basePairs => {
   var endMs = Date.now();
   console.log('elapsed time (ms):', endMs - startMs);
@@ -12,3 +15,6 @@ genome.getFeaturesInRange('chr22', 19178140, 19178170).then(basePairs => {
     throw 'Incorrect genomic data!';
   }
 }).done();
+
+var root = React.render(<Root referenceSource={genome} />,
+                        document.getElementById('root'));

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,14 @@
+/**
+ * Common types used in many React components.
+ * @flow
+ */
+var React = require('react');
+
+module.exports = {
+  // A range in a genome. Note: may be null.
+  GenomeRange: React.PropTypes.shape({
+    contig: React.PropTypes.string,
+    start: React.PropTypes.number,
+    stop: React.PropTypes.number
+  })
+};

--- a/types/types.js
+++ b/types/types.js
@@ -1,0 +1,5 @@
+declare class GenomeRange {
+  contig: string;
+  start: ?number;
+  stop: ?number;
+}


### PR DESCRIPTION
Here it is in action:

![screen shot 2015-02-23 at 7 00 09 pm](https://cloud.githubusercontent.com/assets/98301/6340551/3a90ba0e-bb8e-11e4-91f7-29c4009f2d76.png)

Nothing too fancy, but it works!

There were a few Flow warts that I ran into:

  - Flow can't track types through `this.props`—the `React.PropTypes` type system isn't precise enough.
  - There's an [`import type`][1] statement coming very soon, but it won't import type aliases. "Soon", they say. For now, I'm putting shared type aliases in a global file.

This version of the code doesn't have much to say about how data will be organized eventually—thoughts on that would be much appreciated!

[1]: http://flowtype.org/blog/2015/02/18/Import-Types.html