### PR TITLE
Add an FPS meter to playground-complete.html

### DIFF
--- a/examples/playground-complete.html
+++ b/examples/playground-complete.html
@@ -6,8 +6,13 @@
   position: absolute;
   left: 10px;
   right: 10px;
-  top: 10px;
+  top: 20px;
   bottom: 10px;
+}
+#stats {
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 </style>
 </head>
@@ -22,3 +27,22 @@
   window.yourDiv = document.getElementById("yourDiv");
 </script>
 <script src="./playground.js"></script>
+
+<!--
+Measure the frame rate. Chrome devtools can do this, but having the devtools
+open has a dramatic effect on frame rates.
+-->
+<script src="../node_modules/stats.js/build/stats.min.js"></script>
+<script>
+var stats = new Stats();
+stats.setMode(0); // 0: fps, 1: ms
+document.body.appendChild(stats.domElement);
+
+var update = function() {
+  stats.end();
+  stats.begin();
+  requestAnimationFrame(update);
+};
+stats.begin();
+requestAnimationFrame(update);
+</script>

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "sinon": "^1.12.2",
     "sniper": "^0.2.16",
     "source-map": "^0.3.0",
+    "stats.js": "^1.0.0",
     "uglify-js": "^2.4.23",
     "watchify": "^3.2.1"
   },


### PR DESCRIPTION
This should help us keep track of frame rates as we add features/optimizations. It seems to correlate well with how things feel as I pan back and forth. If I zoom out a few times and pan, I can see the frame rate drop to 1 or 2 fps.

![fps meter](https://cloud.githubusercontent.com/assets/98301/8557863/16eaad54-24ce-11e5-99f2-22671e20b0f8.png)

If you click the meter, it switches between ms/frame and fps mode.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/220)
<!-- Reviewable:end -->
