### PR TITLE
Pass data sources to visualizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "pako": "^0.2.5",
     "q": "^1.1.2",
     "react": "^0.13.2",
+    "shallow-equals": "0.0.0",
     "underscore": "^1.7.0"
   },
   "devDependencies": {

--- a/src/BigBedDataSource.js
+++ b/src/BigBedDataSource.js
@@ -113,6 +113,7 @@ function create(remoteSource: BigBed): BigBedSource {
   }
 
   var o = {
+    // TODO: only fire newdata when new data arrives
     rangeChanged: function(newRange: GenomeRange) {
       fetch(newRange)
           .then(() => o.trigger('newdata', newRange))

--- a/src/Root.js
+++ b/src/Root.js
@@ -33,13 +33,12 @@ var Root = React.createClass({
   },
   componentDidMount: function() {
     // Note: flow is unable to infer this type through `this.propTypes`.
-    var source = this.props.referenceSource;
-    source.needContigs();
+    var referenceSource = this.props.referenceSource;
+    referenceSource.needContigs();
 
-    source.on('contigs', () => { this.update() })
-          .on('newdata', () => { this.update() });
+    referenceSource.on('contigs', () => { this.update() });
 
-    source.on('contigs', () => {
+    referenceSource.on('contigs', () => {
       // this is here to facilitate faster iteration
       this.handleRangeChange(this.props.initialRange);
     });
@@ -80,7 +79,7 @@ var Root = React.createClass({
                   range={this.state.range}
                   onChange={this.handleRangeChange} />
         <GenomeTrack range={this.state.range}
-                     basePairs={this.state.basePairs}
+                     source={this.props.referenceSource}
                      onRangeChange={this.handleRangeChange} />
         <VariantTrack range={this.state.range}
                       variantSource={this.props.variantSource}

--- a/src/Root.js
+++ b/src/Root.js
@@ -43,8 +43,8 @@ var Root = React.createClass({
       this.handleRangeChange(this.props.initialRange);
     });
 
-    var geneSource = this.props.geneSource;
-    geneSource.on('newdata', () => { this.update() });
+    // var geneSource = this.props.geneSource;
+    // geneSource.on('newdata', () => { this.update() });
 
     var bamSource = this.props.bamSource;
     bamSource.on('newdata', () => { this.update() });
@@ -56,8 +56,8 @@ var Root = React.createClass({
         ci = range && new ContigInterval(range.contig, range.start, range.stop);
     this.setState({
       contigList: this.props.referenceSource.contigList(),
-      basePairs: this.props.referenceSource.getRange(range),
-      genes: this.props.geneSource.getGenesInRange(ci),
+      // basePairs: this.props.referenceSource.getRange(range),
+      // genes: this.props.geneSource.getGenesInRange(ci),
       reads: this.props.bamSource.getAlignmentsInRange(ci)
     });
   },
@@ -85,7 +85,8 @@ var Root = React.createClass({
                       variantSource={this.props.variantSource}
                       onRangeChange={this.handleRangeChange} />
         <GeneTrack range={this.state.range}
-                   genes={this.state.genes}
+                   source={this.props.geneSource}
+                   referenceSource={this.props.referenceSource}
                    onRangeChange={this.handleRangeChange} />
         <PileupTrack range={this.state.range}
                      reads={this.state.reads}

--- a/src/Root.js
+++ b/src/Root.js
@@ -7,7 +7,6 @@
 import type * as SamRead from './SamRead';
 
 var React = require('react'),
-    ContigInterval = require('./ContigInterval'),
     Controls = require('./Controls'),
     GenomeTrack = require('./GenomeTrack'),
     GeneTrack = require('./GeneTrack'),
@@ -25,10 +24,7 @@ var Root = React.createClass({
   getInitialState: function() {
     return {
       contigList: ([]: string[]),
-      range: (null: ?GenomeRange),
-      basePairs: (null: any),
-      genes: ([]: Array<any>),  // TODO import Gene type
-      reads: ([]: SamRead[])
+      range: (null: ?GenomeRange)
     };
   },
   componentDidMount: function() {
@@ -36,38 +32,21 @@ var Root = React.createClass({
     var referenceSource = this.props.referenceSource;
     referenceSource.needContigs();
 
-    referenceSource.on('contigs', () => { this.update() });
+    referenceSource.on('contigs', () => {
+      this.setState({
+        contigList: referenceSource.contigList(),
+      });
+    });
 
     referenceSource.on('contigs', () => {
       // this is here to facilitate faster iteration
       this.handleRangeChange(this.props.initialRange);
     });
-
-    // var geneSource = this.props.geneSource;
-    // geneSource.on('newdata', () => { this.update() });
-
-    var bamSource = this.props.bamSource;
-    bamSource.on('newdata', () => { this.update() });
-
-    this.update();
-  },
-  update: function() {
-    var range = this.state.range,
-        ci = range && new ContigInterval(range.contig, range.start, range.stop);
-    this.setState({
-      contigList: this.props.referenceSource.contigList(),
-      // basePairs: this.props.referenceSource.getRange(range),
-      // genes: this.props.geneSource.getGenesInRange(ci),
-      reads: this.props.bamSource.getAlignmentsInRange(ci)
-    });
   },
   handleRangeChange: function(newRange: GenomeRange) {
     this.setState({range: newRange});
-    this.update();
 
-    var ref = this.props.referenceSource;
-    ref.rangeChanged(newRange);
-
+    this.props.referenceSource.rangeChanged(newRange);
     this.props.geneSource.rangeChanged(newRange);
     this.props.bamSource.rangeChanged(newRange);
     this.props.variantSource.rangeChanged(newRange);
@@ -89,7 +68,7 @@ var Root = React.createClass({
                    referenceSource={this.props.referenceSource}
                    onRangeChange={this.handleRangeChange} />
         <PileupTrack range={this.state.range}
-                     reads={this.state.reads}
+                     source={this.props.bamSource}
                      referenceSource={this.props.referenceSource}
                      onRangeChange={this.handleRangeChange} />
 

--- a/src/TwoBitDataSource.js
+++ b/src/TwoBitDataSource.js
@@ -120,6 +120,7 @@ var create = function(remoteSource: TwoBit): TwoBitSource {
   var o = {
     rangeChanged: function(newRange: GenomeRange) {
       // Range has changed! Fetch new data.
+      // TODO: make this a no-op if the range is already covered.
       var range = new ContigInterval(newRange.contig, newRange.start, newRange.stop);
 
       fetch(range)

--- a/src/types.js
+++ b/src/types.js
@@ -4,9 +4,17 @@
  */
 'use strict';
 
+import type * as React from 'react';
+
 export type Track = {
   type: string;
   data: Object;  // either url: string or source: Object
   cssClass: ?string;
   options: ?Object;
+}
+
+export type VisualizedTrack = {
+  visualization: React.Component;
+  source: Object;  // data source
+  track: Track;  // for css class and options
 }


### PR DESCRIPTION
This takes most of the logic out of `Root.js`, which will facilitate creating a public-facing API.

See #30

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/121)
<!-- Reviewable:end -->
