### PR TITLE
Clean up GenomeTrack base pair rendering.

### DIFF
--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -176,34 +176,37 @@ var NonEmptyGenomeTrack = React.createClass({
 
     var g = svg.select('g.wrapper');
 
-    var letter = g.selectAll('.pair')
+    var baseClass = (mode == DisplayMode.LOOSE ? 'loose' :
+                     mode == DisplayMode.TIGHT ? 'tight' : 'blocks');
+    var showText = (mode == DisplayMode.LOOSE || mode == DisplayMode.TIGHT);
+    var modeData = [mode];
+    var modeWrapper = g.selectAll('.mode-wrapper').data(modeData, x => x);
+    modeWrapper.enter().append('g').attr('class', 'mode-wrapper ' + baseClass);
+    modeWrapper.exit().remove();
+
+    var letter = modeWrapper.selectAll('.basepair')
        .data(absBasePairs, bp => bp.pos);
 
     // Enter
     var basePairGs = letter.enter()
-      .append('g');
-    // TODO: look into only creating one or the other of these -- only one is ever visible.
-    basePairGs.append('text');
-    basePairGs.append('rect');
-    
-    var baseClass = (mode == DisplayMode.LOOSE ? 'loose' :
-                     mode == DisplayMode.TIGHT ? 'tight' : 'blocks');
+      .append(showText ? 'text' : 'rect');
 
     // Enter & update
-    letter.attr('class', 'pair ' + baseClass);
 
-    letter.select('text')
-        .attr('x', bp => scale(1 + 0.5 + bp.pos))  // 0.5 = centered
-        .attr('y', height)
-        .attr('class', bp => utils.basePairClass(bp.letter))
-        .text(bp => bp.letter);
-
-    letter.select('rect')
-        .attr('x', bp => scale(1 + bp.pos))
-        .attr('y', height - 14)
-        .attr('height', 14)
-        .attr('width', pxPerLetter - 1)
-        .attr('class', bp => utils.basePairClass(bp.letter));
+    if (showText) {
+      letter
+          .attr('x', bp => scale(1 + 0.5 + bp.pos))  // 0.5 = centered
+          .attr('y', height)
+          .attr('class', bp => utils.basePairClass(bp.letter))
+          .text(bp => bp.letter);
+    } else {
+      letter
+          .attr('x', bp => scale(1 + bp.pos))
+          .attr('y', height - 14)
+          .attr('height', 14)
+          .attr('width', pxPerLetter - 1)
+          .attr('class', bp => utils.basePairClass(bp.letter));
+    }
 
     // Exit
     letter.exit().remove();

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -67,31 +67,21 @@
 .background {
   fill: white;
 }
-.basepair.A, .basepair .A { fill: #188712; }
-.basepair.G, .basepair .G { fill: #C45C16; }
-.basepair.C, .basepair .C { fill: #0600F9; }
-.basepair.T, .basepair .T { fill: #F70016; }
-.basepair.U, .basepair .U { fill: #F70016; }
+.basepair.A { fill: #188712; }
+.basepair.G { fill: #C45C16; }
+.basepair.C { fill: #0600F9; }
+.basepair.T { fill: #F70016; }
+.basepair.U { fill: #F70016; }
 .basepair text, text.basepair {
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   text-anchor: middle;
 }
-.pair.loose text {
+.loose text {
   font-size: 24;
 }
-.pair.tight text {
+.tight text {
   font-size: 12;
   font-weight: bold;
-}
-.pair text, .pair rect {
-  visibility: hidden;
-}
-.pair.loose text,
-.pair.tight text {
-  visibility: visible;
-}
-.pair.blocks rect {
-  visibility: visible;
 }
 
 /* gene track */


### PR DESCRIPTION
Previously a `<rect>` and a `<text>` element were created for every base pair and one was hidden via CSS. Now I only create one. The trick is to add a wrapper element whose d3 data is the display mode. That way it will handle cleanup for us via `enter()`/`exit()`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/223)
<!-- Reviewable:end -->
