### PR TITLE
Performance improvements

### DIFF
--- a/src/GeneTrack.js
+++ b/src/GeneTrack.js
@@ -53,6 +53,12 @@ var NonEmptyGeneTrack = React.createClass({
     genes: React.PropTypes.array.isRequired,
     onRangeChange: React.PropTypes.func.isRequired
   },
+  getInitialState: function() {
+    return {
+      width: 0,
+      height: 0
+    };
+  },
   render: function() {
     return <div className="genes"></div>;
   },
@@ -60,6 +66,11 @@ var NonEmptyGeneTrack = React.createClass({
     var div = this.getDOMNode(),
         svg = d3.select(div)
                 .append('svg');
+
+    this.setState({
+      width: div.offsetWidth,
+      height: div.offsetHeight
+    });
 
     // These define the left/right arrow patterns for sense/antisense genes.
     // The second <path> allows the arrow to be seen on top of an exon.
@@ -80,28 +91,30 @@ var NonEmptyGeneTrack = React.createClass({
     this.updateVisualization();
   },
   getScale: function() {
-    var div = this.getDOMNode(),
-        range = this.props.range,
-        width = div.offsetWidth,
+    var range = this.props.range,
         offsetPx = range.offsetPx || 0;
     var scale = d3.scale.linear()
             .domain([range.start, range.stop + 1])  // 1 bp wide
-            .range([-offsetPx, width - offsetPx]);
+            .range([-offsetPx, this.state.width - offsetPx]);
     return scale;
   },
   componentDidUpdate: function(prevProps: any, prevState: any) {
     // Check a whitelist of properties which could change the visualization.
     var newProps = this.props;
     if (!_.isEqual(newProps.genes, prevProps.genes) ||
-        !_.isEqual(newProps.range, prevProps.range)) {
+        !_.isEqual(newProps.range, prevProps.range) ||
+       prevState != this.state) {
       this.updateVisualization();
     }
   },
   updateVisualization: function() {
     var div = this.getDOMNode(),
-        width = div.offsetWidth,
-        height = div.offsetHeight,
+        width = this.state.width,
+        height = this.state.height,
         svg = d3.select(div).select('svg');
+
+    // Hold off until height & width are known.
+    if (width === 0) return;
 
     var scale = this.getScale(),
         // We can't clamp scale directly because of offsetPx.

--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -40,19 +40,28 @@ var NonEmptyPileupTrack = React.createClass({
     reads: React.PropTypes.array.isRequired,
     onRangeChange: React.PropTypes.func.isRequired
   },
+  getInitialState: function() {
+    return {
+      width: 0,
+      height: 0
+    };
+  },
   render: function(): any {
     return <div className='pileup'></div>;
   },
   componentDidMount: function() {
     var div = this.getDOMNode();
+    this.setState({
+      width: div.offsetWidth,
+      height: div.offsetWidth
+    });
     d3.select(div)
       .append('svg');
     this.updateVisualization();
   },
   getScale: function() {
-    var div = this.getDOMNode(),
-        range = this.props.range,
-        width = div.offsetWidth,
+    var range = this.props.range,
+        width = this.state.width,
         offsetPx = range.offsetPx || 0;
     var scale = d3.scale.linear()
             .domain([range.start, range.stop + 1])  // 1 bp wide
@@ -64,15 +73,19 @@ var NonEmptyPileupTrack = React.createClass({
     // TODO: this is imprecise; it would be better to deep check reads.
     var newProps = this.props;
     if (!_.isEqual(newProps.reads, prevProps.reads) ||
-        !_.isEqual(newProps.range, prevProps.range)) {
+        !_.isEqual(newProps.range, prevProps.range) ||
+       prevState != this.state) {
       this.updateVisualization();
     }
   },
   updateVisualization: function() {
     var div = this.getDOMNode(),
-        width = div.offsetWidth,
-        height = div.offsetHeight,
+        width = this.state.width,
+        height = this.state.height,
         svg = d3.select(div).select('svg');
+
+    // Hold off until height & width are known.
+    if (width === 0) return;
 
     var scale = this.getScale();
 

--- a/src/bam.js
+++ b/src/bam.js
@@ -152,7 +152,11 @@ function fetchAlignments(remoteFile: RemoteFile,
       chunk_end = chunk.chunk_end.coffset;
   var bytesToFetch = Math.min(kMaxFetch, (chunk_end + 65536) - chunk_beg);
   return remoteFile.getBytes(chunk_beg, bytesToFetch).then(buffer => {
-    var blocks = utils.inflateConcatenatedGzip(buffer, chunk_end - chunk_beg);
+    var cacheKey = {
+      filename: remoteFile.url,
+      initialOffset: chunk_beg
+    };
+    var blocks = utils.inflateConcatenatedGzip(buffer, chunk_end - chunk_beg, cacheKey);
 
     // If the chunk hasn't been exhausted, resume it at an appropriate place.
     // The last block needs to be re-read, since it may not have been exhausted.


### PR DESCRIPTION
Two improvements:

- Cache gzip block inflation (fixes #95)

  This was slightly harder than expected, since inflating the same offset in a file can succeed or fail depending on how many bytes of the file have been read. This _is_ a win, though. During casual panning, the same block is inflated (successfully) 40+ times without it.
- Cache `offsetWidth` and `offsetHeight` calculations (fixes #94)

  I was surprised to see these showing up in the flamecharts!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/98)
<!-- Reviewable:end -->
