### PR TITLE
Run build before running test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,8 @@ language: node_js
 node_js:
   - "0.12"
 
-script: npm run test && npm run flow-check && npm run lint
+script: >
+    npm run build &&
+    npm run test &&
+    npm run flow-check &&
+    npm run lint


### PR DESCRIPTION
We're not actually running the tests on Travis right now. mocha-phantomjs just says "0/0 passed", which counts as success:

https://travis-ci.org/hammerlab/pileup.js/builds/69762743

This is one thing we lose by dropping Grunt -- we need to track dependencies between build steps in some other way.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/217)
<!-- Reviewable:end -->
