### PR TITLE
Switch to mainstream jstransformify

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   "browserify": {
     "transform": [
       [
-        "jstransformify", 
+        "jstransformify",
         {
           "react": true,
           "harmony": true,
           "stripTypes": true,
           "nonStrictEs6module": true
-        } 
+        }
       ]
     ]
   },
@@ -63,7 +63,7 @@
     "d3": "^3.5.5",
     "jbinary": "^2.1.3",
     "jdataview": "^2.5.0",
-    "jstransformify": "git://github.com/danvk/jstransformify.git",
+    "jstransformify": "^1.0.0",
     "pako": "^0.2.5",
     "q": "^1.1.2",
     "react": "^0.13.2",
@@ -100,8 +100,12 @@
     "watchify": "^3.2.1"
   },
   "sniper": {
-    "js": [ "/build/pileup.js" ],
-    "css": [ "style/pileup.css" ],
+    "js": [
+      "/build/pileup.js"
+    ],
+    "css": [
+      "style/pileup.css"
+    ],
     "first": "playground"
   }
 }


### PR DESCRIPTION
andreypopp merged [my PR][1], so we're safe to go back to the mainstream release.

[1]: https://github.com/andreypopp/jstransformify/pull/6

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/196)
<!-- Reviewable:end -->
