### PR TITLE
Development-specific tasks are not part of the default install task any more

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To style multiple tracks of the same type, you can use the `cssClass` property.
     git clone https://github.com/hammerlab/pileup.js.git
     cd pileup.js
     npm install
-    npm run prod
+    npm run build
 
 To play with the demo, start an [http-server][hs]:
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ To style multiple tracks of the same type, you can use the `cssClass` property.
     git clone https://github.com/hammerlab/pileup.js.git
     cd pileup.js
     npm install
+    npm run prod
 
 To play with the demo, start an [http-server][hs]:
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "flow-check": "flow check",
     "sniper": "biojs-sniper",
     "build": "npm run jstransform && npm run browserify-all && npm run uglify",
-    "install": "npm run build"
+    "prod": "npm run build"    
   },
   "author": "Dan Vanderkam",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "flow": "flow status",
     "flow-check": "flow check",
     "sniper": "biojs-sniper",
-    "build": "npm run jstransform && npm run browserify-all && npm run uglify",
-    "prod": "npm run build"    
+    "build": "npm run jstransform && npm run browserify-all && npm run uglify"
   },
   "author": "Dan Vanderkam",
   "contributors": [


### PR DESCRIPTION
With this, people have to

```
npm install
npm run build  # or npm run prod
```

for jstransform, browserify and uglify tasks.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/213)
<!-- Reviewable:end -->
