### PR TITLE
Eliminate over-firing of TwoBitDataSource.newdata

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chai": "^2.0.0",
     "coveralls": "^2.11.2",
     "es5-shim": "^4.1.0",
-    "flow-bin": "^0.10.0",
+    "flow-bin": "^0.11.0",
     "grunt": "^0.4.5",
     "grunt-browserify": "^3.3.0",
     "grunt-contrib-connect": "^0.9.0",

--- a/src/TwoBit.js
+++ b/src/TwoBit.js
@@ -128,8 +128,8 @@ class TwoBit {
   remoteFile: RemoteFile;
   header: Q.Promise<TwoBitHeader>;
 
-  constructor(url: string) {
-    this.remoteFile = new RemoteFile(url);
+  constructor(remoteFile: RemoteFile) {
+    this.remoteFile = remoteFile;
     var deferredHeader = Q.defer();
     this.header = deferredHeader.promise;
 

--- a/src/TwoBit.js
+++ b/src/TwoBit.js
@@ -9,8 +9,9 @@ var Q = require('q'),
     _ = require('underscore'),
     jBinary = require('jbinary');
 
-var RemoteFile = require('./RemoteFile'),
-    twoBitTypes = require('./formats/twoBitTypes');
+import type * as RemoteFile from './RemoteFile';
+
+var twoBitTypes = require('./formats/twoBitTypes');
 
 var BASE_PAIRS = [
   'T',  // 0=00

--- a/src/TwoBitDataSource.js
+++ b/src/TwoBitDataSource.js
@@ -40,6 +40,7 @@ type TwoBitSource = {
   getRangeAsString: (range: GenomeRange) => string;
   contigList: () => string[];
   on: (event: string, handler: Function) => void;
+  once: (event: string, handler: Function) => void;
   off: (event: string) => void;
   trigger: (event: string, ...args:any) => void;
 }
@@ -58,6 +59,10 @@ var createFromTwoBitFile = function(remoteSource: TwoBit): TwoBitSource {
   // Local cache of genomic data.
   var contigList = [];
   var basePairs = {};  // contig -> locus -> letter
+
+  // Ranges for which we have complete information -- no need to hit network.
+  var coveredRanges: ContigInterval<string>[] = [];
+
   function getBasePair(contig: string, position: number) {
     return (basePairs[contig] && basePairs[contig][position]) || null;
   }
@@ -65,32 +70,28 @@ var createFromTwoBitFile = function(remoteSource: TwoBit): TwoBitSource {
     if (!basePairs[contig]) basePairs[contig] = {};
     basePairs[contig][position] = letter;
   }
-  // Are all base pairs in the interval known? If so, no need to fetch.
-  function isEntirelyKnown(interval: ContigInterval<string>) {
-    for (var i = interval.start(); i <= interval.stop(); i++) {
-      if (getBasePair(interval.contig, i) === null) return false;
-    }
-    return true;
-  }
 
   function fetch(range: ContigInterval) {
     var span = range.stop() - range.start();
     if (span > MAX_BASE_PAIRS_TO_FETCH) {
       return Q.when();  // empty promise
     }
-    if (isEntirelyKnown(range)) {
-      return Q.when();
-    }
 
     range = expandRange(range);
 
     console.log(`Fetching ${span} base pairs`);
-    return remoteSource.getFeaturesInRange(range.contig, range.start(), range.stop())
-        .then(letters => {
-          for (var i = 0; i < letters.length; i++) {
-            setBasePair(range.contig, range.start() + i, letters[i]);
-          }
-        });
+    remoteSource.getFeaturesInRange(range.contig, range.start(), range.stop())
+      .then(letters => {
+        coveredRanges.push(range);
+        coveredRanges = ContigInterval.coalesce(coveredRanges);
+        for (var i = 0; i < letters.length; i++) {
+          setBasePair(range.contig, range.start() + i, letters[i]);
+        }
+      })
+      .then(() => {
+        o.trigger('newdata', range);
+      })
+      .done();
   }
 
   // Returns a {"chr12:123" -> "[ATCG]"} mapping for the range.
@@ -117,12 +118,14 @@ var createFromTwoBitFile = function(remoteSource: TwoBit): TwoBitSource {
   var o = {
     rangeChanged: function(newRange: GenomeRange) {
       // Range has changed! Fetch new data.
-      // TODO: make this a no-op if the range is already covered.
       var range = new ContigInterval(newRange.contig, newRange.start, newRange.stop);
 
-      fetch(range)
-          .then(() => o.trigger('newdata', range))
-          .done();
+      // Check if this interval is already in the cache.
+      if (range.isCoveredBy(coveredRanges)) {
+        return;
+      }
+
+      fetch(range);
     },
     needContigs: () => {
       remoteSource.getContigList().then(c => {
@@ -136,6 +139,7 @@ var createFromTwoBitFile = function(remoteSource: TwoBit): TwoBitSource {
 
     // These are here to make Flow happy.
     on: () => {},
+    once: () => {},
     off: () => {},
     trigger: () => {}
   };

--- a/src/TwoBitDataSource.js
+++ b/src/TwoBitDataSource.js
@@ -18,7 +18,8 @@
 var Events = require('backbone').Events,
     Q = require('q'),
     _ = require('underscore'),
-    TwoBit = require('./TwoBit');
+    TwoBit = require('./TwoBit'),
+    RemoteFile = require('./RemoteFile');
 
 var ContigInterval = require('./ContigInterval');
 
@@ -149,7 +150,7 @@ function create(data: {url:string}): TwoBitSource {
     throw new Error(`Missing URL from track: ${JSON.stringify(data)}`);
   }
 
-  return createFromTwoBitFile(new TwoBit(url));
+  return createFromTwoBitFile(new TwoBit(new RemoteFile(url)));
 }
 
 module.exports = {

--- a/src/bam.js
+++ b/src/bam.js
@@ -200,6 +200,7 @@ function fetchAlignments(remoteFile: RemoteFile,
 class Bam {
   index: ?BaiFile;
   header: Q.Promise<Object>;
+  remoteFile: RemoteFile;
 
   constructor(remoteFile: RemoteFile,
               remoteIndexFile?: RemoteFile,

--- a/src/formats/helpers.js
+++ b/src/formats/helpers.js
@@ -68,6 +68,11 @@ var uint64native = jBinary.Template({
 // Type returned by lazyArray helper, below.
 // Has a .length property, a .get() method and a .getAll() method.
 class LazyArray {
+  bytesPerItem: number;
+  jb: Object;
+  itemType: Object;
+  length: number;
+
   constructor(jb, bytesPerItem: number, itemType) {
     this.bytesPerItem = bytesPerItem;
     this.jb = jb;

--- a/src/pileuputils.js
+++ b/src/pileuputils.js
@@ -73,6 +73,10 @@ type BasePair = {
 function getDifferingBasePairs(read: SamRead, reference: string): Array<BasePair> {
   var cigar = read.getCigarOps();
 
+  if (read.getName() == 'cb9b557a-3fdc-47c5-9651-825afb4f0d25') {
+    console.log(reference);
+  }
+
   // TODO: account for Cigars with clipping and indels
   if (cigar.length != 1 || cigar[0].op != 'M') {
     return [];

--- a/test/TwoBit-test.js
+++ b/test/TwoBit-test.js
@@ -5,11 +5,13 @@ var chai = require('chai');
 var expect = chai.expect;
 var assert = chai.assert;
 
-var TwoBit = require('../src/TwoBit');
+var TwoBit = require('../src/TwoBit'),
+    RemoteFile = require('../src/RemoteFile');
 
 describe('TwoBit', function() {
   function getTestTwoBit() {
-    return new TwoBit('/test/data/test.2bit');   // See test/data/README.md
+    // See test/data/README.md for provenance
+    return new TwoBit(new RemoteFile('/test/data/test.2bit'));
   }
 
   it('should have the right contigs', function() {

--- a/test/TwoBitDataSource-test.js
+++ b/test/TwoBitDataSource-test.js
@@ -3,13 +3,14 @@
 
 var expect = require('chai').expect;
 
-var TwoBit = require('../src/TwoBit');
-var TwoBitDataSource = require('../src/TwoBitDataSource');
+var TwoBit = require('../src/TwoBit'),
+    TwoBitDataSource = require('../src/TwoBitDataSource'),
+    RemoteFile = require('../src/RemoteFile');
 
 describe('TwoBitDataSource', function() {
   function getTestSource() {
     // See description of this file in TwoBit-test.js
-    var tb = new TwoBit('/test/data/test.2bit');
+    var tb = new TwoBit(new RemoteFile('/test/data/test.2bit'));
     return TwoBitDataSource.createFromTwoBitFile(tb);
   }
 
@@ -49,8 +50,7 @@ describe('TwoBitDataSource', function() {
   });
 
   it('should fetch nearby base pairs', function(done) {
-    var tb = new TwoBit('/test/data/test.2bit'),
-        source = TwoBitDataSource.createFromTwoBitFile(tb);
+    var source = getTestSource();
 
     source.on('newdata', () => {
       expect(source.getRange({contig: 'chr22', start: 1, stop: 15}))


### PR DESCRIPTION
Previously it fired in response to every `rangeChanged` notification. Now it only fires when new data comes in. This should make it easier to address #115.

This also modifies the `TwoBit` interface to take a `RemoteFile` instead of a URL (for easier swapping of alternate implementations for testing). I updated to Flow 0.11 to get better error messages out of this, which also required a few changes. Neither of these was necessary, but they both seem like good ideas.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/141)
<!-- Reviewable:end -->
