### PR TITLE
Add track names

### DIFF
--- a/examples/playground-complete.html
+++ b/examples/playground-complete.html
@@ -3,7 +3,11 @@
 <link rel="stylesheet" href="../style/pileup.css" />
 <style>
 #yourDiv {
-  width: 100%;
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  top: 10px;
+  bottom: 10px;
 }
 </style>
 </head>

--- a/examples/playground.js
+++ b/examples/playground.js
@@ -6,19 +6,22 @@ var sources = [
     isReference: true,
     data: pileup.formats.twoBit({
       url: 'http://www.biodalliance.org/datasets/hg19.2bit'
-    })
+    }),
+    name: 'Reference'
   },
   {
     viz: pileup.viz.variants(),
     data: pileup.formats.vcf({
       url: '/test/data/snv.chr17.vcf'
-    })
+    }),
+    name: 'Variants'
   },
   {
     viz: pileup.viz.genes(),
     data: pileup.formats.bigBed({
       url: 'http://www.biodalliance.org/datasets/ensGene.bb'
-    })
+    }),
+    name: 'Genes'
   },
   {
     viz: pileup.viz.pileup(),
@@ -26,7 +29,8 @@ var sources = [
       url: '/test/data/synth3.normal.17.7500000-7515000.bam',
       indexUrl: '/test/data/synth3.normal.17.7500000-7515000.bam.bai'
     }),
-    cssClass: 'normal'
+    cssClass: 'normal',
+    name: 'Alignments'
   }
 ];
 

--- a/src/Controls.js
+++ b/src/Controls.js
@@ -69,15 +69,14 @@ var Controls = React.createClass({
     // Note: input values are set in componentDidUpdate.
     return (
       <form className='controls' onSubmit={this.handleFormSubmit}>
-        Contig:
         <select ref='contig' onChange={this.handleContigChange}>
           {contigOptions}
-        </select>
-        <input ref='start' type='text' />
-        <input ref='stop' type='text' />
-        <button>Go</button>
+        </select>{' '}
+        <input ref='start' type='text' />–
+        <input ref='stop' type='text' />{' '}
+        <button>Go</button>{' '}
 
-        <button onClick={this.zoomOut}>-</button>
+        <button onClick={this.zoomOut}>-</button>{' '}
         <button onClick={this.zoomIn}>+</button>
       </form>
     );

--- a/src/GeneTrack.js
+++ b/src/GeneTrack.js
@@ -14,6 +14,7 @@ var React = require('./react-shim'),
     ContigInterval = require('./ContigInterval');
 
 var GeneTrack = React.createClass({
+  displayName: 'genes',
   propTypes: {
     range: types.GenomeRange,
     source: React.PropTypes.object.isRequired,
@@ -65,14 +66,13 @@ var NonEmptyGeneTrack = React.createClass({
     };
   },
   render: function() {
-    var className = ['genes', this.props.cssClass || ''].join(' ');
-    return <div className={className}></div>;
+    return <div></div>;
   },
   updateSize: function() {
-    var div = this.getDOMNode();
+    var parentDiv = this.getDOMNode().parentNode;
     this.setState({
-      width: div.offsetWidth,
-      height: div.offsetHeight
+      width: parentDiv.offsetWidth,
+      height: parentDiv.offsetHeight
     });
   },
   componentDidMount: function() {

--- a/src/GeneTrack.js
+++ b/src/GeneTrack.js
@@ -19,7 +19,6 @@ var GeneTrack = React.createClass({
     range: types.GenomeRange,
     source: React.PropTypes.object.isRequired,
     onRangeChange: React.PropTypes.func.isRequired,
-    cssClass: React.PropTypes.string
   },
   render: function(): any {
     var range = this.props.range;
@@ -56,7 +55,6 @@ var NonEmptyGeneTrack = React.createClass({
     range: types.GenomeRange.isRequired,
     source: React.PropTypes.object.isRequired,
     onRangeChange: React.PropTypes.func.isRequired,
-    cssClass: React.PropTypes.string
   },
   getInitialState: function() {
     return {

--- a/src/GenomeTrack.js
+++ b/src/GenomeTrack.js
@@ -18,7 +18,6 @@ var GenomeTrack = React.createClass({
     range: types.GenomeRange,
     source: React.PropTypes.object.isRequired,
     onRangeChange: React.PropTypes.func.isRequired,
-    cssClass: React.PropTypes.string
   },
   render: function(): any {
     var range = this.props.range;
@@ -46,7 +45,6 @@ var NonEmptyGenomeTrack = React.createClass({
     range: types.GenomeRange.isRequired,
     source: React.PropTypes.object.isRequired,
     onRangeChange: React.PropTypes.func.isRequired,
-    cssClass: React.PropTypes.string
   },
   getInitialState: function() {
     return {

--- a/src/GenomeTrack.js
+++ b/src/GenomeTrack.js
@@ -13,6 +13,7 @@ var React = require('./react-shim'),
 
 
 var GenomeTrack = React.createClass({
+  displayName: 'reference',
   propTypes: {
     range: types.GenomeRange,
     source: React.PropTypes.object.isRequired,
@@ -55,14 +56,13 @@ var NonEmptyGenomeTrack = React.createClass({
     };
   },
   render: function(): any {
-    var className = ['reference', this.props.cssClass || ''].join(' ');
-    return <div className={className}></div>;
+    return <div></div>;
   },
   updateSize: function() {
-    var div = this.getDOMNode();
+    var parentDiv = this.getDOMNode().parentNode;
     this.setState({
-      width: div.offsetWidth,
-      height: div.offsetHeight
+      width: parentDiv.offsetWidth,
+      height: parentDiv.offsetHeight
     });
   },
   componentDidMount: function() {

--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -21,8 +21,7 @@ var PileupTrack = React.createClass({
     range: types.GenomeRange,
     onRangeChange: React.PropTypes.func.isRequired,
     source: React.PropTypes.object.isRequired,
-    referenceSource: React.PropTypes.object.isRequired,
-    cssClass: React.PropTypes.string
+    referenceSource: React.PropTypes.object.isRequired
   },
   render: function(): any {
     var range = this.props.range;
@@ -361,8 +360,7 @@ NonEmptyPileupTrack.propTypes = {
   range: types.GenomeRange.isRequired,
   source: React.PropTypes.object.isRequired,
   referenceSource: React.PropTypes.object.isRequired,
-  onRangeChange: React.PropTypes.func.isRequired,
-  cssClass: React.PropTypes.string
+  onRangeChange: React.PropTypes.func.isRequired
 };
 
 

--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -187,8 +187,6 @@ class NonEmptyPileupTrack extends React.Component {
     // as though it doesn't, since adjusting the scale would put it out of sync
     // with other tracks.
     var containerStyles = {
-      'overflowY': 'auto',
-      'overflowX': 'hidden',
       'height': '100%'
     };
     return (

--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -16,6 +16,7 @@ var React = require('./react-shim'),
     ContigInterval = require('./ContigInterval');
 
 var PileupTrack = React.createClass({
+  displayName: 'pileup',
   propTypes: {
     range: types.GenomeRange,
     onRangeChange: React.PropTypes.func.isRequired,
@@ -181,7 +182,6 @@ class NonEmptyPileupTrack extends React.Component {
   }
 
   render(): any {
-    var className = ['pileup', this.props.cssClass || ''].join(' ');
     // These styles allow vertical scrolling to see the full pileup.
     // Adding a vertical scrollbar shrinks the visible area, but we have to act
     // as though it doesn't, since adjusting the scale would put it out of sync
@@ -189,18 +189,19 @@ class NonEmptyPileupTrack extends React.Component {
     var containerStyles = {
       'height': '100%'
     };
+    // TODO: are the nested divs necessary?
     return (
-      <div className={className}>
+      <div>
         <div ref='container' style={containerStyles}></div>
       </div>
     );
   }
 
   updateSize() {
-    var div = this.refs.container.getDOMNode();
+    var parentDiv = this.refs.container.getDOMNode().parentNode;
     this.setState({
-      width: div.offsetWidth,
-      height: div.offsetHeight
+      width: parentDiv.offsetWidth,
+      height: parentDiv.offsetHeight
     });
   }
 

--- a/src/Root.js
+++ b/src/Root.js
@@ -62,7 +62,7 @@ var Root = React.createClass({
     return (
       <div key={key} className={className}>
         <div className='track-label'>
-          {track.track.name || '(track name)'}
+          <span>{track.track.name || '(track name)'}</span>
         </div>
         <div className='track-content'>
           {trackEl}
@@ -74,10 +74,17 @@ var Root = React.createClass({
     // TODO: use a better key than index.
     var trackEls = this.props.tracks.map((t, i) => this.makeDivForTrack(''+i, t));
     return (
-      <div className="pileup-root">
-        <Controls contigList={this.state.contigList}
-                  range={this.state.range}
-                  onChange={this.handleRangeChange} />
+      <div className='pileup-root'>
+        <div className='track controls'>
+          <div className='track-label'>
+            &nbsp;
+          </div>
+          <div className='track-content'>
+            <Controls contigList={this.state.contigList}
+                      range={this.state.range}
+                      onChange={this.handleRangeChange} />
+          </div>
+        </div>
         {trackEls}
       </div>
     );

--- a/src/Root.js
+++ b/src/Root.js
@@ -49,19 +49,30 @@ var Root = React.createClass({
       });
     });
   },
-  makeReactElementFromTrack(key: string, track: VisualizedTrack): React.Element {
-    return React.createElement(track.visualization, {
-      key,
+  makeDivForTrack(key: string, track: VisualizedTrack): React.Element {
+    var trackEl = React.createElement(track.visualization, {
       range: this.state.range,
       onRangeChange: this.handleRangeChange,
       source: track.source,
-      referenceSource: this.props.referenceSource,
-      cssClass: track.track.cssClass,
+      referenceSource: this.props.referenceSource
     });
+
+    var className = ['track', track.visualization.displayName || '', track.track.cssClass || ''].join(' ');
+
+    return (
+      <div key={key} className={className}>
+        <div className='track-label'>
+          {track.track.name || '(track name)'}
+        </div>
+        <div className='track-content'>
+          {trackEl}
+        </div>
+      </div>
+    );
   },
   render: function(): any {
     // TODO: use a better key than index.
-    var trackEls = this.props.tracks.map((t, i) => this.makeReactElementFromTrack(''+i, t));
+    var trackEls = this.props.tracks.map((t, i) => this.makeDivForTrack(''+i, t));
     return (
       <div className="pileup-root">
         <Controls contigList={this.state.contigList}

--- a/src/Root.js
+++ b/src/Root.js
@@ -63,7 +63,7 @@ var Root = React.createClass({
     // TODO: use a better key than index.
     var trackEls = this.props.tracks.map((t, i) => this.makeReactElementFromTrack(''+i, t));
     return (
-      <div>
+      <div className="pileup-root">
         <Controls contigList={this.state.contigList}
                   range={this.state.range}
                   onChange={this.handleRangeChange} />

--- a/src/VariantTrack.js
+++ b/src/VariantTrack.js
@@ -35,8 +35,7 @@ var VariantTrack = React.createClass({
   propTypes: {
     range: types.GenomeRange,
     onRangeChange: React.PropTypes.func.isRequired,
-    source: React.PropTypes.object.isRequired,
-    cssClass: React.PropTypes.string
+    source: React.PropTypes.object.isRequired
   },
   render: function(): any {
     var range = this.props.range;
@@ -56,8 +55,7 @@ var NonEmptyVariantTrack = React.createClass({
   propTypes: {
     range: types.GenomeRange.isRequired,
     source: React.PropTypes.object.isRequired,
-    onRangeChange: React.PropTypes.func.isRequired,
-    cssClass: React.PropTypes.string
+    onRangeChange: React.PropTypes.func.isRequired
   },
   getInitialState: function() {
     return {

--- a/src/VariantTrack.js
+++ b/src/VariantTrack.js
@@ -31,6 +31,7 @@ type VcfDataSource = {
 };
 
 var VariantTrack = React.createClass({
+  displayName: 'variants',
   propTypes: {
     range: types.GenomeRange,
     onRangeChange: React.PropTypes.func.isRequired,
@@ -65,17 +66,16 @@ var NonEmptyVariantTrack = React.createClass({
     };
   },
   render: function(): any {
-    var className = ['variants', this.props.cssClass || ''].join(' ');
-    return <div className={className}></div>;
+    return <div></div>;
   },
   getVariantSource(): VcfDataSource {
     return this.props.source;
   },
   updateSize: function() {
-    var div = this.getDOMNode();
+    var parentDiv = this.getDOMNode().parentNode;
     this.setState({
-      width: div.offsetWidth,
-      height: div.offsetHeight
+      width: parentDiv.offsetWidth,
+      height: parentDiv.offsetHeight
     });
   },
   componentDidMount: function() {

--- a/src/types.js
+++ b/src/types.js
@@ -10,6 +10,7 @@ export type Track = {
   viz: Object;  // for now, a React class
   data: Object;  // This is a DataSource object
   cssClass?: string;
+  name: string;
 }
 
 export type VisualizedTrack = {

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -86,6 +86,7 @@
   stroke: blue;
 }
 .gene text {
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 16px;
   text-anchor: middle;
   stroke: black;

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -16,6 +16,21 @@
 }
 .track-label {
   flex: 0 0 100px;  /* fixed-width track labels */
+  text-align: right;
+  font-family: Helvetica Neue, Helvetica, Arial, sans;
+  font-size: 0.9em;
+  position: relative;  /* make this an offset parent for positioning the label. */
+}
+.track-label > span {
+  padding-right: 5px;
+}
+/* bottom-justify these track labels */
+.track.reference .track-label > span,
+.track.variants .track-label > span
+{
+  position: absolute;
+  bottom: 0;
+  right: 0;
 }
 .track-content {
   flex: 1;  /* stretch to fill remaining space */
@@ -24,11 +39,12 @@
 /* controls */
 .pileup-root > .controls {
   flex: 0 0 30px;  /* fixed height */
+  margin-bottom: 0;  /* overrides browser default */
 }
 
 /* reference track */
 .pileup-root > .reference {
-  flex: 0 0 50px;  /* fixed height */
+  flex: 0 0 20px;  /* fixed height */
 }
 
 .background {
@@ -44,7 +60,7 @@
   text-anchor: middle;
 }
 .pair.loose text {
-  font-size: 28;
+  font-size: 24;
 }
 .pair.tight text {
   font-size: 12;

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -17,7 +17,7 @@
 .track-label {
   flex: 0 0 100px;  /* fixed-width track labels */
   text-align: right;
-  font-family: Helvetica Neue, Helvetica, Arial, sans;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 0.9em;
   position: relative;  /* make this an offset parent for positioning the label. */
 }
@@ -56,7 +56,7 @@
 .basepair.T, .basepair .T { fill: #F70016; }
 .basepair.U, .basepair .U { fill: #F70016; }
 .basepair text, text.basepair {
-  font-family: Helvetica Neue, Helvetica, Arial, sans;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   text-anchor: middle;
 }
 .pair.loose text {

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -4,11 +4,20 @@
  * You are encouraged to override anything you like.
  */
 
+.pileup-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 /* controls */
+.pileup-root > .controls {
+  flex: 0 0 30px;  /* fixed height */
+}
 
 /* reference track */
-.reference {
-  height: 50px;
+.pileup-root > .reference {
+  flex: 0 0 50px;  /* fixed height */
 }
 
 .background {
@@ -42,8 +51,8 @@
 }
 
 /* gene track */
-.genes {
-  height: 50px;
+.pileup-root > .genes {
+  flex: 0 0 50px;
 }
 .gene {
   stroke-width: 1;
@@ -71,8 +80,9 @@
 }
 
 /* pileup track */
-.pileup {
-  height: 300px;
+.pileup-root > .pileup {
+  flex: 1;  /* stretch to fill remaining space */
+  overflow-y: auto;
 }
 .pileup .alignment .match {
   fill: #c8c8c8;  /* matches IGV */
@@ -92,8 +102,8 @@
 }
 
 /* variants */
-.variants {
-  height: 25px;
+.pileup-root > .variants {
+  flex: 0 0 25px;  /* fixed height */
 }
 .variants rect {
   fill: #ddd;

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -10,6 +10,17 @@
   height: 100%;
 }
 
+.pileup-root > .track {
+  display: flex;
+  flex-direction: row;
+}
+.track-label {
+  flex: 0 0 100px;  /* fixed-width track labels */
+}
+.track-content {
+  flex: 1;  /* stretch to fill remaining space */
+}
+
 /* controls */
 .pileup-root > .controls {
   flex: 0 0 30px;  /* fixed height */

--- a/test/components-test.js
+++ b/test/components-test.js
@@ -78,10 +78,10 @@ describe('pileup', function() {
         // Note: there are 11 exons, but two are split into coding/non-coding
         expect(div.querySelectorAll('.gene .exon').length).to.equal(13);
 
-        expect(div.querySelector('div > .a').className).to.equal('reference a');
-        expect(div.querySelector('div > .b').className).to.equal('variants b');
-        expect(div.querySelector('div > .c').className).to.equal('genes c');
-        expect(div.querySelector('div > .d').className).to.equal('pileup d');
+        expect(div.querySelector('div > .a').className).to.equal('track reference a');
+        expect(div.querySelector('div > .b').className).to.equal('track variants b');
+        expect(div.querySelector('div > .c').className).to.equal('track genes c');
+        expect(div.querySelector('div > .d').className).to.equal('track pileup d');
 
         expect(p.getRange()).to.deep.equal({
           contig: 'chr17',


### PR DESCRIPTION
Here's what it looks like:

![screen shot 2015-06-16 at 2 39 15 pm](https://cloud.githubusercontent.com/assets/98301/8191422/f7de8974-1435-11e5-8106-56130e3c6973.png)

This reworks `pileup.css` to use flexbox, which worked very well in Cycledash. You can see the shell of the layout in [this codepen][1].

@jaclynperrone any design feedback would be much appreciated here!

Fixes #129 

[1]: http://codepen.io/anon/pen/VLzbBe?editors=110

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/195)
<!-- Reviewable:end -->
