### PR TITLE
Reduce type definition duplication

### DIFF
--- a/src/BigBedDataSource.js
+++ b/src/BigBedDataSource.js
@@ -21,20 +21,6 @@ type Gene = {
   name: string;  // human-readable name, e.g. "TP53"
 }
 
-// TODO: move this into BigBed.js and get it to type check.
-type BedRow = {
-  // Half-open interval for the BED row.
-  contig: string;
-  start: number;
-  stop: number;
-  // Remaining fields in the BED row (typically tab-delimited)
-  rest: string;
-}
-type BedBlock = {
-  range: ContigInterval<string>;
-  rows: BedRow[];
-}
-
 // Flow type for export.
 type BigBedSource = {
   rangeChanged: (newRange: GenomeRange) => void;

--- a/src/bai.js
+++ b/src/bai.js
@@ -8,6 +8,7 @@
 
 import type * as RemoteFile from './RemoteFile';
 import type * as ContigInterval from './ContigInterval';
+import type {Chunk} from './types';
 
 var jBinary = require('jbinary'),
     jDataView = require('jdataview'),
@@ -64,11 +65,6 @@ function readIntervals(blob: Uint8Array) {
     intervals[pos >> 3] = VirtualOffset.fromBlob(blob, pos);
   }
   return intervals;
-}
-
-type Chunk = {
-  chunk_beg: VirtualOffset;
-  chunk_end: VirtualOffset;
 }
 
 function doChunksOverlap(a: Chunk, b: Chunk) {

--- a/src/bam.js
+++ b/src/bam.js
@@ -12,6 +12,8 @@ var jBinary = require('jbinary'),
     _ = require('underscore'),
     Q = require('q');
 
+import type {Chunk, InflatedBlock} from './types';
+
 var bamTypes = require('./formats/bamTypes'),
     utils = require('./utils'),
     BaiFile = require('./bai'),
@@ -36,19 +38,6 @@ function isAlignmentInRange(read: SamRead,
   }
 }
 
-
-// TODO: import from src/bai.js
-type Chunk = {
-  chunk_beg: VirtualOffset;
-  chunk_end: VirtualOffset;
-}
-
-// TODO: import from src/utils.js
-type InflatedBlock = {
-  offset: number;
-  compressedLength: number;
-  buffer: ArrayBuffer;
-}
 
 var kMaxFetch = 65536 * 2;
 

--- a/src/types.js
+++ b/src/types.js
@@ -1,8 +1,15 @@
 /**
  * Common types used in many modules.
+ *
+ * Flow makes it difficult for a module to export both symbols and types. This
+ * module serves as a dumping ground for types which we'd really like to export
+ * from other modules.
+ *
  * @flow
  */
 'use strict';
+
+// Public API
 
 import type * as React from 'react';
 
@@ -17,4 +24,21 @@ export type VisualizedTrack = {
   visualization: React.Component;
   source: Object;  // data source
   track: Track;  // for css class and options
+}
+
+
+// BAM/BAI parsing
+
+import type * as VirtualOffset from './VirtualOffset';
+
+export type Chunk = {
+  chunk_beg: VirtualOffset;
+  chunk_end: VirtualOffset;
+}
+
+// src/utils.js
+export type InflatedBlock = {
+  offset: number;
+  compressedLength: number;
+  buffer: ArrayBuffer;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@
  */
 'use strict';
 
+import type {InflatedBlock} from './types';
 var pako = require('pako');
 
 // Compare two tuples of equal length. Is t1 <= t2?
@@ -43,12 +44,6 @@ function concatArrayBuffers(buffers: ArrayBuffer[]): ArrayBuffer {
     position += buf.byteLength;
   });
   return output.buffer;
-}
-
-type InflatedBlock = {
-  offset: number;
-  compressedLength: number;
-  buffer: ArrayBuffer;
 }
 
 type InflateCacheKey = {


### PR DESCRIPTION
For now, types shared between modules can live in `types.js`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/202)
<!-- Reviewable:end -->
