### PR TITLE
Fire progress events for BAI fetching

### DIFF
--- a/src/PileupTrack.js
+++ b/src/PileupTrack.js
@@ -192,11 +192,10 @@ class NonEmptyPileupTrack extends React.Component {
     var statusEl = null,
         networkStatus = this.state.networkStatus;
     if (networkStatus) {
-      var numRequests = networkStatus.numRequests,
-          pluralS = numRequests > 1 ? 's' : '';
+      var message = this.formatStatus(networkStatus);
       statusEl = (
         <div ref='status' className='network-status'>
-          Loading alignments… (issued {numRequests} request{pluralS})
+          Loading alignments… ({message})
         </div>
       );
     }
@@ -207,6 +206,16 @@ class NonEmptyPileupTrack extends React.Component {
         <div ref='container' style={containerStyles}></div>
       </div>
     );
+  }
+
+  formatStatus(state): string {
+    if (state.numRequests) {
+      var pluralS = state.numRequests > 1 ? 's' : '';
+      return `issued ${state.numRequests} request${pluralS}`;
+    } else if (state.status) {
+      return state.status;
+    }
+    throw 'invalid';
   }
 
   updateSize() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,6 +5,8 @@
 'use strict';
 
 import type {InflatedBlock} from './types';
+import type * as Q from 'q';
+
 var pako = require('pako');
 
 // Compare two tuples of equal length. Is t1 <= t2?
@@ -150,6 +152,21 @@ function altContigName(contig: string): string {
   }
 }
 
+/**
+ * Pipe all promise events through a deferred object.
+ * This is similar to deferred.resolve(promise), except that it allows progress
+ * notifications from the promise to bubble through.
+ */
+function pipePromise<T>(deferred: Q.Deferred<T>, promise: Q.Promise<T>) {
+  promise.then(function(o) {
+    deferred.resolve(o);
+  }, function(e) {
+    deferred.reject(e);
+  }, function(e) {
+    deferred.notify(e);
+  });
+}
+
 module.exports = {
   tupleLessOrEqual,
   tupleRangeOverlaps,
@@ -157,5 +174,6 @@ module.exports = {
   inflateConcatenatedGzip,
   inflateGzip,
   basePairClass,
-  altContigName
+  altContigName,
+  pipePromise
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -158,13 +158,7 @@ function altContigName(contig: string): string {
  * notifications from the promise to bubble through.
  */
 function pipePromise<T>(deferred: Q.Deferred<T>, promise: Q.Promise<T>) {
-  promise.then(function(o) {
-    deferred.resolve(o);
-  }, function(e) {
-    deferred.reject(e);
-  }, function(e) {
-    deferred.notify(e);
-  });
+  promise.then(deferred.resolve, deferred.reject, deferred.notify);
 }
 
 module.exports = {

--- a/test/BamDataSource-test.js
+++ b/test/BamDataSource-test.js
@@ -79,6 +79,9 @@ describe('BamDataSource', function() {
       expect(readsAfter).to.have.length(12);
 
       expect(networkEvents).to.deep.equal([
+        // TODO: figure out why this notification is getting dropped.
+        // {'status': 'Fetching BAM header'},
+        {'status': 'Fetching BAM index'},
         {'numRequests': 1},
         {'numRequests': 2},
         {'numRequests': 3},

--- a/test/bam-test.js
+++ b/test/bam-test.js
@@ -230,6 +230,8 @@ describe('BAM', function() {
       progressEvents.push(event);
     }).then(reads => {
       expect(progressEvents).to.deep.equal([
+        {status: 'Fetching BAM header'},
+        {status: 'Fetching BAM index'},
         {numRequests: 1},
         {numRequests: 2},
         {numRequests: 3},


### PR DESCRIPTION
Fetching the BAI file can be a significant part of the load time for pileup tracks, especially if there are no index chunks available. This will give more immediate feedback to the user that activity is happening.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/203)
<!-- Reviewable:end -->
