### PR TITLE
Add a demo using BioDalliance

### DIFF
--- a/examples/dalliance.html
+++ b/examples/dalliance.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html>
+
+<head>
+<style>
+.holder-holder {
+  position: absolute;
+  top: 40px;
+  left: 20px;
+  right: 20px;
+  bottom: 0;
+}
+#svgHolder {
+  width: 100%;
+  height: 100%;
+}
+</style>
+</head>
+
+<body>
+
+<p>This mirrors the <a href="playground-complete.html">pileup demo</a>, but
+uses <a href="http://www.biodalliance.org/">biodalliance</a> instead.</p>
+
+<div class="holder-holder">
+  <div id="svgHolder"></div>
+</div>
+
+<script src="//www.biodalliance.org/release-0.13/dalliance-compiled.js"></script>
+
+</body>
+
+<script>
+
+// Style for visualizing BAM reads.
+var bamStyle = [
+  {
+    "zoom": "low",
+    "style": {
+      "glyph": "__NONE",
+    }
+  },
+  {
+    "zoom": "medium",
+    "style": {
+      "glyph": "__NONE",
+    },
+  },
+  {
+    "type": "bam",
+    "zoom": "high",
+    "style": {
+      "glyph": "__SEQUENCE",
+      "_minusColor": "lightgray",
+      "_plusColor": "lightgray",
+      "HEIGHT": 8,
+      "BUMP": true,
+      "LABEL": false,
+      "ZINDEX": 20,
+      "__INSERTIONS": "no",
+      "__SEQCOLOR": "mismatch"  // "mismatch-all" will label all bases
+    },
+    "_typeRE": {},
+    "_labelRE": {},
+    "_methodRE": {}
+  }
+];
+
+  var sources = [
+    {
+      name: 'Genome',
+      twoBitURI: 'http://www.biodalliance.org/datasets/hg19.2bit',
+      tier_type: 'sequence'
+    },
+    {
+      name: 'Variants',
+      tier_type: 'memstore',
+      payload: 'vcf',
+      uri: '/test/data/snv.chr17.vcf'
+    },
+    {
+      name: 'Genes',
+      desc: 'Gene structures from GENCODE 19',
+      bwgURI: '//www.biodalliance.org/datasets/gencode.bb',
+      stylesheet_uri: '//www.biodalliance.org/stylesheets/gencode.xml',
+      collapseSuperGroups: true,
+      trixURI: '//www.biodalliance.org/datasets/geneIndex.ix'
+    },
+    {
+      name: 'Normal',
+      bamURI: '/test/data/synth3.normal.17.7500000-7515000.bam',
+      tier_type: 'bam',
+      style: bamStyle
+    }
+  ];
+
+
+  new Browser({
+    chr:          'chr17',
+    viewStart:    7512384,
+    viewEnd:      7512544,
+    cookieKey:    'human',
+
+    coordSystem: {
+      speciesName: 'Human',
+      taxon: 9606,
+      auth: 'NCBI',
+      version: '36',
+      ucscName: 'hg18'
+    },
+
+    uiPrefix: '//www.biodalliance.org/release-0.13/',
+    setDocumentTitle: false,
+    disablePoweredBy: true,
+    noTitle: true,
+
+    sources: sources
+  });
+</script>
+
+</html>


### PR DESCRIPTION
Now that we're using pileup.js on Cycledash, we don't have a reference for how dalliance renders BAM tracks. This adds one for comparison.

cc @jaclynperrone

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/178)
<!-- Reviewable:end -->
