### PR TITLE
Tweaks to the test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ script: >
     npm run flow-check &&
     npm run lint &&
     npm run coverage &&
-    cat coverage/lcov.info | ./node_modules/.bin/coveralls
+    ./scripts/post-coverage.sh

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "uglify": "uglifyjs --compress --mangle -o dist/pileup.min.js dist/pileup.js",
     "lint": "./scripts/lint.sh",
     "http-server": "http-server .",
-    "mocha-phantomjs": "mocha-phantomjs http://localhost:8080/src/test/runner.html",
     "test": "./scripts/test.sh",
     "flow": "flow status",
     "flow-check": "flow check",

--- a/scripts/generate-coverage.sh
+++ b/scripts/generate-coverage.sh
@@ -15,12 +15,15 @@ cp -r dist/test coverage/test  # test code needn't be covered
 browserify coverage/**/*.js -o coverage/tests.js
 
 # Run http-server and save its PID for cleanup
-npm run http-server > /dev/null &
+http-server > /dev/null &
 SERVER_PID=$!
 function finish() {
-  pkill -TERM -P $SERVER_PID
+  kill -TERM $SERVER_PID
 }
 trap finish EXIT
+
+# Give the server a chance to start up
+sleep 1
 
 # Run the tests using mocha-phantomjs & mocha-phantomjs-istanbul
 # This produces coverage/coverage.json

--- a/scripts/post-coverage.sh
+++ b/scripts/post-coverage.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cat coverage/lcov.info | ./node_modules/.bin/coveralls
+
+echo ''  # reset exit code -- failure to post coverage shouldn't be an error.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 # Starts the http-server and runs mocha-phantomjs-based tests
+# Note that you must run `npm build` or `npm watch` before running this.
+set -o errexit
 
 # Run http-server and save its PID
-npm run http-server > /dev/null &
+http-server -p 8081 > /dev/null &
 SERVER_PID=$!
+function finish() {
+  kill -TERM $SERVER_PID
+}
+trap finish EXIT
 
 # the following sleep step is not really necessary
 # as http-server starts almost instantenously;
@@ -12,11 +18,4 @@ SERVER_PID=$!
 sleep 1
 
 # Start the tests
-npm run mocha-phantomjs
-TEST_STATUS=$?
-
-# Kill the http server
-pkill -TERM -P $SERVER_PID
-
-# Exit with test status
-exit $TEST_STATUS
+mocha-phantomjs http://localhost:8081/src/test/runner.html


### PR DESCRIPTION
- I noticed that whenever I ran `npm run test`, it left an http server behind. Switching from `pkill` to `kill` seems to fix that.
- The test script runs on its own port to avoid conflicting with a dev server you might already have running.
- I killed the `npm run mocha-phantomjs` task, since it was so heavily tied to `scripts/test.sh` anyway.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/222)
<!-- Reviewable:end -->
