### PR TITLE
Fix the flash of mismatches on initial load

### DIFF
--- a/src/main/pileuputils.js
+++ b/src/main/pileuputils.js
@@ -77,7 +77,7 @@ function findMismatches(reference: string, seq: string, refPos: number, scores: 
     var pos = refPos + i,
         ref = reference.charAt(i),
         basePair = seq.charAt(i);
-    if (ref != basePair) {
+    if (ref != basePair && ref != '.') {
       out.push({
         pos,
         basePair,

--- a/src/test/pileuputils-test.js
+++ b/src/test/pileuputils-test.js
@@ -117,6 +117,12 @@ describe('pileuputils', function() {
       }
     };
 
+    var unknownReferenceSource = {
+      getRangeAsString: function({contig, start, stop}) {
+        return _.range(start, stop + 1).map(x => '.').join('');
+      }
+    };
+
     return bam.getAlignmentsInRange(range).then(reads => {
       var findRead = function(startPos): SamRead {
         var r = null;
@@ -175,6 +181,13 @@ describe('pileuputils', function() {
             { pos: 7513112, basePair: 'C', quality: 2 }
           ]
         });
+
+      expect(getOpInfo(simpleMismatch, unknownReferenceSource)).to.deep.equal({
+        ops: [
+          { op: 'M', length: 101, pos: 7513222, arrow: 'R' }
+        ],
+        mismatches: []  // no mismatches against unknown reference data
+      });
     });
   });
 });


### PR DESCRIPTION
If the reference isn't available yet, then we shouldn't color mismatches based on it. This should eliminate the flash of color you occasionally see in the pileup tracks on the demo.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/227)
<!-- Reviewable:end -->
