### PR TITLE
Update to React 0.13 and re-scope pileup cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jdataview": "^2.5.0",
     "pako": "^0.2.5",
     "q": "^1.1.2",
-    "react": "^0.12.2",
+    "react": "^0.13.2",
     "underscore": "^1.7.0"
   },
   "devDependencies": {

--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -121,24 +121,21 @@ function yForRow(row) {
   return row * (READ_HEIGHT + READ_SPACING);
 }
 
-var NonEmptyPileupTrack = React.createClass({
-  propTypes: {
-    range: types.GenomeRange.isRequired,
-    reads: React.PropTypes.array.isRequired,
-    referenceSource: React.PropTypes.object.isRequired,
-    onRangeChange: React.PropTypes.func.isRequired
-  },
-  getInitialState: function() {
-    return {
+class NonEmptyPileupTrack extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
       width: 0,
       height: 0
     };
-  },
-  render: function(): any {
+  }
+
+  render(): any {
     return <div className='pileup'></div>;
-  },
-  componentDidMount: function() {
-    var div = this.getDOMNode();
+  }
+
+  componentDidMount() {
+    var div = React.findDOMNode(this);
     this.setState({
       width: div.offsetWidth,
       height: div.offsetWidth
@@ -146,8 +143,9 @@ var NonEmptyPileupTrack = React.createClass({
     d3.select(div)
       .append('svg');
     this.updateVisualization();
-  },
-  getScale: function() {
+  }
+
+  getScale() {
     var range = this.props.range,
         width = this.state.width,
         offsetPx = range.offsetPx || 0;
@@ -155,8 +153,9 @@ var NonEmptyPileupTrack = React.createClass({
             .domain([range.start, range.stop + 1])  // 1 bp wide
             .range([-offsetPx, width - offsetPx]);
     return scale;
-  },
-  componentDidUpdate: function(prevProps: any, prevState: any) {
+  }
+
+  componentDidUpdate(prevProps: any, prevState: any) {
     // Check a whitelist of properties which could change the visualization.
     // TODO: this is imprecise; it would be better to deep check reads.
     var newProps = this.props;
@@ -165,9 +164,10 @@ var NonEmptyPileupTrack = React.createClass({
        prevState != this.state) {
       this.updateVisualization();
     }
-  },
-  updateVisualization: function() {
-    var div = this.getDOMNode(),
+  }
+
+  updateVisualization() {
+    var div = React.findDOMNode(this),
         width = this.state.width,
         height = this.state.height,
         svg = d3.select(div).select('svg');
@@ -211,7 +211,14 @@ var NonEmptyPileupTrack = React.createClass({
     reads.exit().remove();
   }
 
-});
+}
+
+NonEmptyPileupTrack.propTypes = {
+  range: types.GenomeRange.isRequired,
+  reads: React.PropTypes.array.isRequired,
+  referenceSource: React.PropTypes.object.isRequired,
+  onRangeChange: React.PropTypes.func.isRequired
+};
 
 
 var EmptyTrack = React.createClass({


### PR DESCRIPTION
Fixes #108 

This uses [ES6-style classes with React][1], which makes it easier to stick arbitrary fields (like a cache) onto a component without affecting `state` or `props`.

This is required for showing two pileup tracks (e.g. tumor and normal).

[1]: https://facebook.github.io/react/blog/2015/01/27/react-v0.13.0-beta-1.html

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/119)
<!-- Reviewable:end -->
