### PR TITLE
Correct the way we require 'pileup' in tests

### DIFF
--- a/test/GenomeTrack-test.js
+++ b/test/GenomeTrack-test.js
@@ -11,7 +11,7 @@ var expect = require('chai').expect;
 
 var React = require('../src/react-shim');
 
-var pileup = require('../src/pileup'),
+var pileup = require('pileup'),
     TwoBit = require('../src/TwoBit'),
     TwoBitDataSource = require('../src/TwoBitDataSource'),
     MappedRemoteFile = require('./MappedRemoteFile'),

--- a/test/PileupTrack-test.js
+++ b/test/PileupTrack-test.js
@@ -13,7 +13,7 @@ var Q = require('q'),
 
 import type * as SamRead from '../src/SamRead';
 
-var pileup = require('../src/pileup'),
+var pileup = require('pileup'),
     TwoBit = require('../src/TwoBit'),
     TwoBitDataSource = require('../src/TwoBitDataSource'),
     Bam = require('../src/bam'),

--- a/test/components-test.js
+++ b/test/components-test.js
@@ -3,7 +3,7 @@
 
 var expect = require('chai').expect;
 
-var pileup = require('../src/pileup'),
+var pileup = require('pileup'),
     {waitFor} = require('./async');
 
 


### PR DESCRIPTION
A problem with the `watchify` was causing all relative requires turn into requires with full paths when initiated with `{ watch: true }` option; but due to our recent changes, the correct way to require our main module is now `require('pileup')`.

More info:
- https://github.com/jmreidy/grunt-browserify/issues/245
- https://github.com/jmreidy/grunt-browserify/issues/197

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/191)
<!-- Reviewable:end -->
