### PR TITLE
Improvements to gene display

### DIFF
--- a/src/GeneTrack.js
+++ b/src/GeneTrack.js
@@ -99,6 +99,7 @@ var NonEmptyGeneTrack = React.createClass({
     var div = this.getDOMNode(),
         width = div.offsetWidth,
         height = div.offsetHeight,
+        range = this.props.range,
         svg = d3.select(div).select('svg');
 
     var scale = this.getScale(),
@@ -113,6 +114,11 @@ var NonEmptyGeneTrack = React.createClass({
 
     var genes = svg.selectAll('g.gene')
        .data(this.props.genes, gene => gene.id);
+
+    // By default, the left of the arrow pattern goes to x=0 in SVG space.
+    // We'd prefer it start at genome coordinate 0.
+    svg.selectAll('pattern').attr('patternTransform',
+                                  `translate(${scale(0) % 30} 0)`);
 
     // Enter
     var geneGs = genes.enter()
@@ -142,7 +148,7 @@ var NonEmptyGeneTrack = React.createClass({
     // Enter & update
     var track = genes.selectAll('g.track')
         .attr('transform',
-              g => `translate(${scale(g.position.start())} ${geneLineY})`);
+              g => `translate(0 ${geneLineY})`);
 
     genes.selectAll('text')
         .attr({
@@ -152,8 +158,8 @@ var NonEmptyGeneTrack = React.createClass({
         .text(g => g.name || g.id);
 
     track.selectAll('line').attr({
-      'x1': 0,
-      'x2': scaledWidth,
+      'x1': g => scale(g.position.start()),
+      'x2': g => scale(g.position.stop()),
       'y1': 0,
       'y2': 0
     });
@@ -162,7 +168,7 @@ var NonEmptyGeneTrack = React.createClass({
         .attr({
           'y': -4,
           'height': 9,
-          'x': 0,
+          'x': g => scale(g.position.start()),
           'width': scaledWidth,
           'fill': g => `url(#${g.strand == '+' ? '' : 'anti'}sense)`,
           'stroke': 'none'
@@ -170,7 +176,7 @@ var NonEmptyGeneTrack = React.createClass({
 
     track.selectAll('rect.exon')
         .attr({
-          'x': ([exon, gStart]) => scale(exon.start - gStart) - scale(0),
+          'x': ([exon, gStart]) => scale(exon.start),
           'y':      ([exon]) => -3 * (exon.isCoding ? 2 : 1),
           'height': ([exon]) =>  6 * (exon.isCoding ? 2 : 1),
           'width':  ([exon]) => scale(exon.stop) - scale(exon.start)

--- a/src/GeneTrack.js
+++ b/src/GeneTrack.js
@@ -42,7 +42,7 @@ var NonEmptyGeneTrack = React.createClass({
 
     // These define the left/right arrow patterns for sense/antisense genes.
     var defs = svg.append('defs');
-    defs.append('pattern')
+    var antiSense = defs.append('pattern')
         .attr({
           'id': 'antisense',
           'patternUnits': 'userSpaceOnUse',
@@ -50,15 +50,24 @@ var NonEmptyGeneTrack = React.createClass({
           'height': 9,
           'x': 0,
           'y': -4
-        })
-        .append('path')
+        });
+    antiSense.append('path')
           .attr({
-            'd': 'M4,0 L0,4 L4,8',  // Arrow pointing left
+            'd': 'M5,0 L1,4 L5,8',  // Arrow pointing left
             'fill': 'none',
-            'stroke-width': 1
+            'stroke-width': 1,
+            'class': 'main'
+          });
+    antiSense.append('path')
+          .attr({
+            // 'd': 'M4,0 L0,4 L4,8',  // Arrow pointing left
+            'd': 'M4,0 L1,3 M1,5 L4,8',  // offset 1, less center pixel
+            'fill': 'none',
+            'stroke-width': 1,
+            'class': 'offset'
           });
 
-    defs.append('pattern')
+    var sense = defs.append('pattern')
         .attr({
           'id': 'sense',
           'patternUnits': 'userSpaceOnUse',
@@ -66,10 +75,16 @@ var NonEmptyGeneTrack = React.createClass({
           'height': 9,
           'x': 0,
           'y': -4
-        })
-        .append('path')
+        });
+    sense.append('path')
           .attr({
             'd': 'M0,0 L4,4 L0,8',  // Arrow pointing right
+            'fill': 'none',
+            'stroke-width': 1
+          });
+    sense.append('path')
+          .attr({
+            'd': 'M1,0 L4,3 M4,5 L1,8',  // offset 1, less center pixel
             'fill': 'none',
             'stroke-width': 1
           });
@@ -126,8 +141,6 @@ var NonEmptyGeneTrack = React.createClass({
         .attr('class', 'gene');
     geneGs.append('text');
     var geneLineG = geneGs.append('g').attr('class', 'track');
-    geneLineG.append('line');
-    geneLineG.append('rect').attr('class', 'strand');
 
     geneLineG.selectAll('rect.exon')
       .data(g => bedtools.splitCodingExons(g.exons, g.codingRegion)
@@ -135,6 +148,9 @@ var NonEmptyGeneTrack = React.createClass({
       .enter()
       .append('rect')
         .attr('class', 'exon');
+
+    geneLineG.append('line');
+    geneLineG.append('rect').attr('class', 'strand');
 
     // The gene name goes in the center of the gene, modulo boundary effects.
     var textCenterX = g => {

--- a/src/GeneTrack.js
+++ b/src/GeneTrack.js
@@ -41,53 +41,20 @@ var NonEmptyGeneTrack = React.createClass({
                 .append('svg');
 
     // These define the left/right arrow patterns for sense/antisense genes.
+    // The second <path> allows the arrow to be seen on top of an exon.
     var defs = svg.append('defs');
-    var antiSense = defs.append('pattern')
-        .attr({
-          'id': 'antisense',
-          'patternUnits': 'userSpaceOnUse',
-          'width': 30,
-          'height': 9,
-          'x': 0,
-          'y': -4
-        });
-    antiSense.append('path')
-          .attr({
-            'd': 'M5,0 L1,4 L5,8',  // Arrow pointing left
-            'fill': 'none',
-            'stroke-width': 1,
-            'class': 'main'
-          });
-    antiSense.append('path')
-          .attr({
-            // 'd': 'M4,0 L0,4 L4,8',  // Arrow pointing left
-            'd': 'M4,0 L1,3 M1,5 L4,8',  // offset 1, less center pixel
-            'fill': 'none',
-            'stroke-width': 1,
-            'class': 'offset'
-          });
-
-    var sense = defs.append('pattern')
-        .attr({
-          'id': 'sense',
-          'patternUnits': 'userSpaceOnUse',
-          'width': 30,
-          'height': 9,
-          'x': 0,
-          'y': -4
-        });
-    sense.append('path')
-          .attr({
-            'd': 'M0,0 L4,4 L0,8',  // Arrow pointing right
-            'fill': 'none',
-            'stroke-width': 1
-          });
-    sense.append('path')
-          .attr({
-            'd': 'M1,0 L4,3 M4,5 L1,8',  // offset 1, less center pixel
-            'fill': 'none',
-            'stroke-width': 1
-          });
+    defs[0][0].innerHTML = `
+      <pattern id="antisense" patternUnits="userSpaceOnUse"
+            width="30" height="9" x="0" y="-4">
+        <path d="M5,0 L1,4 L5,8" class="main"></path>
+        <path d="M4,0 L1,3 M1,5 L4,8" class="offset"></path>
+      </pattern>
+      <pattern id="sense" patternUnits="userSpaceOnUse"
+            width="30" height="9" x="0" y="-4">
+        <path d="M0,0 L4,4 L0,8" class="main"></path>
+        <path d="M1,0 L4,3 M4,5 L1,8" class="offset"></path>
+      </pattern>
+    `;
 
     this.updateVisualization();
   },

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -43,4 +43,5 @@ text.basepair {
 }
 .exon {
   fill: blue;
+  stroke: none;
 }

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -38,11 +38,15 @@ text.basepair {
   stroke: black;
   alignment-baseline: hanging;
 }
-#sense, #antisense {
+#sense, #antisense .main {
   stroke: blue;
+  fill: none;
+  stroke-width: 1;
 }
 #antisense .offset, #sense .offset {
   stroke: white;
+  fill: none;
+  stroke-width: 1;
 }
 .exon {
   fill: blue;

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -41,6 +41,9 @@ text.basepair {
 #sense, #antisense {
   stroke: blue;
 }
+#antisense .offset, #sense .offset {
+  stroke: white;
+}
 .exon {
   fill: blue;
   stroke: none;


### PR DESCRIPTION
Strand arrows are now visible over exons:

![screen shot 2015-03-20 at 4 30 32 pm](https://cloud.githubusercontent.com/assets/98301/6760410/90f3ba42-cf1e-11e4-8bcf-f43bbba80726.png)

Strand arrows are aligned to the genome, so arrows on overlapping transcripts line up:

![screen shot 2015-03-20 at 4 30 50 pm](https://cloud.githubusercontent.com/assets/98301/6760414/a2f2f80c-cf1e-11e4-94b1-40d3f0ff3a06.png)

And overlapping labels are elided, ala IGV:

![screen shot 2015-03-20 at 4 30 55 pm](https://cloud.githubusercontent.com/assets/98301/6760416/aa38adaa-cf1e-11e4-8086-1e6d3511dedb.png)


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/58)
<!-- Reviewable:end -->
