### PR TITLE
Production fails due to missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-tools": "^0.13.1",
     "reactify": "danvk/reactify",
     "sinon": "^1.12.2",
-    "source-map": "^0.3.0"
+    "source-map": "^0.3.0",
+    "watchify": "^3.2.1"
   }
 }


### PR DESCRIPTION
The production task was failing due to missing module, watchify:

```
$ grunt prod
Loading "browserify.js" tasks...ERROR
>> Error: Cannot find module 'watchify'
Warning: Task "browserify:dist" not found. Use --force to continue.

Aborted due to warnings.
```

Added watchify `^3.2.1` to the devDependencies to resolve this problem.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/162)
<!-- Reviewable:end -->
