### PR TITLE
URL in the README now points to the hammerlab repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Interactive in-browser track viewer
 
 ## Quickstart
 
-    git clone https://github.com/danvk/pileup.js.git
+    git clone https://github.com/hammerlab/pileup.js.git
     cd pileup.js
     npm install
     grunt prod


### PR DESCRIPTION
A quick fix to the URL in the README file to point to the right repository.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/164)
<!-- Reviewable:end -->
