### PR TITLE
Indicate alignment mismatches

### DIFF
--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -5,8 +5,6 @@
 'use strict';
 
 import type * as SamRead from './SamRead';
-// import type * as TwoBitSource from './TwoBitDataSource';
-// import type {BasePair} from './pileuputils';
 
 var React = require('react/addons'),
     _ = require('underscore'),
@@ -62,7 +60,7 @@ function makePath(scale, visualRead: VisualAlignment) {
 }
 
 function readClass(vread: VisualAlignment) {
-  return 'alignment' + (vread.strand == Strand.NEGATIVE ? ' negative' : ' positive');
+  return 'alignment ' + (vread.strand == Strand.NEGATIVE ? 'negative' : 'positive');
 }
 
 // Copied from pileuputils.js
@@ -88,12 +86,10 @@ var Strand = {
 
 // TODO: scope to PileupTrack
 var pileup = [];
-var keyToVisualAlignment = {};  // TODO: add type
-
-window.vreads = keyToVisualAlignment;
+var keyToVisualAlignment: {[key:string]: VisualAlignment} = {};
 
 // Attach visualization info to the read and cache it.
-function addRead(read: SamRead, referenceSource) {
+function addRead(read: SamRead, referenceSource): VisualAlignment {
   var k = read.offset.toString();
   var v = keyToVisualAlignment[k];
   if (v) return v;
@@ -108,7 +104,6 @@ function addRead(read: SamRead, referenceSource) {
 
   var key = read.offset.toString();
 
-  // assign this read to a row in the pileup
   var visualAlignment = {
     key,
     read,

--- a/src/Root.js
+++ b/src/Root.js
@@ -85,6 +85,7 @@ var Root = React.createClass({
                    onRangeChange={this.handleRangeChange} />
         <PileupTrack range={this.state.range}
                      reads={this.state.reads}
+                     referenceSource={this.props.referenceSource}
                      onRangeChange={this.handleRangeChange} />
 
       </div>

--- a/src/SamRead.js
+++ b/src/SamRead.js
@@ -30,6 +30,9 @@ type CigarOp = {
   length: number
 }
 
+var SEQUENCE_VALUES = ['=', 'A', 'C', 'M', 'G', 'R', 'S', 'V',
+                       'T', 'W', 'Y', 'H', 'K', 'D', 'B', 'N'];
+
 
 class SamRead {
   buffer: ArrayBuffer;
@@ -39,7 +42,11 @@ class SamRead {
   refID: number;
   ref: string;
   l_seq: number;
+
+  // cached values
   _full: ?Object;
+  _refLength: ?number;
+  _seq: ?string;
 
   /**
    * @param buffer contains the raw bytes of the serialized BAM read. It must
@@ -99,7 +106,9 @@ class SamRead {
   }
 
   getInterval(): ContigInterval<string> {
-    return new ContigInterval(this.ref, this.pos, this.pos + this.l_seq - 1);
+    return new ContigInterval(this.ref,
+                              this.pos,
+                              this.pos + this.getReferenceLength() - 1);
   }
 
   intersects(interval: ContigInterval<string>): boolean {
@@ -128,6 +137,47 @@ class SamRead {
 
   getQualPhred(): string {
     return makeAsciiPhred(this.getFull().qual);
+  }
+
+  getSequence(): string {
+    if (this._seq) return this._seq;
+    var jv = this._getJDataView(),
+        l_read_name = jv.getUint8(8),
+        n_cigar_op = jv.getUint16(12),
+        l_seq = jv.getInt32(16),
+        pos = 32 + l_read_name + 4 * n_cigar_op,
+        basePairs = new Array(l_seq),
+        numBytes = Math.ceil(l_seq / 2);
+
+    for (var i = 0; i < numBytes; i++) {
+      var b = jv.getUint8(pos + i);
+      basePairs[2 * i] = SEQUENCE_VALUES[b >> 4];
+      if (2 * i + 1 < l_seq) {
+        basePairs[2 * i + 1] = SEQUENCE_VALUES[b & 0xf];
+      }
+    }
+
+    var seq = basePairs.join('');
+    this._seq = seq;
+    return seq;
+  }
+
+  // Returns the length of the alignment from first aligned read to last aligned read.
+  getReferenceLength(): number {
+    if (this._refLength) return this._refLength;
+    var refLength = 0;
+    this.getCigarOps().forEach(({op, length}) => {
+      switch (op) {
+        case 'M':
+        case 'D':
+        case 'N':
+        case '=':
+        case 'X':
+          refLength += length;
+      }
+    });
+    this._refLength = refLength;
+    return refLength;
   }
 
   debugString(): string {

--- a/src/SamRead.js
+++ b/src/SamRead.js
@@ -62,10 +62,10 @@ class SamRead {
 
     // Go ahead and parse a few fields immediately.
     var jv = this._getJDataView();
-    this.refID = jv.getUint32(0);
+    this.refID = jv.getInt32(0);
     this.ref = ref;
-    this.pos = jv.getUint32(4);
-    this.l_seq = jv.getUint32(16);
+    this.pos = jv.getInt32(4);
+    this.l_seq = jv.getInt32(16);
   }
 
   toString(): string {

--- a/src/TwoBitDataSource.js
+++ b/src/TwoBitDataSource.js
@@ -113,7 +113,7 @@ var createTwoBitDataSource = function(remoteSource: TwoBit): TwoBitSource {
   function getRangeAsString(range: GenomeRange): string {
     if (!range) return '';
     return _.range(range.start, range.stop + 1)
-        .map(x => getBasePair(range.contig, x))
+        .map(x => getBasePair(range.contig, x) || '.')
         .join('');
   }
 

--- a/src/TwoBitDataSource.js
+++ b/src/TwoBitDataSource.js
@@ -39,6 +39,7 @@ type TwoBitSource = {
   rangeChanged: (newRange: GenomeRange) => void;
   needContigs: () => void;
   getRange: (range: GenomeRange) => ?{[key:string]: string};
+  getRangeAsString: (range: GenomeRange) => string;
   contigList: () => string[];
   on: (event: string, handler: Function) => void;
   off: (event: string) => void;
@@ -108,6 +109,14 @@ var createTwoBitDataSource = function(remoteSource: TwoBit): TwoBitSource {
         .value();
   }
 
+  // Returns a string of base pairs for this range.
+  function getRangeAsString(range: GenomeRange): string {
+    if (!range) return '';
+    return _.range(range.start, range.stop + 1)
+        .map(x => getBasePair(range.contig, x))
+        .join('');
+  }
+
   var o = {
     rangeChanged: function(newRange: GenomeRange) {
       // Range has changed! Fetch new data.
@@ -123,7 +132,8 @@ var createTwoBitDataSource = function(remoteSource: TwoBit): TwoBitSource {
         o.trigger('contigs', contigList);
       }).done();
     },
-    getRange: getRange,
+    getRange,
+    getRangeAsString,
     contigList: () => contigList,
 
     // These are here to make Flow happy.

--- a/src/bam.js
+++ b/src/bam.js
@@ -233,7 +233,13 @@ class Bam {
       var slice = function(u8: Uint8Array) {
         return u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength - 1);
       };
-      o.alignments = o.alignments.map(x => new SamRead(slice(x.contents), vo, ''));
+      o.alignments = o.alignments.map(x => {
+        var r = new SamRead(slice(x.contents), vo, '');
+        if (r.refID != -1) {
+          r.ref = o.header.references[r.refID].name;
+        }
+        return r;
+      });
       return o;
     });
   }

--- a/src/pileuputils.js
+++ b/src/pileuputils.js
@@ -1,6 +1,7 @@
 /** @flow */
 'use strict';
 
+import type * as SamRead from './SamRead';
 import type * as Interval from './Interval';
 
 /**
@@ -64,4 +65,39 @@ function addToPileup(read: Interval, pileup: Array<Interval[]>): number {
   return chosenRow;
 }
 
-module.exports = {pileup, addToPileup};
+type BasePair = {
+  pos: number;
+  basePair: string;
+}
+
+// TODO: document reference type
+function getDifferingBasePairs(read: SamRead, reference: string): Array<BasePair> {
+  var cigar = read.getCigarOps();
+
+  // TODO: account for Cigars with clipping and indels
+  if (cigar.length != 1 || cigar[0].op != 'M') {
+    return [];
+  }
+  var range = read.getInterval(),
+      seq = read.getSequence(),
+      start = range.start();
+  var out = [];
+  for (var i = 0; i < seq.length; i++) {
+    var pos = start + i,
+        ref = reference.charAt(i),
+        basePair = seq.charAt(i);
+    if (ref != basePair) {
+      out.push({
+        pos,
+        basePair
+      });
+    }
+  }
+  return out;
+}
+
+module.exports = {
+  pileup,
+  addToPileup,
+  getDifferingBasePairs
+};

--- a/src/pileuputils.js
+++ b/src/pileuputils.js
@@ -70,7 +70,6 @@ type BasePair = {
   basePair: string;
 }
 
-// TODO: document reference type
 function getDifferingBasePairs(read: SamRead, reference: string): Array<BasePair> {
   var cigar = read.getCigarOps();
 

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -14,12 +14,12 @@
 .background {
   fill: white;
 }
-.basepair .a { fill: #188712; }
-.basepair .g { fill: #C45C16; }
-.basepair .c { fill: #0600F9; }
-.basepair .t { fill: #F70016; }
-.basepair .u { fill: #F70016; }
-.basepair text {
+.basepair.a, .basepair .a { fill: #188712; }
+.basepair.g, .basepair .g { fill: #C45C16; }
+.basepair.c, .basepair .c { fill: #0600F9; }
+.basepair.t, .basepair .t { fill: #F70016; }
+.basepair.u, .basepair .u { fill: #F70016; }
+.basepair text, text.basepair {
   font-family: Helvetica Neue, Helvetica, Arial, sans;
 }
 .basepair.loose text {
@@ -73,8 +73,13 @@
 .pileup {
   height: 300px;
 }
-.pileup .alignment {
+.pileup .alignment path {
   fill: #c8c8c8;  /* matches IGV */
 }
-.pileup .alignment.negative {
+.pileup .alignment.negative path {
+}
+.pileup text.basepair {
+  alignment-baseline: hanging;
+  font-size: 12;
+  font-weight: bold;
 }

--- a/test/BamDataSource-test.js
+++ b/test/BamDataSource-test.js
@@ -37,9 +37,9 @@ describe('BamDataSource', function() {
 
     source.on('newdata', () => {
       var reads = source.getAlignmentsInRange(range);
-      expect(reads).to.have.length(1114);
+      expect(reads).to.have.length(1112);
       expect(reads[0].toString()).to.equal('20:31511251-31511351');
-      expect(reads[1113].toString()).to.equal('20:31514171-31514271');
+      expect(reads[1111].toString()).to.equal('20:31514171-31514271');
       done();
     });
     source.rangeChanged({
@@ -64,14 +64,14 @@ describe('BamDataSource', function() {
     // Fetching [50, 150] should cache [0, 200]
     source.on('newdata', () => {
       var reads = source.getAlignmentsInRange(range);
-      expect(reads).to.have.length(19);
+      expect(reads).to.have.length(18);
       expect(reads[0].toString()).to.equal('20:31511951-31512051');
-      expect(reads[18].toString()).to.equal('20:31512146-31512246');
+      expect(reads[17].toString()).to.equal('20:31512146-31512246');
 
       var readsBefore = source.getAlignmentsInRange(rangeBefore),
           readsAfter = source.getAlignmentsInRange(rangeAfter);
 
-      expect(readsBefore).to.have.length(28);
+      expect(readsBefore).to.have.length(26);
       expect(readsAfter).to.have.length(12);
 
       // TODO: test that fetching readsBefore and readsAfter produces no

--- a/test/SamRead-test.js
+++ b/test/SamRead-test.js
@@ -2,32 +2,18 @@
 'use strict';
 
 import type * as Q from 'q';
+import type * as SamRead from '../src/SamRead';
 
 var expect = require('chai').expect;
 
-var jBinary = require('jbinary');
-
 var RemoteFile = require('../src/RemoteFile'),
-    utils = require('../src/utils'),
-    bamTypes = require('../src/formats/bamTypes'),
-    SamRead = require('../src/SamRead'),
-    VirtualOffset = require('../src/VirtualOffset'),
+    Bam = require('../src/bam'),
     ContigInterval = require('../src/ContigInterval');
 
 describe('SamRead', function() {
 
   function getSamArray(url): Q.Promise<SamRead[]> {
-    var zero = new VirtualOffset(0, 0);
-    var file = new RemoteFile(url);
-    return file.getAll().then(gzipBuffer => {
-      var buf = utils.inflateGzip(gzipBuffer);
-      var jb = new jBinary(buf, bamTypes.TYPE_SET);
-      jb.read('BamHeader');  // skip past the header to get to alignments.
-      return jb.read(['array', {
-        block_size: 'int32',
-        contents: ['blob', 'block_size']
-      }]).map(block => new SamRead(block.contents, zero, 'ref'));
-    });
+    return new Bam(new RemoteFile(url)).readAll().then(d => d.alignments);
   }
 
   var testReads = getSamArray('/test/data/test_input_1_a.bam');
@@ -46,10 +32,10 @@ describe('SamRead', function() {
       var read = reads[0];
       expect(read.getName()).to.equal('r000');
       expect(read.refID).to.equal(0);
-      expect(read.ref).to.equal('ref');
+      expect(read.ref).to.equal('insert');
       expect(read.pos).to.equal(49);  // 0-based
       expect(read.l_seq).to.equal(10);
-      expect(read.toString()).to.equal('ref:50-59');
+      expect(read.toString()).to.equal('insert:50-59');
       expect(read.getCigarOps()).to.deep.equal([{op: 'M', length: 10}]);
 
       // This one has a more interesting Cigar string
@@ -73,7 +59,7 @@ describe('SamRead', function() {
       var r000 = reads[0].getFull();
       expect(r000.read_name).to.equal('r000');
       expect(r000.FLAG).to.equal(99);
-      expect(r000.refID).to.equal(0);
+      expect(reads[0].ref).to.equal('insert');
       // .. POS
       expect(r000.MAPQ).to.equal(30);
       expect(reads[0].getCigarString()).to.equal('10M');
@@ -88,6 +74,10 @@ describe('SamRead', function() {
       expect(aux).to.have.length(2);
       expect(aux[0]).to.contain({tag: 'RG', value: 'cow'});
       expect(aux[1]).to.contain({tag: 'PG', value: 'bull'});
+
+      expect(reads).to.have.length(15);
+      expect(reads[14].refID).to.equal(-1);  // unmapped read
+      expect(reads[14].ref).to.equal('');
     });
   });
 
@@ -95,12 +85,12 @@ describe('SamRead', function() {
     return testReads.then(reads => {
       var read = reads[0];
       // toString() produces a 1-based result, but ContigInterval is 0-based.
-      expect(read.toString()).to.equal('ref:50-59');
-      expect(read.intersects(new ContigInterval('ref', 40, 49))).to.be.true;
-      expect(read.intersects(new ContigInterval('ref', 40, 48))).to.be.false;
+      expect(read.toString()).to.equal('insert:50-59');
+      expect(read.intersects(new ContigInterval('insert', 40, 49))).to.be.true;
+      expect(read.intersects(new ContigInterval('insert', 40, 48))).to.be.false;
       expect(read.intersects(new ContigInterval('0', 40, 55))).to.be.false;
-      expect(read.intersects(new ContigInterval('ref', 58, 60))).to.be.true;
-      expect(read.intersects(new ContigInterval('ref', 59, 60))).to.be.false;
+      expect(read.intersects(new ContigInterval('insert', 58, 60))).to.be.true;
+      expect(read.intersects(new ContigInterval('insert', 59, 60))).to.be.false;
     });
   });
 });

--- a/test/SamRead-test.js
+++ b/test/SamRead-test.js
@@ -50,6 +50,20 @@ describe('SamRead', function() {
       expect(read.pos).to.equal(49);  // 0-based
       expect(read.l_seq).to.equal(10);
       expect(read.toString()).to.equal('ref:50-59');
+      expect(read.getCigarOps()).to.deep.equal([{op: 'M', length: 10}]);
+
+      // This one has a more interesting Cigar string
+      expect(reads[3].getCigarOps()).to.deep.equal([
+        {op: 'S', length: 1},
+        {op: 'I', length: 2},
+        {op: 'M', length: 6},
+        {op: 'P', length: 1},
+        {op: 'I', length: 1},
+        {op: 'P', length: 1},
+        {op: 'I', length: 1},
+        {op: 'M', length: 4},
+        {op: 'I', length: 2}
+      ]);
     });
   });
 

--- a/test/SamRead-test.js
+++ b/test/SamRead-test.js
@@ -81,6 +81,7 @@ describe('SamRead', function() {
       // next pos
       expect(r000.tlen).to.equal(30);
       expect(r000.seq).to.equal('ATTTAGCTAC');
+      expect(reads[0].getSequence()).to.equal('ATTTAGCTAC');
       expect(reads[0].getQualPhred()).to.equal('AAAAAAAAAA');
 
       var aux = r000.auxiliary;

--- a/test/TwoBitDataSource-test.js
+++ b/test/TwoBitDataSource-test.js
@@ -33,6 +33,7 @@ describe('TwoBitDataSource', function() {
       'chr22:3': null,
       'chr22:4': null
     });
+    expect(source.getRangeAsString(range)).to.equal('....');
 
     source.on('newdata', () => {
       expect(source.getRange(range)).to.deep.equal({
@@ -41,6 +42,7 @@ describe('TwoBitDataSource', function() {
         'chr22:3': 'C',
         'chr22:4': 'A'
       });
+      expect(source.getRangeAsString(range)).to.equal('NTCA');
       done();
     });
     source.rangeChanged(range);


### PR DESCRIPTION
First cut at this. Here's what it looks like:

![screen shot 2015-04-28 at 12 51 33 pm](https://cloud.githubusercontent.com/assets/98301/7375466/d0fc5120-eda6-11e4-90e1-de2b32e09f4d.png)

What this does:

- Threads `referenceSource` through to `PileupTrack`
- Exposes a few more "fast" methods on `SamRead`, e.g. `getCigarOps` and `getSequence()`
- Uses the aligned length of a read for display, not the sequence length
- Factors out a `VisualAlignment` type for `PileupTrack` for data binding
- Uses a [nested selection][1] to indicate the mismatched bases

Still to do:
- Support indels and clipping
- Figure out why some reads are completely colored (off by one?)
- Re-color mismatches when the reference changes
- Scale the font of the mismatches in the same way as the reference track

See #84 

[1]: http://bost.ocks.org/mike/nest/

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/112)
<!-- Reviewable:end -->
