### PR TITLE
License identifier is now a valid SPDX expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "grunt test"
   },
   "author": "Dan Vanderkam",
-  "license": "Apache2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/hammerlab/pileup.js/issues"
   },


### PR DESCRIPTION
When installing the package, NPM was complaining about the license:

```
$ npm install
npm WARN package.json pileup@0.1.0 license should be a valid SPDX license expression
```

Changed the license description to `Apache-2.0`, for SPDX compatibility.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/174)
<!-- Reviewable:end -->
