### PR TITLE
Show mismatches as blocks when appropriate

### DIFF
--- a/src/main/DisplayMode.js
+++ b/src/main/DisplayMode.js
@@ -1,8 +1,9 @@
 /**
+ * Individual base pairs are rendered differently depending on the scale.
+ * This enum & associated functions help track these transitions.
  * @flow
  */
 
-// Individual base pairs are rendered differently depending on the scale.
 var DisplayMode = {
   LOOSE: 1,   // Lots of space -- a big font is OK.
   TIGHT: 2,   // Letters need to be shrunk to fit.
@@ -19,6 +20,22 @@ var DisplayMode = {
     } else {
       return DisplayMode.HIDDEN;
     }
+  },
+
+  toString(mode: number): string {
+    if (mode == DisplayMode.LOOSE) {
+      return 'loose';
+    } else if (mode == DisplayMode.TIGHT) {
+      return 'tight';
+    } else if (mode == DisplayMode.BLOCKS) {
+      return 'blocks';
+    } else {
+      return 'hidden';
+    }
+  },
+
+  isText(mode: number): boolean {
+    return (mode == DisplayMode.LOOSE || mode == DisplayMode.TIGHT);
   }
 };
 

--- a/src/main/DisplayMode.js
+++ b/src/main/DisplayMode.js
@@ -1,0 +1,25 @@
+/**
+ * @flow
+ */
+
+// Individual base pairs are rendered differently depending on the scale.
+var DisplayMode = {
+  LOOSE: 1,   // Lots of space -- a big font is OK.
+  TIGHT: 2,   // Letters need to be shrunk to fit.
+  BLOCKS: 3,  // Change from letters to blocks of color
+  HIDDEN: 4,
+
+  getDisplayMode(pxPerLetter: number): number {
+    if (pxPerLetter >= 25) {
+      return DisplayMode.LOOSE;
+    } else if (pxPerLetter >= 10) {
+      return DisplayMode.TIGHT;
+    } else if (pxPerLetter >= 1) {
+      return DisplayMode.BLOCKS;
+    } else {
+      return DisplayMode.HIDDEN;
+    }
+  }
+};
+
+module.exports = DisplayMode;

--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -169,11 +169,10 @@ var NonEmptyGenomeTrack = React.createClass({
 
     var g = svg.select('g.wrapper');
 
-    var baseClass = (mode == DisplayMode.LOOSE ? 'loose' :
-                     mode == DisplayMode.TIGHT ? 'tight' : 'blocks');
-    var showText = (mode == DisplayMode.LOOSE || mode == DisplayMode.TIGHT);
-    var modeData = [mode];
-    var modeWrapper = g.selectAll('.mode-wrapper').data(modeData, x => x);
+    var baseClass = DisplayMode.toString(mode),
+        showText = DisplayMode.isText(mode),
+        modeData = [mode],
+        modeWrapper = g.selectAll('.mode-wrapper').data(modeData, x => x);
     modeWrapper.enter().append('g').attr('class', 'mode-wrapper ' + baseClass);
     modeWrapper.exit().remove();
 

--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -9,7 +9,8 @@ var React = require('./react-shim'),
     d3 = require('d3'),
     shallowEquals = require('shallow-equals'),
     types = require('./react-types'),
-    utils = require('./utils');
+    utils = require('./utils'),
+    DisplayMode = require('./DisplayMode');
 
 
 var GenomeTrack = React.createClass({
@@ -28,14 +29,6 @@ var GenomeTrack = React.createClass({
     return <NonEmptyGenomeTrack {...this.props} />;
   }
 });
-
-// Individual base pairs are rendered differently depending on the scale.
-var DisplayMode = {
-  LOOSE: 1,   // Lots of space -- a big font is OK.
-  TIGHT: 2,   // Letters need to be shrunk to fit.
-  BLOCKS: 3,  // Change from letters to blocks of color
-  HIDDEN: 4
-};
 
 var NonEmptyGenomeTrack = React.createClass({
   // This prevents updates if state & props have not changed.
@@ -150,7 +143,7 @@ var NonEmptyGenomeTrack = React.createClass({
 
     var scale = this.getScale();
     var pxPerLetter = scale(1) - scale(0);
-    var mode = this.getDisplayMode(pxPerLetter);
+    var mode = DisplayMode.getDisplayMode(pxPerLetter);
 
     var basePairs = this.props.source.getRange({
       contig: range.contig,
@@ -210,18 +203,6 @@ var NonEmptyGenomeTrack = React.createClass({
 
     // Exit
     letter.exit().remove();
-  },
-
-  getDisplayMode(pxPerLetter): number {
-    if (pxPerLetter >= 25) {
-      return DisplayMode.LOOSE;
-    } else if (pxPerLetter >= 10) {
-      return DisplayMode.TIGHT;
-    } else if (pxPerLetter >= 1) {
-      return DisplayMode.BLOCKS;
-    } else {
-      return DisplayMode.HIDDEN;
-    }
   }
 });
 

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -376,8 +376,6 @@ class NonEmptyPileupTrack extends React.Component {
       });
     });
 
-    readsG.append('path');  // the alignment arrow
-
     // Mismatched base pairs
     var pxPerLetter = scale(1) - scale(0),
         mode = DisplayMode.getDisplayMode(pxPerLetter),


### PR DESCRIPTION
Fixes #42 

This uses the same trick as `GenomeTrack`, i.e. creating a one-element wrapper to force updates when the display mode changes. There were enough differences between the two (one is a subselect, the other isn't; they use different coordinate systems) that I didn't think it was worth factoring out the commonalities.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/228)
<!-- Reviewable:end -->
