### PR TITLE
Update to flow 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chai": "^2.0.0",
     "coveralls": "^2.11.2",
     "es5-shim": "^4.1.0",
-    "flow-bin": "^0.6.0",
+    "flow-bin": "^0.10.0",
     "grunt": "^0.4.5",
     "grunt-browserify": "^3.3.0",
     "grunt-contrib-connect": "^0.9.0",

--- a/src/bam.js
+++ b/src/bam.js
@@ -282,8 +282,8 @@ class Bam {
    * The 'contained' parameter controls whether the alignments must be fully
    * contained within the range, or need only overlap it.
    */
-  getAlignmentsInRange(range: ContigInterval<string>, contained?: boolean): Q.Promise<SamRead[]> {
-    contained = contained || false;
+  getAlignmentsInRange(range: ContigInterval<string>, opt_contained?: boolean): Q.Promise<SamRead[]> {
+    var contained = opt_contained || false;
     if (!this.index) {
       throw 'Range searches are only supported on BAMs with BAI indices.';
     }


### PR DESCRIPTION
This lets us use the new [`export type`][1] statement.

[1]: https://github.com/facebook/flow/issues/267#event-291051612

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/109)
<!-- Reviewable:end -->
