### PR TITLE
Generate coverage data using Istanbul

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ script: >
     npm run build &&
     npm run test &&
     npm run flow-check &&
-    npm run lint
+    npm run lint &&
+    npm run coverage &&
+    cat coverage/lcov.info | ./node_modules/.bin/coveralls

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test": "./scripts/test.sh",
     "flow": "flow status",
     "flow-check": "flow check",
+    "coverage": "./scripts/generate-coverage.sh",
     "sniper": "biojs-sniper",
     "publish": "./scripts/publish.sh",
     "build": "npm run jstransform && npm run browserify-all && npm run uglify"
@@ -78,6 +79,7 @@
     "es5-shim": "^4.1.0",
     "flow-bin": "^0.12.0",
     "http-server": "^0.8.0",
+    "istanbul": "^0.3.17",
     "jscoverage": "^0.5.9",
     "jstransform": "^11.0.2",
     "jstransformify": "^1.0.0",
@@ -86,6 +88,7 @@
     "mocha": "^2.1.0",
     "mocha-lcov-reporter": ">=0.0.2",
     "mocha-phantomjs": "^3.5.3",
+    "mocha-phantomjs-istanbul": "0.0.2",
     "parse-data-uri": "^0.2.0",
     "phantomjs": "^1.9.17",
     "prepush-hook": "^0.1.0",

--- a/scripts/generate-coverage.sh
+++ b/scripts/generate-coverage.sh
@@ -7,10 +7,9 @@ set -o errexit
 set -x
 
 # Instrument the source code with Istanbul's __coverage__ variable.
-# We clear out everything to ensure a hermetic run.
-rm -rf coverage/*
+rm -rf coverage/*  # Clear out everything to ensure a hermetic run.
 istanbul instrument --output coverage/main dist/main
-istanbul instrument --output coverage/test dist/test
+cp -r dist/test coverage/test  # test code needn't be covered
 
 # Build a combined file for running the tests in-browser
 browserify coverage/**/*.js -o coverage/tests.js
@@ -32,3 +31,6 @@ phantomjs \
 
 # Convert the JSON coverage to LCOV for coveralls.
 istanbul report --include coverage/*.json lcovonly
+
+# Monkey patch in the untransformed source paths.
+perl -i -pe 's,dist/main,src/main,' coverage/lcov.info

--- a/scripts/generate-coverage.sh
+++ b/scripts/generate-coverage.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Generate code coverage data for posting to Coveralls.
+# This requires dist/*.js to be in place.
+# Output is coverage/lcov.info
+
+set -o errexit
+set -x
+
+# Instrument the source code with Istanbul's __coverage__ variable.
+# We clear out everything to ensure a hermetic run.
+rm -rf coverage/*
+istanbul instrument --output coverage/main dist/main
+istanbul instrument --output coverage/test dist/test
+
+# Build a combined file for running the tests in-browser
+browserify coverage/**/*.js -o coverage/tests.js
+
+# Run http-server and save its PID for cleanup
+npm run http-server > /dev/null &
+SERVER_PID=$!
+function finish() {
+  pkill -TERM -P $SERVER_PID
+}
+trap finish EXIT
+
+# Run the tests using mocha-phantomjs & mocha-phantomjs-istanbul
+# This produces coverage/coverage.json
+phantomjs \
+  ./node_modules/mocha-phantomjs/lib/mocha-phantomjs.coffee \
+  http://localhost:8080/src/test/coverage.html \
+  spec '{"hooks": "mocha-phantomjs-istanbul", "coverageFile": "coverage/coverage.json"}'
+
+# Convert the JSON coverage to LCOV for coveralls.
+istanbul report --include coverage/*.json lcovonly

--- a/src/test/coverage.html
+++ b/src/test/coverage.html
@@ -17,7 +17,7 @@
   <!-- Mocha -->
   <script src="../../node_modules/mocha/mocha.js"></script>
   <script>mocha.setup('bdd')</script>
-  <script src="../../dist/cov/tests.js"></script>
+  <script src="../../coverage/tests.js"></script>
 
   <script>
     mocha.checkLeaks();


### PR DESCRIPTION
Istanbul instruments our source code with a coverage-tracking variable. This works great now that we have transformed files in `/dist`. I instrument each file individually and then browserify it to get accurate line numbers for coverage.

Fixes #209
Fixes #151
Closes #12 (that script is no longer needed)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/218)
<!-- Reviewable:end -->
