### PR TITLE
Faster rebuilds with watchify

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,14 +20,6 @@ module.exports = function(grunt) {
         ],
         tasks: ['flow:app:status']
       },
-      flowProd: {
-        files: ['<%= watch.flow.files %>'],
-        tasks: ['flow:app:status', 'prod']
-      },
-      prod: {
-        files: ['<%= watch.flow.files %>'],
-        tasks: ['browserify:dist']
-      }
     },
     browserify: {
       dist: {
@@ -38,6 +30,20 @@ module.exports = function(grunt) {
       test: {
         files: {
           'build/tests.js': ['src/**/*.js', 'test/**/*-test.js', '!src/main.js']
+        }
+      },
+      watchDist: {
+        files: '<%= browserify.dist.files %>',
+        options: {
+          watch: true,
+          keepAlive: true,
+        }
+      },
+      watchTest: {
+        files: '<%= browserify.test.files %>',
+        options: {
+          watch: true,
+          keepAlive: true,
         }
       },
       options: {
@@ -103,7 +109,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-uglify');
 
   grunt.registerTask('watchFlow', ['flow:app:start', 'watch:flow']);
-  grunt.registerTask('watchFlowProd', ['flow:app:start', 'watch:flowProd']);
   grunt.registerTask('prod', ['browserify:dist', 'uglify:dist']);
   grunt.registerTask('browsertests', ['browserify:test']);
   grunt.registerTask('test', ['browsertests', 'mocha_phantomjs:run']);

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ To iterate on code while running the type checker:
 
 To continuously regenerate the combined JS, run:
 
-    grunt watch:prod
+    grunt browserify:watchDist
+
+To continuously regenerate the testing JS, run:
+
+    grunt browserify:watchTest
 
 [hs]: https://github.com/nodeapps/http-server


### PR DESCRIPTION
This reduces iteration time on the test bundle from 10–15s to around 1s.

Fixes #31 