### PR TITLE
Allow browserification via the standalone tool

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,9 @@
 'use strict';
 
 module.exports = function(grunt) {
+  // We read package.json to access shared settings
+  var packageSettings = grunt.file.readJSON('package.json');
+
   grunt.initConfig({
     flow: {
       app: {
@@ -37,17 +40,8 @@ module.exports = function(grunt) {
       },
       options: {
         require: ['./src/pileup.js:pileup'],
-        transform: [
-          [
-            "jstransformify",
-            {
-              react: true,
-              harmony: true,
-              stripTypes: true,
-              nonStrictEs6module: true
-            }
-          ]
-        ],
+        // read shared transformation options from package.json
+        transform: packageSettings.browserify.transform,
         browserifyOptions: {
           debug: true  // generate a source map
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pileup",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "JavaScript track viewer",
   "keywords": [
     "genome",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,20 @@
     "biojs"
   ],
   "main": "build/pileup.js",
-  "browser": "build/pileup.js",
+  "browser": "src/pileup.js",
+  "browserify": {
+    "transform": [
+      [
+        "jstransformify", 
+        {
+          "react": true,
+          "harmony": true,
+          "stripTypes": true,
+          "nonStrictEs6module": true
+        } 
+      ]
+    ]
+  },
   "files": [
     "build",
     "src",


### PR DESCRIPTION
The earlier configuration in `package.json` was confusing  [node-browserify](https://github.com/substack/node-browserify), forcing it to re-browserify `build/pileup.js` and therefore causing it to fail. As an example, see the output of [this browserify request](https://wzrd.in/bundle/pileup@0.1.2) for our version `v0.1.2`:

```
---FLAGRANT SYSTEM ERROR---

(logs uuid: 48fd78d0-1074-11e5-8345-05735e43db5c )

Error: "browserify exited with code 1"

code: 1
stderr: Error: Cannot find module './lib/utils/common' from '/tmp/pileup115511-14891-13ix8yo/node_modules/pileup/build'
    at /home/admin/browserify-cdn/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:42:25
    at load (/home/admin/browserify-cdn/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:60:43)
    at /home/admin/browserify-cdn/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:66:22
    at /home/admin/browserify-cdn/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:21:47
    at Object.oncomplete (fs.js:107:15)

dirPath: /tmp/pileup115511-14891-13ix8yo

This is probably an issue with the package, and not browserify-cdn itself.
If you feel differently, feel free to file a bug report at:

    https://github.com/jfhbrook/browserify-cdn/issues

Include the ENTIRETY of the contents of this message, and the maintainer(s)
can try to help you out.

Have a nice day!
```

This error was manifesting itself within the demo on the [BioJS repository](http://workmen.biojs.net/demo/pileup/playground) through the [wzrd.in service](https://wzrd.in/) . I was able to track this problem down and found that `browser` field in our `package.json` was the reason for this particular error. This can also be replicated locally:

```
$ npm install pileup@0.1.2
pileup@0.1.2 node_modules/pileup
├── shallow-equals@0.0.0
├── jdataview@2.5.0
├── underscore@1.8.3
├── q@1.4.1
├── backbone@1.1.2
├── pako@0.2.7
├── jbinary@2.1.3 (es6-promise@2.3.0, request@2.57.0)
├── d3@3.5.5
└── react@0.13.3 (envify@3.4.0)

$ browserify node_modules/pileup
Error: Cannot find module './lib/utils/common' from '/Users/aksoyb/Desktop/npm/node_modules/pileup/build'
    at /usr/local/lib/node_modules/browserify/node_modules/resolve/lib/async.js:55:21
    at load (/usr/local/lib/node_modules/browserify/node_modules/resolve/lib/async.js:69:43)
    at onex (/usr/local/lib/node_modules/browserify/node_modules/resolve/lib/async.js:92:31)
    at /usr/local/lib/node_modules/browserify/node_modules/resolve/lib/async.js:22:47
    at FSReqWrap.oncomplete (fs.js:95:15)
```

These changes fix the package metadata and allow browserification via the standalone [node-browserify](https://github.com/substack/node-browserify) tool.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/175)
<!-- Reviewable:end -->
