### PR TITLE
Pin grunt-browserify version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "arraybuffer-slice": "^0.1.2",
     "chai": "^2.0.0",
-    "coveralls": "^2.11.2",
+    "coveralls": "2.10.x",
     "es5-shim": "^4.1.0",
     "flow-bin": "^0.11.0",
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pileup",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "JavaScript track viewer",
   "main": "build/pileup.js",
   "browser": "build/pileup.js",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "es5-shim": "^4.1.0",
     "flow-bin": "^0.11.0",
     "grunt": "^0.4.5",
-    "grunt-browserify": "^3.3.0",
+    "grunt-browserify": "3.7.0",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-uglify": "^0.8.0",
     "grunt-env": "^0.4.2",

--- a/scripts/post-coverage.sh
+++ b/scripts/post-coverage.sh
@@ -5,6 +5,12 @@ set -x
 # Generate LCOV data for the bundled tests
 grunt coverage
 
+
+# dump it out temporarily for debugging
+./scripts/transform-coverage.js \
+  build/tests.map \
+  build/bundled.lcov
+
 # Convert code coverage data on the bundled test file back to the originals.
 ./scripts/transform-coverage.js \
   build/tests.map \


### PR DESCRIPTION
See #151 

This is a workaround until `grunt-exorcist` updates its `exorcist` dep.
It also works around https://github.com/cainus/node-coveralls/issues/80

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/152)
<!-- Reviewable:end -->
