### PR TITLE
Drop unused reactify dep

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,7 +2,6 @@
 .*node_modules/flow-bin.*
 .*node_modules/jsxhint.*
 .*node_modules/.*mocha.*
-.*node_modules/reactify.*
 .*node_modules/phantomjs.*
 .*pileup.js/dist.*
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "phantomjs": "^1.9.17",
     "prepush-hook": "^0.1.0",
     "react-tools": "^0.13.1",
-    "reactify": "danvk/reactify",
     "sinon": "^1.12.2",
     "sniper": "^0.2.16",
     "source-map": "^0.3.0",


### PR DESCRIPTION
At least I'm pretty sure it's unused!

This is our only remaining forked dependency.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/212)
<!-- Reviewable:end -->
