### PR TITLE
Strong flow on BigBed.js

### DIFF
--- a/src/BigBed.js
+++ b/src/BigBed.js
@@ -1,7 +1,7 @@
 /**
  * Parser for bigBed format.
  * Based on UCSC's src/inc/bbiFile.h
- * @flow weak
+ * @flow
  */
 'use strict';
 


### PR DESCRIPTION
I'm surprised that this works with no errors, but I'm not complaining.

This _used_ to fail, but maybe something changed over the last five or six flow releases.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/201)
<!-- Reviewable:end -->
