### PR TITLE
Change reference UI depending on scale

### DIFF
--- a/src/GenomeTrack.js
+++ b/src/GenomeTrack.js
@@ -32,6 +32,13 @@ var GenomeTrack = React.createClass({
   }
 });
 
+var DisplayMode = {
+  TIGHT: 1,
+  LOOSE: 2,
+  BLOCKS: 3,
+  HIDDEN: 4
+};
+
 var NonEmptyGenomeTrack = React.createClass({
   // This prevents updates if state & props have not changed.
   mixins: [React.addons.PureRenderMixin],
@@ -137,10 +144,11 @@ var NonEmptyGenomeTrack = React.createClass({
 
     var scale = this.getScale();
     var pxPerLetter = scale(1) - scale(0);
+    var mode = this.getDisplayMode(pxPerLetter);
 
     var contigColon = this.props.range.contig + ':';
     var absBasePairs;
-    if (pxPerLetter > MIN_PX_PER_LETTER) {
+    if (mode != DisplayMode.HIDDEN) {
       absBasePairs = _.range(range.start - 1, range.stop + 1)
           .map(locus => ({
             position: locus,
@@ -162,15 +170,29 @@ var NonEmptyGenomeTrack = React.createClass({
     // Enter
     letter.enter().append('text');
 
+    var baseClass = 'basepair ' + (mode == DisplayMode.LOOSE ? 'loose' : 'tight') + ' ';
+
     // Enter & update
     letter
         .attr('x', bp => scale(bp.position))
         .attr('y', height)
-        .attr('class', bp => 'basepair ' + bp.letter)
+        .attr('class', bp => baseClass + bp.letter)
         .text(bp => bp.letter);
 
     // Exit
     letter.exit().remove();
+  },
+
+  getDisplayMode(pxPerLetter): number {
+    if (pxPerLetter >= 25) {
+      return DisplayMode.LOOSE;
+    } else if (pxPerLetter >= 10) {
+      return DisplayMode.TIGHT;
+    } else if (pxPerLetter >= 1) {
+      return DisplayMode.BLOCKS;
+    } else {
+      return DisplayMode.HIDDEN;
+    }
   }
 });
 

--- a/src/GenomeTrack.js
+++ b/src/GenomeTrack.js
@@ -41,6 +41,12 @@ var NonEmptyGenomeTrack = React.createClass({
     basePairs: React.PropTypes.object.isRequired,
     onRangeChange: React.PropTypes.func.isRequired
   },
+  getInitialState: function() {
+    return {
+      width: 0,
+      height: 0
+    };
+  },
   render: function(): any {
     return <div className="reference"></div>;
   },
@@ -48,6 +54,11 @@ var NonEmptyGenomeTrack = React.createClass({
     var div = this.getDOMNode(),
         svg = d3.select(div)
                 .append('svg');
+
+    this.setState({
+      width: div.offsetWidth,
+      height: div.offsetHeight
+    });
 
     var originalRange, originalScale, dx=0;
     var dragstarted = () => {
@@ -109,16 +120,20 @@ var NonEmptyGenomeTrack = React.createClass({
     // For now, just basePairs and range.
     var newProps = this.props;
     if (!_.isEqual(newProps.basePairs, prevProps.basePairs) ||
-        !_.isEqual(newProps.range, prevProps.range)) {
+        !_.isEqual(newProps.range, prevProps.range) ||
+       this.state != prevState) {
       this.updateVisualization();
     }
   },
   updateVisualization: function() {
     var div = this.getDOMNode(),
         range = this.props.range,
-        width = div.offsetWidth,
-        height = div.offsetHeight,
+        width = this.state.width,
+        height = this.state.height,
         svg = d3.select(div).select('svg');
+
+    // Hold off until height & width are known.
+    if (width === 0) return;
 
     var scale = this.getScale();
     var pxPerLetter = scale(1) - scale(0);

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -20,8 +20,13 @@
 .basepair.t { fill: #F70016; }
 .basepair.u { fill: #F70016; }
 text.basepair {
-  font-size: 36;
   font-weight: bold;
+}
+text.basepair.loose {
+  font-size: 30;
+}
+text.basepair.tight {
+  font-size: 12;
 }
 
 /* gene track */

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -14,19 +14,30 @@
 .background {
   fill: white;
 }
-.basepair.a { fill: #188712; }
-.basepair.g { fill: #C45C16; }
-.basepair.c { fill: #0600F9; }
-.basepair.t { fill: #F70016; }
-.basepair.u { fill: #F70016; }
-text.basepair {
+.basepair .a { fill: #188712; }
+.basepair .g { fill: #C45C16; }
+.basepair .c { fill: #0600F9; }
+.basepair .t { fill: #F70016; }
+.basepair .u { fill: #F70016; }
+.basepair text {
+  font-family: Helvetica Neue, Helvetica, Arial, sans;
+}
+.basepair.loose text {
+  font-size: 28;
+}
+.basepair.tight text {
+  font-size: 12;
   font-weight: bold;
 }
-text.basepair.loose {
-  font-size: 30;
+.basepair text, .basepair rect {
+  visibility: hidden;
 }
-text.basepair.tight {
-  font-size: 12;
+.basepair.loose text,
+.basepair.tight text {
+  visibility: visible;
+}
+.basepair.blocks rect {
+  visibility: visible;
 }
 
 /* gene track */


### PR DESCRIPTION
Fixes #42 

There are four modes: Loose, Tight, Blocks and Hidden.

Loose:

![screen shot 2015-04-24 at 4 47 40 pm](https://cloud.githubusercontent.com/assets/98301/7328224/b1cbb852-eaa1-11e4-84d6-5e33dc5c38c5.png)

Tight:

![screen shot 2015-04-24 at 4 47 37 pm](https://cloud.githubusercontent.com/assets/98301/7328227/b84ebfc6-eaa1-11e4-952a-1214529e06f4.png)

Blocks:

![screen shot 2015-04-24 at 4 47 31 pm](https://cloud.githubusercontent.com/assets/98301/7328230/bdbd19c6-eaa1-11e4-8f5b-05b6f3a0864a.png)

This is implemented by creating both `<text>` and `<rect>` elements for every base pair, one of which is hidden via CSS. It would be better to create just one or the other, but I wasn't quite sure what the right way to do this was in D3.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/107)
<!-- Reviewable:end -->
