### PR TITLE
A few more fixes for CycleDash

### DIFF
--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -44,7 +44,7 @@ function makePath(scale, visualRead: VisualAlignment) {
   var read = visualRead.read,
       left = scale(visualRead.read.pos + 1),
       top = 0,
-      right = scale(read.pos + visualRead.refLength) - 5,
+      right = scale(read.pos + visualRead.refLength + 1) - 5,
       bottom = READ_HEIGHT,
       path = visualRead.strand == Strand.POSITIVE ? [
         [left, top],
@@ -175,7 +175,7 @@ class NonEmptyPileupTrack extends React.Component {
     var refLength = read.getReferenceLength();
     var range = read.getInterval();
     var reference = referenceSource.getRangeAsString({
-       contig: 'chr' + range.contig,  // XXX remove 'chr'--TwoBit should handle it
+       contig: range.contig,
        start: range.start(),
        stop: range.stop()
     });
@@ -203,7 +203,7 @@ class NonEmptyPileupTrack extends React.Component {
           read = vRead.read,
           range = read.getInterval(),
           reference = referenceSource.getRangeAsString({
-            contig: 'chr' + range.contig,
+            contig: range.contig,
             start: range.start(),
             stop: range.stop()
           });
@@ -245,7 +245,7 @@ class NonEmptyPileupTrack extends React.Component {
 
     readsG.append('path');  // the alignment arrow
     var mismatchTexts = reads.selectAll('text.basepair')
-        .data(vRead => vRead.mismatches, m => m.position + m.basePair);
+        .data(vRead => vRead.mismatches, m => m.pos + m.basePair);
     
     mismatchTexts
         .enter()

--- a/src/Root.js
+++ b/src/Root.js
@@ -34,8 +34,10 @@ var Root = React.createClass({
       });
     });
 
-    referenceSource.on('contigs', () => {
-      this.handleRangeChange(this.props.initialRange);
+    referenceSource.once('contigs', () => {
+      if (!this.state.range) {
+        this.handleRangeChange(this.props.initialRange);
+      }
     });
   },
   handleRangeChange: function(newRange: GenomeRange) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -138,7 +138,6 @@ function inflateGzip(buffer: ArrayBuffer): ArrayBuffer {
   return concatArrayBuffers(inflateConcatenatedGzip(buffer).map(x => x.buffer));
 }
 
-
 /**
  * Generate a space-separated css class name for a base pair.
  */
@@ -147,11 +146,21 @@ function basePairClass(basePair: ?string): string {
   return 'basepair ' + basePair;
 }
 
+// Given 'chr9', return '9'. Given '9', return 'chr9'.
+function altContigName(contig: string): string {
+  if (contig.slice(0, 3) == 'chr') {
+    return contig.slice(3);
+  } else {
+    return 'chr' + contig;
+  }
+}
+
 module.exports = {
   tupleLessOrEqual,
   tupleRangeOverlaps,
   concatArrayBuffers,
   inflateConcatenatedGzip,
   inflateGzip,
-  basePairClass
+  basePairClass,
+  altContigName
 };

--- a/test/PileupTrack-test.js
+++ b/test/PileupTrack-test.js
@@ -144,6 +144,8 @@ describe('PileupTrack', function() {
       _.each(mismatches, mm => {
         expect(mm.textContent).to.equal('T');
       });
+      // Make sure there are no variants in the previous column, just the reference.
+      expect(testDiv.querySelectorAll('text[x^="387"]').length).to.equal(1);
     };
 
   it('should indicate mismatches when the reference loads first', function() {
@@ -160,7 +162,7 @@ describe('PileupTrack', function() {
       // Some number of mismatches are expected, but it should be dramatically
       // lower than the number of total base pairs in alignments.
       var mismatches = testDiv.querySelectorAll('.pileup .alignment .basepair');
-      expect(mismatches).to.have.length.below(20);
+      expect(mismatches).to.have.length.below(40);
       assertHasColumnOfTs();
     });
   });
@@ -178,7 +180,7 @@ describe('PileupTrack', function() {
       return waitFor(hasReference, 2000);
     }).then(() => {
       var mismatches = testDiv.querySelectorAll('.pileup .alignment .basepair');
-      expect(mismatches).to.have.length.below(20);
+      expect(mismatches).to.have.length.below(40);
       assertHasColumnOfTs();
     });
   });

--- a/test/TwoBit-test.js
+++ b/test/TwoBit-test.js
@@ -40,5 +40,13 @@ describe('TwoBit', function() {
           });
   });
 
+  it('should add chr', function() {
+    var twoBit = getTestTwoBit();
+    return twoBit.getFeaturesInRange('22', 0, 4)  // 22, not chr22
+        .then(basePairs => {
+          expect(basePairs).to.equal('NTCAC');
+        });
+  });
+
   // TODO: masked regions
 });

--- a/test/TwoBitDataSource-test.js
+++ b/test/TwoBitDataSource-test.js
@@ -101,4 +101,40 @@ describe('TwoBitDataSource', function() {
       source.rangeChanged({contig: 'chr22', start: 5, stop: 10});
     }).done();
   });
+
+  it('should add chr', function(done) {
+    var source = getTestSource();
+    var range = {contig: '22', start: 0, stop: 3};
+
+    source.on('newdata', () => {
+      expect(source.getRange(range)).to.deep.equal({
+        '22:0': 'N',
+        '22:1': 'T',
+        '22:2': 'C',
+        '22:3': 'A'
+      });
+      expect(source.getRangeAsString(range)).to.equal('NTCA');
+      done();
+    });
+    source.rangeChanged(range);
+  });
+
+  it('should allow a mix of chr and non-chr', function(done) {
+    var source = getTestSource();
+    var chrRange = {contig: 'chr22', start: 0, stop: 3},
+        range = {contig: '22', start: 0, stop: 3};
+
+    source.on('newdata', () => {
+      expect(source.getRange(range)).to.deep.equal({
+        '22:0': 'N',
+        '22:1': 'T',
+        '22:2': 'C',
+        '22:3': 'A'
+      });
+      expect(source.getRangeAsString(range)).to.equal('NTCA');
+      done();
+    });
+    source.needContigs();
+    source.rangeChanged(chrRange);
+  });
 });

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -112,4 +112,11 @@ describe('utils', function() {
     expect(inflated).to.have.length(1);
     expect(bufferToText(inflated[0].buffer)).to.equal('Hello World');
   });
+
+  it('should add or remove chr from contig names', function() {
+    expect(utils.altContigName('21')).to.equal('chr21');
+    expect(utils.altContigName('chr21')).to.equal('21');
+    expect(utils.altContigName('M')).to.equal('chrM');
+    expect(utils.altContigName('chrM')).to.equal('M');
+  });
 });


### PR DESCRIPTION
- Sneaky `pos` vs. `position` error in the D3 key that was causing chaos.
- Ignore `initialRange` if `setRange` has already been called.
- Tolerate chr prefix mismatches between `rangeChanged` and `getRange` in `TwoBitDataSource`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/144)
<!-- Reviewable:end -->
