### PR TITLE
Visualize genes

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1,25 +1,2 @@
 declare function describe(description: string, spec: () => void): void;
 declare function it(expectation: string, assertion: (done: () => void) => void): void;
-
-/*
-declare function before(action: () => void): void;
-
-declare function before(action: (done: MochaDone) => void): void;
-
-declare function setup(action: () => void): void;
-
-declare function setup(action: (done: MochaDone) => void): void;
-
-declare function after(action: () => void): void;
-
-declare function after(action: (done: MochaDone) => void): void;
-
-declare function teardown(action: () => void): void;
-
-declare function teardown(action: (done: MochaDone) => void): void;
-
-declare function beforeEach(action: () => void): void;
-
-declare function beforeEach(action: (done: MochaDone) => void): void;
-
-*/

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1,0 +1,25 @@
+declare function describe(description: string, spec: () => void): void;
+declare function it(expectation: string, assertion: (done: () => void) => void): void;
+
+/*
+declare function before(action: () => void): void;
+
+declare function before(action: (done: MochaDone) => void): void;
+
+declare function setup(action: () => void): void;
+
+declare function setup(action: (done: MochaDone) => void): void;
+
+declare function after(action: () => void): void;
+
+declare function after(action: (done: MochaDone) => void): void;
+
+declare function teardown(action: () => void): void;
+
+declare function teardown(action: (done: MochaDone) => void): void;
+
+declare function beforeEach(action: () => void): void;
+
+declare function beforeEach(action: (done: MochaDone) => void): void;
+
+*/

--- a/lib/underscore.js
+++ b/lib/underscore.js
@@ -6,7 +6,7 @@ declare module "underscore" {
 
   declare function isEqual<S, T>(a: S, b: T): boolean;
   declare function range(a: number, b: number): Array<number>;
-  declare function extend(...o: Object): Object;
+  declare function extend<S, T>(o1: S, o2: T): S & T;
 
   declare function chain<S>(obj: S): any;
 }

--- a/lib/underscore.js
+++ b/lib/underscore.js
@@ -8,6 +8,10 @@ declare module "underscore" {
   declare function range(a: number, b: number): Array<number>;
   declare function extend<S, T>(o1: S, o2: T): S & T;
 
+  declare function zip<S, T>(a1: S[], a2: T[]): Array<[S, T]>;
+
+  declare function flatten<S>(a: S[][]): S[];
+
   declare function chain<S>(obj: S): any;
 }
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "mocha": "^2.1.0",
     "mocha-lcov-reporter": ">=0.0.2",
     "parse-data-uri": "^0.2.0",
-    "react-tools": "^0.12.2",
+    "react-tools": "^0.13.1",
     "reactify": "^1.0.0",
     "sinon": "^1.12.2",
     "source-map": "^0.3.0"

--- a/playground.html
+++ b/playground.html
@@ -8,6 +8,9 @@
 }
 
 /* reference track */
+.background {
+  fill: white;
+}
 .basepair.a { fill: #188712; }
 .basepair.g { fill: #C45C16; }
 .basepair.c { fill: #0600F9; }

--- a/playground.html
+++ b/playground.html
@@ -50,5 +50,3 @@ text.basepair {
 </body>
 
 <script src="build/all.js"></script>
-
-<script src="//cdnjs.cloudflare.com/ajax/libs/q.js/1.2.0/q.js"></script>

--- a/playground.html
+++ b/playground.html
@@ -47,3 +47,5 @@ text.basepair {
 </body>
 
 <script src="build/all.js"></script>
+
+<script src="//cdnjs.cloudflare.com/ajax/libs/q.js/1.2.0/q.js"></script>

--- a/playground.html
+++ b/playground.html
@@ -1,18 +1,43 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <style>
+/* track dimensions */
 .reference {
   width: 1200px;
   height: 50px;
 }
+
+/* reference track */
 .basepair.a { fill: #188712; }
 .basepair.g { fill: #C45C16; }
 .basepair.c { fill: #0600F9; }
 .basepair.t { fill: #F70016; }
 .basepair.u { fill: #F70016; }
-text {
+text.basepair {
   font-size: 36;
   font-weight: bold;
+}
+
+/* gene track */
+.genes {
+  width: 1200px;
+  height: 50px;
+}
+.gene {
+  stroke-width: 1;
+  stroke: blue;
+}
+.gene text {
+  font-size: 16px;
+  text-anchor: middle;
+  stroke: black;
+  alignment-baseline: hanging;
+}
+#sense, #antisense {
+  stroke: blue;
+}
+.exon {
+  fill: blue;
 }
 </style>
 </head>

--- a/src/BigBedDataSource.js
+++ b/src/BigBedDataSource.js
@@ -1,0 +1,85 @@
+'use strict';
+
+var Events = require('backbone').Events,
+    _ = require('underscore');
+
+
+var ContigInterval = require('./ContigInterval'),
+    Interval = require('./Interval');
+
+
+// TODO: move this into BigBed.js
+type Gene = {
+  position: ContigInterval;
+  id: string;  // transcript ID, e.g. "ENST00000269305"
+  strand: string;  // '+' or '-'
+  codingStart: number;  // locus of coding start
+  codingStop: number;
+  exons: Array<Interval>;
+  geneId: string;  // ensembl gene ID
+  name: string;  // human-readable name, e.g. "TP53"
+}
+
+// The fields are described at http://genome.ucsc.edu/FAQ/FAQformat#format1
+function parseBedFeature(f): Gene {
+  var position = new ContigInterval(f.contig, f.start, f.stop),
+      x = f.rest.split('\t'),
+      exonLengths = x[7].split(',').map(Number),
+      exonStarts = x[8].split(',').map(Number),
+      exons = _.zip(exonStarts, exonLengths)
+               .map(function([start, length]) {
+                 return new Interval(start, start + length);
+               });
+
+  return {
+    position,
+    id: x[0],  // e.g. ENST00000359597
+    strand: x[2],  // either + or -
+    codingStart: Number(x[3]),
+    codingStop: Number(x[4]),
+    geneId: x[9],
+    name: x[10],
+    exons
+  };
+}
+
+
+function createBigBedDataSource(remoteSource: BigBed) {
+  // Collection of genes that have already been loaded.
+  var genes: Array<Gene> = [];
+  window.genes = genes;
+
+  function addGene(newGene) {
+    if (!_.findWhere(genes, {id: newGene.id})) {
+      genes.push(newGene);
+    }
+  }
+
+  function getGenesInRange(range: ContigInterval) {
+    if (!range) return [];
+    return genes.filter(gene => range.intersects(gene.position));
+  }
+
+  function fetch(range: GenomeRange) {
+    // TODO: add an API for requesting the entire block of genes.
+    return remoteSource.getFeaturesInRange(range.contig, range.start, range.stop)
+        .then(features => {
+          var genes = features.map(parseBedFeature);
+          genes.forEach(gene => addGene(gene));
+        });
+  }
+
+  var o = {
+    rangeChanged: function(newRange: GenomeRange) {
+      fetch(newRange)
+          .then(() => o.trigger('newdata', newRange))
+          .done();
+    },
+    getGenesInRange
+  };
+  _.extend(o, Events);  // Make this an event emitter
+
+  return o;
+}
+
+module.exports = createBigBedDataSource;

--- a/src/BigBedDataSource.js
+++ b/src/BigBedDataSource.js
@@ -55,7 +55,7 @@ function createBigBedDataSource(remoteSource: BigBed) {
     }
   }
 
-  function getGenesInRange(range: ContigInterval) {
+  function getGenesInRange(range: ContigInterval): Gene[] {
     if (!range) return [];
     return genes.filter(gene => range.intersects(gene.position));
   }

--- a/src/Controls.js
+++ b/src/Controls.js
@@ -45,9 +45,11 @@ var Controls = React.createClass({
   zoomOut: function() {
     this.zoomByFactor(2.0);
   },
-  zoomByFactor: function(factor) {
-    var r = this.props.range,
-        span = r.stop - r.start,
+  zoomByFactor: function(factor: number) {
+    var r = this.props.range;
+    if (!r) return;
+
+    var span = r.stop - r.start,
         center = r.start + span / 2,
         newSpan = factor * span;
     this.props.onChange({

--- a/src/Controls.js
+++ b/src/Controls.js
@@ -39,6 +39,23 @@ var Controls = React.createClass({
       this.refs.contig.getDOMNode().selectedIndex = contigIdx;
     }
   },
+  zoomIn: function() {
+    this.zoomByFactor(0.5);
+  },
+  zoomOut: function() {
+    this.zoomByFactor(2.0);
+  },
+  zoomByFactor: function(factor) {
+    var r = this.props.range,
+        span = r.stop - r.start,
+        center = r.start + span / 2,
+        newSpan = factor * span;
+    this.props.onChange({
+      contig: r.contig,
+      start: Math.max(0, center - newSpan / 2),
+      stop: center + newSpan / 2  // TODO: clamp
+    });
+  },
   render: function(): any {
     var contigOptions = this.props.contigList
         ? this.props.contigList.map((contig, i) => <option key={i}>{contig}</option>)
@@ -54,6 +71,9 @@ var Controls = React.createClass({
         <input ref='start' type='text' />
         <input ref='stop' type='text' />
         <button>Go</button>
+
+        <button onClick={this.zoomOut}>-</button>
+        <button onClick={this.zoomIn}>+</button>
       </form>
     );
   },

--- a/src/GeneTrack.js
+++ b/src/GeneTrack.js
@@ -1,0 +1,104 @@
+var React = require('react/addons'),
+    _ = require('underscore'),
+    d3 = require('d3'),
+    types = require('./types');
+
+var GeneTrack = React.createClass({
+  propTypes: {
+    range: types.GenomeRange,
+    genes: React.PropTypes.array.isRequired
+  },
+  render: function(): any {
+    return (
+      <div className="genes">
+        {JSON.stringify(this.props.genes)}
+      </div>
+    );
+  }
+});
+
+module.exports = GeneTrack;
+
+/*
+
+TP53 record:
+
+chr17
+7512444
+7531642
+
+ 1  ENST00000269305
+ 2  0
+ 3  -
+ 4  7513651
+ 5  7520637
+ 6  0
+ 7  11
+ 8  1289,107,74,137,110,113,184,279,22,102,223,
+ 9  0,2207,5133,5299,5779,6457,6651,7592,7980,8119,18975,
+10  ENSG00000141510
+11  TP53
+
+
+ 4: Transcript ID
+ 5: (always 0)
+ 6: Strand ("-" = right to left, "+" = left to right)
+ 7: left coordinate of translated region
+ 8: right coordinate of translated region
+ 9: (always 0)
+10: number of exons
+11: lengths of exons, left to right
+12: start of exons offset from start of gene, left to right
+13: Ensembl Gene ID
+14: Canonical name
+
+Here's a description of this format (http://genome.ucsc.edu/FAQ/FAQformat#format1)
+ 1. chrom
+ 2. chromStart
+ 3. chromEnd
+ 4. name
+ 5. score
+ 6. strand
+ 7. thickStart
+ 8. thickEnd
+ 9. itemRgb
+10. blockCount
+11. blockSize
+11. blockStarts
+
+
+exon 11: chr17:7512445-7513733
+exon 10: chr17:7514652-7514758
+exon  9: chr17:7517578-7517651
+..
+exon  1: chr17:7531420-7531642
+
+  --->
+
+exon 11: chr17:    0- 1288
+exon 10: chr17: 2207- 2313
+exon  9: chr17: 5133- 5206
+..
+exon  1: chr17:18975-19197
+
+
+
+In "collapsed" view, IGV merges all transcripts onto the same line.
+
+
+Also:
+chr17
+7517349
+7531521
+ 0  ENST00000359597
+ 1  0
+ 2  -
+ 3  7517349
+ 4  7520637
+ 5  0
+ 6  10
+ 7  33,74,137,110,113,184,279,22,102,102,
+ 8  0,228,394,874,1552,1746,2687,3075,3214,14070,
+ 9  ENSG00000141510
+10  TP53
+*/

--- a/src/GeneTrack.js
+++ b/src/GeneTrack.js
@@ -6,14 +6,176 @@ var React = require('react/addons'),
 var GeneTrack = React.createClass({
   propTypes: {
     range: types.GenomeRange,
-    genes: React.PropTypes.array.isRequired
+    genes: React.PropTypes.array.isRequired,
+    onRangeChange: React.PropTypes.func.isRequired
   },
   render: function(): any {
-    return (
-      <div className="genes">
-        {JSON.stringify(this.props.genes)}
-      </div>
-    );
+    var range = this.props.range;
+    if (!range) {
+      return <EmptyTrack />;
+    }
+
+    return <NonEmptyGeneTrack {...this.props} />;
+  }
+});
+
+var NonEmptyGeneTrack = React.createClass({
+  propTypes: {
+    range: types.GenomeRange,
+    genes: React.PropTypes.array.isRequired,
+    onRangeChange: React.PropTypes.func.isRequired
+  },
+  render: function() {
+    return <div className="genes"></div>;
+  },
+  componentDidMount: function() {
+    var div = this.getDOMNode(),
+        svg = d3.select(div)
+                .append('svg');
+
+    var defs = svg.append('defs')
+
+    defs
+        .append('pattern')
+          .attr('id', 'antisense')
+          .attr('patternUnits', 'userSpaceOnUse')
+          .attr('width', 30)
+          .attr('height', 9)
+          .attr('x', 0)
+          .attr('y', -4)
+          .append('path')
+            .attr('d', 'M4,0 L0,4 L4,8')
+            .attr('fill', 'none')
+            .attr('stroke-width', 1);
+    defs
+        .append('pattern')
+          .attr('id', 'sense')
+          .attr('patternUnits', 'userSpaceOnUse')
+          .attr('width', 30)
+          .attr('height', 9)
+          .attr('x', 0)
+          .attr('y', -4)
+          .append('path')
+            .attr('d', 'M0,0 L4,4 L0,8')
+            .attr('fill', 'none')
+            .attr('stroke-width', 1);
+
+    this.updateVisualization();
+  },
+  getScale: function() {
+    var div = this.getDOMNode(),
+        range = this.props.range,
+        width = div.offsetWidth,
+        offsetPx = range.offsetPx || 0;
+    var scale = d3.scale.linear()
+            .domain([range.start, range.stop + 1])  // 1 bp wide
+            .range([-offsetPx, width - offsetPx]);
+    return scale;
+  },
+  componentDidUpdate: function(prevProps: any, prevState: any) {
+    // Check a whitelist of properties which could change the visualization.
+    // For now, just basePairs and range.
+    var newProps = this.props;
+    if (!_.isEqual(newProps.genes, prevProps.genes) ||
+        !_.isEqual(newProps.range, prevProps.range)) {
+      this.updateVisualization();
+    }
+  },
+  updateVisualization: function() {
+    var div = this.getDOMNode(),
+        range = this.props.range,
+        width = div.offsetWidth,
+        height = div.offsetHeight,
+        svg = d3.select(div).select('svg');
+
+    var scale = this.getScale(),
+        // We can't clamp scale directly because of offsetPx.
+        clampedScale = d3.scale.linear()
+            .domain([scale.invert(0), scale.invert(width)])
+            .range([0, width])
+            .clamp(true);
+
+    svg.attr('width', width)
+       .attr('height', height);
+
+    var genes = svg.selectAll('g.gene')
+       .data(this.props.genes, gene => gene.id);
+
+    // Enter
+    var geneGs = genes.enter()
+        .append('g')
+        .attr('class', 'gene');
+    geneGs.append('text');
+    var geneLineG = geneGs.append('g').attr('class', 'track');
+    geneLineG.append('line');
+    geneLineG.append('rect').attr('class', 'strand');
+
+    geneLineG.selectAll('rect.exon')
+      .data(g => g.exons.map(function(x) {
+        return [x.start, x.stop, g.position.start()]
+      }))
+      .enter()
+      .append('rect')
+        .attr('class', 'exon')
+
+    // The gene name goes in the center of the gene, modulo boundary effects.
+    var textCenterX = g => {
+      var p = g.position;
+      return 0.5 * (clampedScale(p.start()) + clampedScale(p.stop()));
+    };
+    var scaledWidth = g => scale(g.position.stop()) - scale(g.position.start());
+
+    var geneLineY = height / 4;
+
+    // Enter & update
+    var track = genes.selectAll('g.track')
+        .attr('transform',
+              g => `translate(${scale(g.position.start())} ${geneLineY})`);
+
+    genes.selectAll('text')
+        .attr({
+          'x': textCenterX,
+          'y': geneLineY + 15
+        })
+        .text(g => g.name || g.id);
+
+    track.selectAll('line').attr({
+      'x1': 0,
+      'x2': scaledWidth,
+      'y1': 0,
+      'y2': 0
+    });
+
+    track.selectAll('rect.strand')
+        .attr({
+          'y': -4,
+          'height': 9,
+          'x': 0,
+          'width': scaledWidth,
+          'fill': g => `url(#${g.strand == '+' ? '' : 'anti'}sense)`,
+          'stroke': 'none'
+        });
+
+    track.selectAll('rect.exon')
+        .attr({
+          'x': function([start, stop, gStart]) {
+            return scale(start) - scale(0);
+          },
+          'y': -3,
+          'height': 6,
+          'width': function([start, stop]) {
+            return scale(stop) - scale(start);
+          }
+        })
+
+    // Exit
+    genes.exit().remove();
+  }
+});
+
+var EmptyTrack = React.createClass({
+  render: function() {
+    return <div className="genes empty">Zoom in to see genes</div>
   }
 });
 

--- a/src/GeneTrack.js
+++ b/src/GeneTrack.js
@@ -1,7 +1,12 @@
+/**
+ * Visualization of genes, including exons and coding regions.
+ * @flow
+ */
 var React = require('react/addons'),
     _ = require('underscore'),
     d3 = require('d3'),
-    types = require('./types');
+    types = require('./types'),
+    bedtools = require('./bedtools');
 
 var GeneTrack = React.createClass({
   propTypes: {
@@ -21,7 +26,7 @@ var GeneTrack = React.createClass({
 
 var NonEmptyGeneTrack = React.createClass({
   propTypes: {
-    range: types.GenomeRange,
+    range: types.GenomeRange.isRequired,
     genes: React.PropTypes.array.isRequired,
     onRangeChange: React.PropTypes.func.isRequired
   },
@@ -33,32 +38,39 @@ var NonEmptyGeneTrack = React.createClass({
         svg = d3.select(div)
                 .append('svg');
 
+    // These define the left/right arrow patterns for sense/antisense genes.
     var defs = svg.append('defs')
+    defs.append('pattern')
+        .attr({
+          'id': 'antisense',
+          'patternUnits': 'userSpaceOnUse',
+          'width': 30,
+          'height': 9,
+          'x': 0,
+          'y': -4
+        })
+        .append('path')
+          .attr({
+            'd': 'M4,0 L0,4 L4,8',  // Arrow pointing left
+            'fill': 'none',
+            'stroke-width': 1
+          });
 
-    defs
-        .append('pattern')
-          .attr('id', 'antisense')
-          .attr('patternUnits', 'userSpaceOnUse')
-          .attr('width', 30)
-          .attr('height', 9)
-          .attr('x', 0)
-          .attr('y', -4)
-          .append('path')
-            .attr('d', 'M4,0 L0,4 L4,8')
-            .attr('fill', 'none')
-            .attr('stroke-width', 1);
-    defs
-        .append('pattern')
-          .attr('id', 'sense')
-          .attr('patternUnits', 'userSpaceOnUse')
-          .attr('width', 30)
-          .attr('height', 9)
-          .attr('x', 0)
-          .attr('y', -4)
-          .append('path')
-            .attr('d', 'M0,0 L4,4 L0,8')
-            .attr('fill', 'none')
-            .attr('stroke-width', 1);
+    defs.append('pattern')
+        .attr({
+          'id': 'sense',
+          'patternUnits': 'userSpaceOnUse',
+          'width': 30,
+          'height': 9,
+          'x': 0,
+          'y': -4
+        })
+        .append('path')
+          .attr({
+            'd': 'M0,0 L4,4 L0,8',  // Arrow pointing right
+            'fill': 'none',
+            'stroke-width': 1
+          });
 
     this.updateVisualization();
   },
@@ -111,9 +123,8 @@ var NonEmptyGeneTrack = React.createClass({
     geneLineG.append('rect').attr('class', 'strand');
 
     geneLineG.selectAll('rect.exon')
-      .data(g => g.exons.map(function(x) {
-        return [x.start, x.stop, g.position.start()]
-      }))
+      .data(g => bedtools.splitCodingExons(g.exons, g.codingRegion)
+                    .map(x => [x, g.position.start()]))
       .enter()
       .append('rect')
         .attr('class', 'exon')
@@ -158,15 +169,11 @@ var NonEmptyGeneTrack = React.createClass({
 
     track.selectAll('rect.exon')
         .attr({
-          'x': function([start, stop, gStart]) {
-            return scale(start) - scale(0);
-          },
-          'y': -3,
-          'height': 6,
-          'width': function([start, stop]) {
-            return scale(stop) - scale(start);
-          }
-        })
+          'x': ([exon, gStart]) => scale(exon.start - gStart) - scale(0),
+          'y':      ([exon]) => -3 * (exon.isCoding ? 2 : 1),
+          'height': ([exon]) =>  6 * (exon.isCoding ? 2 : 1),
+          'width':  ([exon]) => scale(exon.stop) - scale(exon.start)
+        });
 
     // Exit
     genes.exit().remove();
@@ -180,87 +187,3 @@ var EmptyTrack = React.createClass({
 });
 
 module.exports = GeneTrack;
-
-/*
-
-TP53 record:
-
-chr17
-7512444
-7531642
-
- 1  ENST00000269305
- 2  0
- 3  -
- 4  7513651
- 5  7520637
- 6  0
- 7  11
- 8  1289,107,74,137,110,113,184,279,22,102,223,
- 9  0,2207,5133,5299,5779,6457,6651,7592,7980,8119,18975,
-10  ENSG00000141510
-11  TP53
-
-
- 4: Transcript ID
- 5: (always 0)
- 6: Strand ("-" = right to left, "+" = left to right)
- 7: left coordinate of translated region
- 8: right coordinate of translated region
- 9: (always 0)
-10: number of exons
-11: lengths of exons, left to right
-12: start of exons offset from start of gene, left to right
-13: Ensembl Gene ID
-14: Canonical name
-
-Here's a description of this format (http://genome.ucsc.edu/FAQ/FAQformat#format1)
- 1. chrom
- 2. chromStart
- 3. chromEnd
- 4. name
- 5. score
- 6. strand
- 7. thickStart
- 8. thickEnd
- 9. itemRgb
-10. blockCount
-11. blockSize
-11. blockStarts
-
-
-exon 11: chr17:7512445-7513733
-exon 10: chr17:7514652-7514758
-exon  9: chr17:7517578-7517651
-..
-exon  1: chr17:7531420-7531642
-
-  --->
-
-exon 11: chr17:    0- 1288
-exon 10: chr17: 2207- 2313
-exon  9: chr17: 5133- 5206
-..
-exon  1: chr17:18975-19197
-
-
-
-In "collapsed" view, IGV merges all transcripts onto the same line.
-
-
-Also:
-chr17
-7517349
-7531521
- 0  ENST00000359597
- 1  0
- 2  -
- 3  7517349
- 4  7520637
- 5  0
- 6  10
- 7  33,74,137,110,113,184,279,22,102,102,
- 8  0,228,394,874,1552,1746,2687,3075,3214,14070,
- 9  ENSG00000141510
-10  TP53
-*/

--- a/src/GenomeTrack.js
+++ b/src/GenomeTrack.js
@@ -86,6 +86,11 @@ var NonEmptyGenomeTrack = React.createClass({
     var g = svg.append('g')
                .call(drag);
 
+    g.append('rect')
+        .attr('x', 0)
+        .attr('y', 0)
+        .attr('class', 'background');
+
     this.updateVisualization();
   },
   getScale: function() {
@@ -131,6 +136,7 @@ var NonEmptyGenomeTrack = React.createClass({
 
     svg.attr('width', width)
        .attr('height', height);
+    svg.select('rect').attr({width, height});
 
     var g = svg.select('g');
 

--- a/src/GenomeTrack.js
+++ b/src/GenomeTrack.js
@@ -22,10 +22,6 @@ var GenomeTrack = React.createClass({
     if (!range) {
       return <EmptyTrack />;
     }
-    var rangeLength = range.limit - range.start;
-    if (rangeLength > 200) {
-      return <EmptyTrack />;
-    }
 
     if (!this.props.basePairs) {
       return <div className="reference empty">no data</div>;

--- a/src/GenomeTrack.js
+++ b/src/GenomeTrack.js
@@ -8,6 +8,9 @@ var React = require('react/addons'),
     d3 = require('d3'),
     types = require('./types');
 
+var MIN_PX_PER_LETTER = 6;  // hide individual base pairs at this resolution.
+
+
 var GenomeTrack = React.createClass({
   propTypes: {
     range: types.GenomeRange,
@@ -116,13 +119,19 @@ var NonEmptyGenomeTrack = React.createClass({
         svg = d3.select(div).select('svg');
 
     var scale = this.getScale();
+    var pxPerLetter = scale(1) - scale(0);
 
     var contigColon = this.props.range.contig + ':';
-    var absBasePairs = _.range(range.start - 1, range.stop + 1)
-        .map(locus => ({
-          position: locus,
-          letter: this.props.basePairs[contigColon + locus]
-        }));
+    var absBasePairs;
+    if (pxPerLetter > MIN_PX_PER_LETTER) {
+      absBasePairs = _.range(range.start - 1, range.stop + 1)
+          .map(locus => ({
+            position: locus,
+            letter: this.props.basePairs[contigColon + locus]
+          }));
+    } else {
+      absBasePairs = [];  // TODO: show a "zoom out" message.
+    }
 
     svg.attr('width', width)
        .attr('height', height);

--- a/src/Interval.js
+++ b/src/Interval.js
@@ -32,6 +32,10 @@ class Interval {
     return value >= this.start && value <= this.stop;
   }
 
+  containsInterval(other: Interval): boolean {
+    return this.contains(other.start) && this.contains(other.stop);
+  }
+
   clone(): Interval {
     return new Interval(this.start, this.stop);
   }

--- a/src/RemoteFile.js
+++ b/src/RemoteFile.js
@@ -13,6 +13,7 @@ type Chunk = {
   // TODO(danvk): priority: number;
 }
 
+
 class RemoteFile {
   url: string;
   fileLength: number;
@@ -27,19 +28,19 @@ class RemoteFile {
   }
 
   getBytes(start: number, length: number): Q.Promise<ArrayBuffer> {
-    var stop = start + length;
+    var stop = start + length - 1;
     // First check the cache.
     for (var i = 0; i < this.chunks.length; i++) {
       var chunk = this.chunks[i];
       if (chunk.start <= start && chunk.stop >= stop) {
-        return Q.when(chunk.buffer.slice(start - chunk.start, stop - chunk.start));
+        return Q(chunk.buffer.slice(start - chunk.start, stop - chunk.start));
       }
     }
 
     // TODO: handle partial overlap of request w/ cache.
 
     // Need to fetch from the network.
-    return this.getFromNetwork(start, start + length - 1);
+    return this.getFromNetwork(start, stop);
   }
 
   getFromNetwork(start: number, stop: number): Q.Promise<ArrayBuffer> {
@@ -53,6 +54,8 @@ class RemoteFile {
     xhr.onload = function(e) {
       // The actual length of the response may be less than requested if it's
       // too short, e.g. if we request bytes 0-1000 of a 500-byte file.
+      // TODO: record the length of the file whenever we learn it and clamp
+      // requests to fit within it. The cache is broken at EOF.
       var buffer = this.response;
 
       var newChunk = { start, stop: start + buffer.byteLength - 1, buffer };
@@ -65,6 +68,10 @@ class RemoteFile {
     xhr.send();
 
     return deferred.promise;
+  }
+
+  clearCache() {
+    this.chunks = [];
   }
 }
 

--- a/src/RemoteFile.js
+++ b/src/RemoteFile.js
@@ -33,7 +33,8 @@ class RemoteFile {
     for (var i = 0; i < this.chunks.length; i++) {
       var chunk = this.chunks[i];
       if (chunk.start <= start && chunk.stop >= stop) {
-        return Q(chunk.buffer.slice(start - chunk.start, stop - chunk.start));
+        return Q.when(
+            chunk.buffer.slice(start - chunk.start, stop - chunk.start + 1));
       }
     }
 

--- a/src/Root.js
+++ b/src/Root.js
@@ -18,12 +18,12 @@ var Root = React.createClass({
     referenceSource: React.PropTypes.object.isRequired,
     geneSource: React.PropTypes.object.isRequired
   },
-  getInitialState: function(): any {
+  getInitialState: function() {
     return {
-      contigList: [],
-      range: null,
-      basePairs: null,
-      genes: []
+      contigList: ([]: string[]),
+      range: (null: ?GenomeRange),
+      basePairs: (null: any),
+      genes: ([]: Array<any>)  // TODO import Gene type
     }
   },
   componentDidMount: function() {

--- a/src/TwoBitDataSource.js
+++ b/src/TwoBitDataSource.js
@@ -18,6 +18,7 @@
 // import type * as TwoBit from './TwoBit';
 
 var Events = require('backbone').Events,
+    Q = require('q'),
     _ = require('underscore');
 
 // TODO: make this an "import type" when react-tools 0.13.0 is out.
@@ -28,6 +29,7 @@ var TwoBit = require('./TwoBit');
 // requested over the network (100 * 2.0 too much)
 var EXPANSION_FACTOR = 2.0;
 
+var MAX_BASE_PAIRS_TO_FETCH = 100000;
 
 // TODO: make the return type more precise
 var createTwoBitDataSource = function(remoteSource: TwoBit): any {
@@ -43,6 +45,11 @@ var createTwoBitDataSource = function(remoteSource: TwoBit): any {
   }
 
   function fetch(range: GenomeRange) {
+    var span = range.stop - range.start;
+    if (span > MAX_BASE_PAIRS_TO_FETCH) {
+      return Q();  // empty promise
+    }
+
     return remoteSource.getFeaturesInRange(range.contig, range.start, range.stop)
         .then(letters => {
           for (var i = 0; i < letters.length; i++) {

--- a/src/TwoBitDataSource.js
+++ b/src/TwoBitDataSource.js
@@ -31,8 +31,18 @@ var EXPANSION_FACTOR = 2.0;
 
 var MAX_BASE_PAIRS_TO_FETCH = 10000;
 
+
+// Flow type for export.
+type TwoBitSource = {
+  rangeChanged: (newRange: GenomeRange) => void;
+  needContigs: () => void;
+  getRange: (range: GenomeRange) => ?{[key:string]: string};
+  contigList: () => string[];
+}
+
+
 // TODO: make the return type more precise
-var createTwoBitDataSource = function(remoteSource: TwoBit): any {
+var createTwoBitDataSource = function(remoteSource: TwoBit): TwoBitSource {
   // Local cache of genomic data.
   var contigList = [];
   var basePairs = {};  // contig -> locus -> letter
@@ -47,7 +57,7 @@ var createTwoBitDataSource = function(remoteSource: TwoBit): any {
   function fetch(range: GenomeRange) {
     var span = range.stop - range.start;
     if (span > MAX_BASE_PAIRS_TO_FETCH) {
-      return Q();  // empty promise
+      return Q.when();  // empty promise
     }
 
     console.log(`Fetching ${span} base pairs`);

--- a/src/TwoBitDataSource.js
+++ b/src/TwoBitDataSource.js
@@ -29,7 +29,7 @@ var TwoBit = require('./TwoBit');
 // requested over the network (100 * 2.0 too much)
 var EXPANSION_FACTOR = 2.0;
 
-var MAX_BASE_PAIRS_TO_FETCH = 100000;
+var MAX_BASE_PAIRS_TO_FETCH = 10000;
 
 // TODO: make the return type more precise
 var createTwoBitDataSource = function(remoteSource: TwoBit): any {
@@ -50,6 +50,7 @@ var createTwoBitDataSource = function(remoteSource: TwoBit): any {
       return Q();  // empty promise
     }
 
+    console.log(`Fetching ${span} base pairs`);
     return remoteSource.getFeaturesInRange(range.contig, range.start, range.stop)
         .then(letters => {
           for (var i = 0; i < letters.length; i++) {
@@ -61,6 +62,10 @@ var createTwoBitDataSource = function(remoteSource: TwoBit): any {
   // Returns a {"chr12:123" -> "[ATCG]"} mapping for the range.
   function getRange(range: GenomeRange) {
     if (!range) return null;
+    var span = range.stop - range.start;
+    if (span > MAX_BASE_PAIRS_TO_FETCH) {
+      return {};
+    }
     return _.chain(_.range(range.start, range.stop))
         .map(x => [range.contig + ':' + x, getBasePair(range.contig, x)])
         .object()

--- a/src/bedtools.js
+++ b/src/bedtools.js
@@ -1,0 +1,49 @@
+/* @flow */
+
+var _ = require('underscore');
+var Interval = require('./Interval');
+
+class CodingInterval extends Interval {
+  isCoding: boolean;
+  constructor(start, stop, isCoding: boolean) {
+    super(start, stop);
+    this.isCoding = isCoding;
+  }
+}
+
+/**
+ * Split exons which cross the coding/non-coding boundary into purely coding &
+ * non-coding parts.
+ */
+function splitCodingExons(exons: Interval[],
+                          codingRegion: Interval): CodingInterval[] {
+  return _.flatten(exons.map(exon => {
+    // Special case: the coding region is entirely contained by this exon.
+    if (exon.containsInterval(codingRegion)) {
+      // split into three parts.
+      return [
+          new CodingInterval(exon.start, codingRegion.start - 1, false),
+          new CodingInterval(codingRegion.start, codingRegion.stop, true),
+          new CodingInterval(codingRegion.stop + 1, exon.stop, false)
+      ].filter(interval => interval.start <= interval.stop);
+    }
+
+    var startIsCoding = codingRegion.contains(exon.start),
+        stopIsCoding = codingRegion.contains(exon.stop);
+    if (startIsCoding == stopIsCoding) {
+      return [new CodingInterval(exon.start, exon.stop, startIsCoding)];
+    } else if (startIsCoding) {
+      return [
+        new CodingInterval(exon.start, codingRegion.stop, true),
+        new CodingInterval(codingRegion.stop + 1, exon.stop, false)
+      ];
+    } else {
+      return [
+        new CodingInterval(exon.start, codingRegion.start - 1, false),
+        new CodingInterval(codingRegion.start, exon.stop, true)
+      ];
+    }
+  }));
+}
+
+module.exports = {splitCodingExons, CodingInterval};

--- a/src/main.js
+++ b/src/main.js
@@ -1,13 +1,18 @@
 /* @flow */
 var React = require('react'),
     TwoBit = require('./TwoBit'),
+    BigBed = require('./BigBed'),
     Root = require('./Root'),
-    createTwoBitDataSource = require('./TwoBitDataSource');
+    createTwoBitDataSource = require('./TwoBitDataSource'),
+    createBigBedDataSource = require('./BigBedDataSource');
 
 var startMs = Date.now();
 // var genome = new TwoBit('http://www.biodalliance.org/datasets/hg19.2bit');
 var genome = new TwoBit('/hg19.2bit');
 var dataSource = createTwoBitDataSource(genome);
+
+var ensembl = new BigBed('/ensGene.bb');
+var ensemblDataSource = createBigBedDataSource(ensembl);
 
 genome.getFeaturesInRange('chr22', 19178140, 19178170).then(basePairs => {
   var endMs = Date.now();
@@ -21,5 +26,9 @@ genome.getFeaturesInRange('chr22', 19178140, 19178170).then(basePairs => {
 // pre-load some data to allow network-free panning
 genome.getFeaturesInRange('chr1', 123000, 124000).done();
 
-var root = React.render(<Root referenceSource={dataSource} />,
+var root = React.render(<Root referenceSource={dataSource}
+                              geneSource={ensemblDataSource} />,
                         document.getElementById('root'));
+
+window.ensembl = ensembl;
+window.genome = genome;

--- a/test/TwoBitDataSource-test.js
+++ b/test/TwoBitDataSource-test.js
@@ -1,0 +1,31 @@
+var chai = require('chai');
+var expect = chai.expect;
+var assert = chai.assert;
+
+var TwoBit = require('../src/TwoBit');
+var createTwoBitDataSource = require('../src/TwoBitDataSource');
+
+describe('TwoBitDataSource', function() {
+  function getTestSource() {
+    // See description of this file in TwoBit-test.js
+    var tb = new TwoBit('/test/data/test.2bit');
+    return createTwoBitDataSource(tb);
+  }
+
+  it('should fetch contigs', function(done) {
+    var source = getTestSource();
+    source.on('contigs', contigs => {
+      expect(contigs).to.deep.equal(['chr1', 'chr17', 'chr22']);
+      done();
+    });
+    source.needContigs();
+  });
+
+  it('should fetch base pairs', function(done) {
+    var source = getTestSource();
+    var range = {contig: 'chr22', start: 1, stop: 4};
+    expect(source.getRange()).to.deep.equal({
+
+    });
+  });
+});

--- a/test/TwoBitDataSource-test.js
+++ b/test/TwoBitDataSource-test.js
@@ -1,3 +1,4 @@
+/* @flow */
 var chai = require('chai');
 var expect = chai.expect;
 var assert = chai.assert;
@@ -24,8 +25,56 @@ describe('TwoBitDataSource', function() {
   it('should fetch base pairs', function(done) {
     var source = getTestSource();
     var range = {contig: 'chr22', start: 1, stop: 4};
-    expect(source.getRange()).to.deep.equal({
 
+    // Before data has been fetched, all base pairs are null.
+    expect(source.getRange(range)).to.deep.equal({
+      'chr22:1': null,
+      'chr22:2': null,
+      'chr22:3': null,
+      'chr22:4': null
     });
+
+    source.on('newdata', () => {
+      expect(source.getRange(range)).to.deep.equal({
+        'chr22:1': 'N',
+        'chr22:2': 'T',
+        'chr22:3': 'C',
+        'chr22:4': 'A'
+      });
+      done();
+    });
+    source.rangeChanged(range);
+  });
+
+  it('should fetch nearby base pairs', function(done) {
+    var tb = new TwoBit('/test/data/test.2bit'),
+        remote = tb.remoteFile,
+        source = createTwoBitDataSource(tb);
+
+    source.on('newdata', () => {
+      expect(source.getRange({contig: 'chr22', start: 1, stop: 18}))
+          .to.deep.equal({
+            'chr22:1':  'N',
+            'chr22:2':  'T',
+            'chr22:3':  'C',
+            'chr22:4':  'A',
+            'chr22:5':  'C',  // start of actual request
+            'chr22:6':  'A',
+            'chr22:7':  'G',
+            'chr22:8':  'A',
+            'chr22:9':  'T',
+            'chr22:10': 'C',  // end of actual requuest
+            'chr22:11': 'A',
+            'chr22:12': 'C',
+            'chr22:13': 'C',
+            'chr22:14': 'A',
+            'chr22:15': 'T',  // 5 past end of request
+            'chr22:16': null,
+            'chr22:17': null,
+            'chr22:18': null
+          });
+      done();
+    });
+    source.rangeChanged({contig: 'chr22', start: 5, stop: 10})
   });
 });

--- a/test/bedtools-test.js
+++ b/test/bedtools-test.js
@@ -1,0 +1,57 @@
+/* @flow */
+var chai = require('chai');
+var expect = chai.expect;
+
+var bedtools = require('../src/bedtools'),
+    Interval = require('../src/Interval');
+
+describe('bedtools', function() {
+  describe('splitCodingExons', function() {
+    var splitCodingExons = bedtools.splitCodingExons;
+    var CodingInterval = bedtools.CodingInterval;
+
+    it('should split one exon', function() {
+      var exon = new Interval(10, 20);
+
+      expect(splitCodingExons([exon], new Interval(13, 17))).to.deep.equal([
+        new CodingInterval(10, 12, false),
+        new CodingInterval(13, 17, true),
+        new CodingInterval(18, 20, false)
+      ]);
+
+      expect(splitCodingExons([exon], new Interval(5, 15))).to.deep.equal([
+        new CodingInterval(10, 15, true),
+        new CodingInterval(16, 20, false)
+      ]);
+
+      expect(splitCodingExons([exon], new Interval(15, 25))).to.deep.equal([
+        new CodingInterval(10, 14, false),
+        new CodingInterval(15, 20, true)
+      ]);
+
+      expect(splitCodingExons([exon], new Interval(10, 15))).to.deep.equal([
+        new CodingInterval(10, 15, true),
+        new CodingInterval(16, 20, false)
+      ]);
+
+      expect(splitCodingExons([exon], new Interval(15, 20))).to.deep.equal([
+        new CodingInterval(10, 14, false),
+        new CodingInterval(15, 20, true)
+      ]);
+    });
+
+    it('should handle purely coding or non-coding exons', function() {
+      var exon = new Interval(10, 20);
+
+      expect(splitCodingExons([exon], new Interval(0, 9))).to.deep.equal([
+        new CodingInterval(10, 20, false)
+      ]);
+      expect(splitCodingExons([exon], new Interval(21, 25))).to.deep.equal([
+        new CodingInterval(10, 20, false)
+      ]);
+      expect(splitCodingExons([exon], new Interval(10, 20))).to.deep.equal([
+        new CodingInterval(10, 20, true)
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
The gist of this change is that we can now visualize genes:
![screen shot 2015-03-17 at 11 35 20 pm](https://cloud.githubusercontent.com/assets/98301/6702200/50a8085c-ccfe-11e4-9cc3-6323e04099a8.png)

A few other changes came along for the ride to facilitate this:
- Adds zoom in/out buttons (Fixes #29)
- Suppress reference track when sufficiently zoomed out (it's a crowded bottleneck)
- Adds a background to `GenomeTrack` to make it draggable even when not showing base pairs.
- Be more aggressive about pre-fetching the reference genome (smooths panning)
- Adds some tests to make sure network caching is working as expected.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/43)
<!-- Reviewable:end -->