### PR TITLE
Add prepush-hook for linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/danvk/pileup.js/issues"
   },
   "homepage": "https://github.com/danvk/pileup.js",
+  "prepush": ["lint"],
   "dependencies": {
     "backbone": "^1.1.2",
     "d3": "^3.5.5",
@@ -48,6 +49,7 @@
     "mocha": "^2.1.0",
     "mocha-lcov-reporter": ">=0.0.2",
     "parse-data-uri": "^0.2.0",
+    "prepush-hook": "^0.1.0",
     "react-tools": "^0.13.1",
     "reactify": "danvk/reactify",
     "sinon": "^1.12.2",


### PR DESCRIPTION
The pre-push hook gets installed when you run `npm install`.

Fixes #54 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/55)
<!-- Reviewable:end -->
