### PR TITLE
Show BAI fetch notification w/o index chunks

### DIFF
--- a/src/main/Root.js
+++ b/src/main/Root.js
@@ -47,7 +47,7 @@ var Root = React.createClass({
       this.props.tracks.forEach(track => {
         track.source.rangeChanged(range);
       });
-    });
+    }).done();
   },
   makeDivForTrack(key: string, track: VisualizedTrack): React.Element {
     var trackEl = React.createElement(track.visualization, {

--- a/src/main/bam.js
+++ b/src/main/bam.js
@@ -198,12 +198,14 @@ class Bam {
   index: ?BaiFile;
   header: Q.Promise<Object>;
   remoteFile: RemoteFile;
+  hasIndexChunks: boolean;
 
   constructor(remoteFile: RemoteFile,
               remoteIndexFile?: RemoteFile,
               indexChunks?: Object) {
     this.remoteFile = remoteFile;
     this.index = remoteIndexFile ? new BaiFile(remoteIndexFile, indexChunks) : null;
+    this.hasIndexChunks = !!indexChunks;
 
     var sizePromise = this.index ? this.index.getHeaderSize() : Q.when(2 * 65535);
     this.header = sizePromise.then(size => {


### PR DESCRIPTION
Previously, when a BAI file didn't have index chunks, any requests for the BAM file header would block on downloading the entire BAI file (which is required to know how precisely large the BAM header is). This meant that there would be no status message visible while the BAI file was being loaded.

This change shows a message when that's the case, so that you always get an immediate notification. I tried to thread this notification through `bam.js` but had no luck.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/224)
<!-- Reviewable:end -->
