### PR TITLE
Optimize BAM parsing

### DIFF
--- a/src/SamRead.js
+++ b/src/SamRead.js
@@ -1,0 +1,57 @@
+/**
+ * This class parses and represents a single read in a SAM/BAM file.
+ *
+ * This is used instead of parsing directly via jBinary in order to:
+ * - Make the parsing lazy (for significant performance wins)
+ * - Make the resulting object more precisely typed.
+ *
+ * @flow
+ */
+
+var jDataView = require('jdataview');
+var jBinary = require('jbinary');
+var {nullString} = require('./formats/helpers');
+var bamTypes = require('./formats/bamTypes');
+
+
+class SamRead {
+  buffer: ArrayBuffer;
+  reader: jDataView;
+
+  pos: number;
+  refID: number;
+  l_seq: number;
+
+  constructor(buffer: ArrayBuffer) {
+    this.buffer = buffer;
+
+    // Go ahead and parse a few fields immediately.
+    var jv = new jDataView(buffer, 0, buffer.byteLength, true /* little endian */);
+    this.refID = jv.getUint32(0);
+    this.pos = jv.getUint32(4);
+    this.l_seq = jv.getUint32(16);
+
+    this.reader = jv;
+  }
+
+  toString(): string {
+    var stop = this.pos + this.l_seq;
+    return `${this.refID}:${this.pos}-${stop}`;
+  }
+
+  getName(): string {
+    var l_read_name = this.reader.getUint8(8);
+    var jb = new jBinary(this.buffer, {
+      'jBinary.littleEndian': true
+    });
+    return jb.read([nullString, l_read_name], 32);
+  }
+
+  // TODO: get rid of this; move all methods into SamRead.
+  getFull(): Object {
+    var jb = new jBinary(this.buffer, bamTypes.TYPE_SET);
+    return jb.read(bamTypes.ThickAlignment, 0);
+  }
+}
+
+module.exports = SamRead;

--- a/src/SamRead.js
+++ b/src/SamRead.js
@@ -5,14 +5,19 @@
  * - Make the parsing lazy (for significant performance wins)
  * - Make the resulting object more precisely typed.
  *
+ * Parsing reads using SamRead is ~2-3x faster than using jBinary and
+ * ThinAlignment directly.
+ *
  * @flow
  */
+'use strict';
 
-var jDataView = require('jdataview');
-var jBinary = require('jbinary');
-var {nullString} = require('./formats/helpers');
-var bamTypes = require('./formats/bamTypes');
+var jDataView = require('jdataview'),
+    jBinary = require('jbinary'),
+    {nullString} = require('./formats/helpers'),
+    bamTypes = require('./formats/bamTypes');
 
+// TODO: Make more extensive use of the jBinary specs.
 
 class SamRead {
   buffer: ArrayBuffer;

--- a/src/bam.js
+++ b/src/bam.js
@@ -19,6 +19,24 @@ var bamTypes = require('./formats/bamTypes'),
 
 
 /**
+ * The 'contained' parameter controls whether the alignments must be fully
+ * contained within the range, or need only overlap it.
+ */
+function isAlignmentInRange(read: Object,
+                            idxRange: ContigInterval<number>,
+                            contained: boolean): boolean {
+  // TODO: Use cigar.getReferenceLength() instead of l_seq, like htsjdk. 
+  var readRange = new ContigInterval(read.refID, read.pos, read.pos + read.l_seq - 1);
+  if (contained) {
+    return idxRange.containsInterval(readRange);
+  } else {
+    return readRange.intersects(idxRange);
+  }
+}
+    
+
+
+/**
  * Filter a list of alignments down to just those which overlap the range.
  * The 'contained' parameter controls whether the alignments must be fully
  * contained within the range, or need only overlap it.
@@ -26,15 +44,7 @@ var bamTypes = require('./formats/bamTypes'),
 function filterAlignments(alignments: Object[],
                           idxRange: ContigInterval<number>,
                           contained: boolean): Object[] {
-  return alignments.filter(read => {
-    // TODO: Use cigar.getReferenceLength() instead of l_seq, like htsjdk. 
-    var readRange = new ContigInterval(read.refID, read.pos, read.pos + read.l_seq - 1);
-    if (contained) {
-      return idxRange.containsInterval(readRange);
-    } else {
-      return readRange.intersects(idxRange);
-    }
-  });
+  return alignments.filter(read => isAlignmentInRange(read, idxRange, contained));
 }
 
 

--- a/src/formats/bamTypes.js
+++ b/src/formats/bamTypes.js
@@ -31,7 +31,7 @@ var ThinAlignment = {
   next_pos: 'int32',     // 24
   tlen: 'int32'          // 28
   // length of fixed-size header = 32 bytes
-}
+};
 
 var ThickAlignment = _.extend({}, ThinAlignment, {
   read_name: [nullString, 'l_read_name'],

--- a/test/SamRead-test.js
+++ b/test/SamRead-test.js
@@ -1,0 +1,81 @@
+/* @flow */
+'use strict';
+
+import type * as Q from 'q';
+
+var chai = require('chai');
+var expect = chai.expect;
+
+var jBinary = require('jbinary');
+
+var RemoteFile = require('../src/RemoteFile'),
+    utils = require('../src/utils'),
+    Bam = require('../src/bam'),
+    bamTypes = require('../src/formats/bamTypes'),
+    SamRead = require('../src/SamRead');
+
+describe('SamRead', function() {
+
+  function getSamArray(url): Q.Promise<SamRead[]> {
+    var file = new RemoteFile(url);
+    return file.getAll().then(gzipBuffer => {
+      var buf = utils.inflateGzip(gzipBuffer);
+      var jb = new jBinary(buf, bamTypes.TYPE_SET);
+      jb.read('BamHeader');  // skip past the header to get to alignments.
+      return jb.read(['array', {
+        block_size: 'int32',
+        contents: ['blob', 'block_size']
+      }]).map(block => new SamRead(block.contents));
+    });
+  }
+
+  var testReads = getSamArray('/test/data/test_input_1_a.bam');
+
+  // This is more of a test for the test than for SamRead.
+  it('should pull records from a BAM file', function(done) {
+    testReads.then(reads => {
+      expect(reads).to.have.length(15);
+      done();
+    }).done();
+  });
+
+  it('should parse BAM records', function(done) {
+    testReads.then(reads => {
+      // The first record in test_input_1_a.sam is:
+      // r000 99 insert 50 30 10M = 80 30 ATTTAGCTAC AAAAAAAAAA RG:Z:cow PG:Z:bull
+      var read = reads[0];
+      expect(read.getName()).to.equal('r000');
+      // expect(read.FLAG).to.equal(99);
+      expect(read.refID).to.equal(0);
+      expect(read.pos).to.equal(49);  // 0-based
+      expect(read.l_seq).to.equal(10);
+      // expect(refs[r000.refID].name).to.equal('insert');
+
+      done();
+    }).done();
+  });
+
+  it('should read thick records', function(done) {
+    testReads.then(reads => {
+      // This mirrors the "BAM > should parse BAM files" test.
+      var r000 = reads[0].getFull();
+      expect(r000.read_name).to.equal('r000');
+      expect(r000.FLAG).to.equal(99);
+      expect(r000.refID).to.equal(0);
+      // .. POS
+      expect(r000.MAPQ).to.equal(30);
+      expect(Bam.makeCigarString(r000.cigar)).to.equal('10M');
+      // next ref
+      // next pos
+      expect(r000.tlen).to.equal(30);
+      expect(r000.seq).to.equal('ATTTAGCTAC');
+      expect(Bam.makeAsciiPhred(r000.qual)).to.equal('AAAAAAAAAA');
+
+      var aux = r000.auxiliary;
+      expect(aux).to.have.length(2);
+      expect(aux[0]).to.contain({tag: 'RG', value: 'cow'});
+      expect(aux[1]).to.contain({tag: 'PG', value: 'bull'});
+      done();
+    }).done();
+  });
+});

--- a/test/bam-test.js
+++ b/test/bam-test.js
@@ -55,7 +55,8 @@ describe('BAM', function() {
       expect(aux[3]).to.contain({tag: 'PG', value: 'colt'});
 
       // This one has a more interesting Cigar string
-      expect(Bam.makeCigarString(aligns[3].cigar)).to.equal('1S2I6M1P1I1P1I4M2I');
+      expect(Bam.makeCigarString(aligns[3].cigar))
+          .to.equal('1S2I6M1P1I1P1I4M2I');
 
       // - one with a more interesting Phred string
       done();


### PR DESCRIPTION
This speeds up `BamFile.getAlignmentsInRange` in a few ways:

- Filters reads as it parses them to reduce memory overhead & bail out more quickly.
- Introduces a `SamRead` class for lazy parsing and type safety (Fixes #71)
- Reads `SamRead`s directly using `ArrayBuffer`, bypassing the jBinary overhead.

The latter optimization is particularly effective. Overall the "should fetch from a large, dense BAM file" test case went from taking ~1450ms/run on my machine to taking ~550ms/run.

See #26

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/74)
<!-- Reviewable:end -->
