### PR TITLE
Display coverage information for BAM sources

### DIFF
--- a/examples/playground.js
+++ b/examples/playground.js
@@ -24,6 +24,15 @@ var sources = [
     name: 'Genes'
   },
   {
+    viz: pileup.viz.coverage(),
+    data: pileup.formats.bam({
+      url: '/test-data/synth3.normal.17.7500000-7515000.bam',
+      indexUrl: '/test-data/synth3.normal.17.7500000-7515000.bam.bai'
+    }),
+    cssClass: 'normal-coverage',
+    name: 'Coverage'
+  },
+  {
     viz: pileup.viz.pileup(),
     data: pileup.formats.bam({
       url: '/test-data/synth3.normal.17.7500000-7515000.bam',
@@ -31,6 +40,15 @@ var sources = [
     }),
     cssClass: 'normal',
     name: 'Alignments'
+  },
+  {
+    viz: pileup.viz.coverage(),
+    data: pileup.formats.bam({
+      url: '/test-data/synth3.normal.17.7500000-7515000.bam',
+      indexUrl: '/test-data/synth3.normal.17.7500000-7515000.bam.bai'
+    }),
+    cssClass: 'tumor-coverage',
+    name: 'Coverage'
   },
   {
     viz: pileup.viz.pileup(),

--- a/examples/playground.js
+++ b/examples/playground.js
@@ -1,5 +1,11 @@
 var pileup = require('pileup');
 
+// We are going to use the same data source for multiple tracks
+var bamSource = pileup.formats.bam({
+  url: '/test-data/synth3.normal.17.7500000-7515000.bam',
+  indexUrl: '/test-data/synth3.normal.17.7500000-7515000.bam.bai'
+});
+
 var sources = [
   {
     viz: pileup.viz.genome(),
@@ -25,37 +31,25 @@ var sources = [
   },
   {
     viz: pileup.viz.coverage(),
-    data: pileup.formats.bam({
-      url: '/test-data/synth3.normal.17.7500000-7515000.bam',
-      indexUrl: '/test-data/synth3.normal.17.7500000-7515000.bam.bai'
-    }),
+    data: bamSource,
     cssClass: 'normal-coverage',
     name: 'Coverage'
   },
   {
     viz: pileup.viz.pileup(),
-    data: pileup.formats.bam({
-      url: '/test-data/synth3.normal.17.7500000-7515000.bam',
-      indexUrl: '/test-data/synth3.normal.17.7500000-7515000.bam.bai'
-    }),
+    data: bamSource,
     cssClass: 'normal',
     name: 'Alignments'
   },
   {
     viz: pileup.viz.coverage(),
-    data: pileup.formats.bam({
-      url: '/test-data/synth3.normal.17.7500000-7515000.bam',
-      indexUrl: '/test-data/synth3.normal.17.7500000-7515000.bam.bai'
-    }),
+    data: bamSource,
     cssClass: 'tumor-coverage',
     name: 'Coverage'
   },
   {
     viz: pileup.viz.pileup(),
-    data: pileup.formats.bam({
-      url: '/test-data/synth3.normal.17.7500000-7515000.bam',
-      indexUrl: '/test-data/synth3.normal.17.7500000-7515000.bam.bai'
-    }),
+    data: bamSource,
     cssClass: 'tumor',
     name: 'Alignments'
   }

--- a/examples/playground.js
+++ b/examples/playground.js
@@ -32,7 +32,7 @@ var sources = [
   {
     viz: pileup.viz.coverage(),
     data: bamSource,
-    cssClass: 'normal-coverage',
+    cssClass: 'normal',
     name: 'Coverage'
   },
   {
@@ -44,7 +44,7 @@ var sources = [
   {
     viz: pileup.viz.coverage(),
     data: bamSource,
-    cssClass: 'tumor-coverage',
+    cssClass: 'tumor',
     name: 'Coverage'
   },
   {

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -224,16 +224,6 @@ class NonEmptyCoverageTrack extends React.Component {
       svg.append('g').attr('class', 'y-axis');
     } else {
       yAxisEl.call(yAxis);  // update the axis
-
-      /* aa
-      // Resize the background box according to the axis dimensions
-      var bbox = yAxisEl.node().getBBox();
-      svg.selectAll('rect.y-axis-background')
-        .attr('x', bbox.x)
-        .attr('y', bbox.y)
-        .attr('width', bbox.width * 1.2)  // %20 bigger box
-        .attr('height', bbox.height);
-      */
     }
   }
 }

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -1,5 +1,5 @@
 /**
- * Pileup visualization of BAM sources.
+ * Coverage visualization of BAM sources.
  * @flow
  */
 'use strict';
@@ -46,6 +46,8 @@ class NonEmptyCoverageTrack extends React.Component {
   }
 
   render(): any {
+    // Fill the container up
+    // as we are going to use almost all the space available
     var containerStyles = {
       'height': '100%'
     };
@@ -80,7 +82,13 @@ class NonEmptyCoverageTrack extends React.Component {
     this.updateSize();
 
     var div = this.refs.container.getDOMNode();
-    d3.select(div).append('svg');
+    var svg = d3.select(div).append('svg');
+
+    // Below, we create the container group for our bars upfront
+    // as we want to overlay the axis on top of them
+    // therefore we have to make sure their container
+    // is defined first in the SVG
+    svg.append('g').attr('class', 'bin-group');
 
     this.props.source.on('newdata', () => {
       var range = this.props.range,
@@ -109,42 +117,85 @@ class NonEmptyCoverageTrack extends React.Component {
     // Hold off until height & width are known.
     if (width === 0) return;
 
-    svg
-      .attr('width', width)
-      .attr('height', height);
+    svg.attr('width', width).attr('height', height);
 
+    // Calculate summary statistics for coverage from the reads
     var binCounts = _.chain(this.state.reads)
+      // Extract the interval a read covers
       .map(read => read.getInterval().interval)
+      // Create arrays for nucleotides covered by a read
       .map(interval => _.range(interval.start, interval.stop+1))
+      // Merge all covered reads into a single array
       .flatten()
+      // Group observations by nucleotide position and count them
       .countBy()
+      // Convert the pos=>count object into an array for easier parsing
       .pairs()
+      // Convert the array into a custom object to be used for D3 plotting
       .map(c => ({key: c[0], count: c[1]}))
+      // Extract the value from the underscore chain
       .value();
 
-    var maxVal = _.chain(binCounts).map(b => b.count).max().value();
+    var maxCoverage = _.chain(binCounts)
+      .map(b => b.count)
+      .max()
+      .value();
+    // Now that we know the max coverage,
+    // we now want to create a visually appealing axis
+    // to make it easy to comprehend for us, humans
+    // Rule: if maxCoverage is smaller than 10X,
+    //  then show it as it is (we like small numbers);
+    //  otherwise, round the number to the nearest tenth
+    //  (we hate numbers like 61)
+    maxCoverage = maxCoverage < 10
+      ? maxCoverage
+      : Math.round(maxCoverage/10)*10;
+
+    // We are also going to add some padding in two ways:
+    //   1. leave some padding at the bottom for axis origin text (axisHeight)
+    //   2. do not create an axis with the range = maxCoverage (axisMax)
+    var axisMax = maxCoverage * 1.2;  // +20% of the original value
+    var axisHeight = height * .9;  // use 90% of the available space
     var yScale = d3.scale.linear()
-      .domain([0, maxVal])
-      .range([0, height]);
+      .domain([axisMax, 0])  // mind the inverted axis
+      .range([0, axisHeight]);
 
-    var histBars = svg.selectAll("rect.covbin").data(binCounts, d => d.key);
+    // Select the group we created first
+    var histBars = svg.select('g.bin-group').selectAll("rect.covbin")
+      .data(binCounts, d => d.key);
 
+    // D3 logic for our histogram bars
     histBars
       .enter()
       .append('rect')
       .attr('x', d => xScale(d.key))
-      .attr('y', d => yScale(maxVal-d.count))
+      .attr('y', d => yScale(d.count))
       .attr('width', d => xScale(d.key) - xScale(d.key-1))
-      .attr('height', d => yScale(d.count))
+      .attr('height', d => yScale(axisMax-d.count))
       .attr('class', 'covbin');
-
     histBars
       .attr('x', d => xScale(d.key))
-      .attr('y', d => yScale(maxVal-d.count))
+      .attr('y', d => yScale(d.count))
       .attr('width', d => xScale(d.key) - xScale(d.key-1))
-      .attr('height', d => yScale(d.count))
-
+      .attr('height', d => yScale(axisMax-d.count))
     histBars.exit().remove();
+
+    // Logic for our axis
+    var yAxis = d3.svg.axis()
+      .scale(yScale)
+      .orient('left')  // this is gonna be at the far right
+      .tickSize(5)  // Make our ticks much more visible
+      .outerTickSize(0)  // Remove the default range ticks (they are ugly)
+      .tickFormat(t => t + 'X')  // X -> times in coverage terminology
+      .tickValues([0, maxCoverage/2, maxCoverage]);  // show min, avg and max
+    var yAxisEl = svg.selectAll('g.y-axis');
+    if(yAxisEl.empty()) {  // no axis element yet
+      svg.append('g')
+        .attr('class', 'y-axis')
+        .attr('transform', 'translate(' + width + ', 0)');
+    }
+    yAxisEl.call(yAxis);  // update the axis
+
   }
 }
 

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -71,34 +71,35 @@ class NonEmptyCoverageTrack extends React.Component {
     });
   }
 
+  /**
+   * Create a dummy label to see how much space the label occupies.
+   * Once calculated, save it into the state for later use in
+   * padding-related calculations.
+   */
+  calculateLabelSize(svg) {
+    // Create a dummy element that matches with the style:
+    //        ".coverage .y-axis g.tick text {...}"
+    var dummyAxis = svg.append('g').attr('class', 'y-axis');
+    var dummySize = dummyAxis.append('g').attr('class', 'tick')
+      .append('text')
+      .text("100X")
+      .node()
+      .getBBox();  // Measure its size
+
+    // Save the size information
+    this.setState({
+          labelSize: {height: dummySize.height, width: dummySize.width}
+    });
+    dummyAxis.remove();
+  }
+
   componentDidMount() {
     window.addEventListener('resize', () => this.updateSize());
     this.updateSize();
 
     var div = this.refs.container.getDOMNode();
     var svg = d3.select(div).append('svg');
-
-    /*
-      We are going to create a dummy label to see how big is our label
-      text will be. Once we get this information, we will save it in our state
-      and use it in plot padding calculations.
-    */
-    // Create a dummy element that matches with the style:
-    //        ".coverage .y-axis g.tick text {...}"
-    var dummyAxis = svg.append('g').attr('class', 'y-axis');
-    // Measure its size
-    var dummySize = dummyAxis.append('g').attr('class', 'tick')
-      .append('text')
-      .text("100X")
-      .node()
-      .getBBox();
-    // Save the size information
-    this.setState({
-          labelSize: {height: dummySize.height, width: dummySize.width}
-    });
-    // Remove the dummy element
-    dummyAxis.remove();
-    /* end of dummy label calculations */
+    this.calculateLabelSize(svg);
 
     // Below, we create the container group for our bars upfront as we want
     // to overlay the axis on top of them; therefore, we have to make sure
@@ -121,39 +122,35 @@ class NonEmptyCoverageTrack extends React.Component {
     }
   }
 
-  /*
-    The following extacts the summary statistics from the read data.
-    It might look ugly and you might have the temptation to convert
-    this into a functional form; but, please don't. We need these hacky
-    optimizations not to chug the browser with histogram data generation.
-  */
-  extractSummaryStatistics(reads: Array<SamRead>, range: GenomeRange) {
+  /**
+   * Extract summary statistics from the read data.
+   */
+  extractSummaryStatistics(reads: Array<SamRead>, range: ContigInterval<string>) {
     // Keep track of the start/stop points of our view
     var rstart = range.start - 1,  // this is to account for 0 vs 1-based pos.
         rstop = range.stop;
     // Create an array to keep track of all counts for each of the positions
-    var binCounts = new Array(rstop - rstart + 1);  // length = num of bases
-    binCounts = _.map(binCounts, () => 0);  // start w/ 0 counts for each base
-    _.chain(this.state.reads)  // Parse the read data
-        // Walk over the interval one base at a time and update the counts
-        .each(read => {
-            var interval = read.getInterval().interval,
-                istart = interval.start,
-                istop = interval.stop;
+    var binCounts = _.range(rstart, rstop + 1).map(() => 0);
 
-            for (var j = Math.max(istart, rstart);  // don't go beyond start
-                j <= Math.min(istop, rstop);  // don't go beyond stop
-                j++) {
-              binCounts[j - rstart] += 1;
-            }
-        });
-    // binCounts is a simple array now, so let's find the max val right away
+    // This is written in an imperative style (instead of with _.groupBy)
+    // as an optimization.
+    _.each(this.state.reads, read => {
+      var interval = read.getInterval().interval,
+          istart = interval.start,
+          istop = interval.stop;
+
+      for (var j = Math.max(istart, rstart);  // don't go beyond start
+          j <= Math.min(istop, rstop);  // don't go beyond stop
+          j++) {
+        binCounts[j - rstart] += 1;
+      }
+    });
     var maxCoverage = _.max(binCounts);
 
-    // This will convert the array into an array of objects with keys
-    // where the key will be the nucleotide location
+    // This will convert the array into an array of objects with positions
+    // where the position will be used a unique key
     binCounts = _.map(binCounts,
-      (val, idx) => ({key: rstart + idx + 1, count: val})
+      (val, idx) => ({position: rstart + idx + 1, count: val})
     );
 
     return {binCounts, maxCoverage};
@@ -184,24 +181,20 @@ class NonEmptyCoverageTrack extends React.Component {
     var axisMax = yScale.domain()[0];
     // Select the group we created first
     var histBars = svg.select('g.bin-group').selectAll('rect.bin')
-      .data(binCounts, d => d.key);
+      .data(binCounts, d => d.position);
 
-    var calcBarHeight = (d) => Math.max(0, yScale(axisMax - d.count)),
-        calcBarPos = (d) => yScale(d.count) - yScale(axisMax),
-        calcBarWidth = (d) => xScale(d.key) - xScale(d.key - 1);
+    var calcBarHeight = d => Math.max(0, yScale(axisMax - d.count)),
+        calcBarPosY = d => yScale(d.count) - yScale(axisMax),
+        calcBarWidth = d => xScale(d.position) - xScale(d.position - 1);
 
     // D3 logic for our histogram bars
     histBars
       .enter()
       .append('rect')
-      .attr('x', d => xScale(d.key))
-      .attr('y', calcBarPos)
-      .attr('width', calcBarWidth)
-      .attr('height', calcBarHeight)
       .attr('class', 'bin');
     histBars
-      .attr('x', d => xScale(d.key))
-      .attr('y', calcBarPos)
+      .attr('x', d => xScale(d.position))
+      .attr('y', calcBarPosY)
       .attr('width', calcBarWidth)
       .attr('height', calcBarHeight)
     histBars.exit().remove();

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -84,10 +84,9 @@ class NonEmptyCoverageTrack extends React.Component {
     var div = this.refs.container.getDOMNode();
     var svg = d3.select(div).append('svg');
 
-    // Below, we create the container group for our bars upfront
-    // as we want to overlay the axis on top of them
-    // therefore we have to make sure their container
-    // is defined first in the SVG
+    // Below, we create the container group for our bars upfront as we want
+    // to overlay the axis on top of them; therefore, we have to make sure
+    // their container is defined first in the SVG
     svg.append('g').attr('class', 'bin-group');
 
     this.props.source.on('newdata', () => {
@@ -152,13 +151,11 @@ class NonEmptyCoverageTrack extends React.Component {
     );
     /* Here ends the summary stat extraction part */
 
-    // Now that we know the max coverage,
-    // we now want to create a visually appealing axis
-    // to make it easy to comprehend for us, humans
+    // Now that we know the max coverage, we now want to create a visually
+    // appealing axis to make it easy to comprehend for us, humans
     // Rule: if maxCoverage is smaller than 10X,
     //  then show it as it is (we like small numbers);
-    //  otherwise, round the number to the nearest tenth
-    //  (we hate numbers like 61)
+    //  otherwise, round the number to the nearest tenth.
     maxCoverage = maxCoverage < 10
       ? maxCoverage
       : Math.round(maxCoverage/10)*10;

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -156,8 +156,6 @@ class NonEmptyCoverageTrack extends React.Component {
     svg.attr('width', width).attr('height', height);
 
     var {binCounts, maxCoverage} = this.extractSummaryStatistics(reads, range);
-    // Now that we know the max coverage, we now want to create a visually
-    // appealing axis to make it easy to comprehend for us, humans
     // Rule: if maxCoverage is smaller than 10X,
     //  then show it as it is (we like small numbers);
     //  otherwise, round the number to the nearest tenth.

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -12,6 +12,7 @@ var React = require('./react-shim'),
     shallowEquals = require('shallow-equals'),
     types = require('./react-types'),
     utils = require('./utils'),
+    d3utils = require('./d3utils'),
     _ = require("underscore"),
     ContigInterval = require('./ContigInterval');
 
@@ -60,7 +61,7 @@ class NonEmptyCoverageTrack extends React.Component {
   }
 
   getScale() {
-    return utils.getTrackScale(this.props.range, this.state.width);
+    return d3utils.getTrackScale(this.props.range, this.state.width);
   }
 
   updateSize() {

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -13,7 +13,6 @@ var React = require('./react-shim'),
     types = require('./react-types'),
     utils = require('./utils'),
     _ = require("underscore"),
-    {addToPileup, getOpInfo, CigarOp} = require('./pileuputils'),
     ContigInterval = require('./ContigInterval');
 
 var CoverageTrack = React.createClass({
@@ -61,13 +60,7 @@ class NonEmptyCoverageTrack extends React.Component {
   }
 
   getScale() {
-    var range = this.props.range,
-        width = this.state.width,
-        offsetPx = range.offsetPx || 0;
-    var scale = d3.scale.linear()
-            .domain([range.start, range.stop + 1])  // 1 bp wide
-            .range([-offsetPx, width - offsetPx]);
-    return scale;
+    return utils.getTrackScale(this.props.range, this.state.width);
   }
 
   updateSize() {

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -1,0 +1,402 @@
+/**
+ * Pileup visualization of BAM sources.
+ * @flow
+ */
+'use strict';
+
+import type * as SamRead from './SamRead';
+import type * as Interval from './Interval';
+
+var React = require('./react-shim'),
+    d3 = require('d3'),
+    shallowEquals = require('shallow-equals'),
+    types = require('./react-types'),
+    utils = require('./utils'),
+    {addToPileup, getOpInfo, CigarOp} = require('./pileuputils'),
+    ContigInterval = require('./ContigInterval');
+
+var CoverageTrack = React.createClass({
+  displayName: 'coverage',
+  propTypes: {
+    range: types.GenomeRange,
+    onRangeChange: React.PropTypes.func.isRequired,
+    source: React.PropTypes.object.isRequired,
+    referenceSource: React.PropTypes.object.isRequired
+  },
+  render: function(): any {
+    var range = this.props.range;
+    if (!range) {
+      return <EmptyTrack />;
+    }
+
+    return <NonEmptyCoverageTrack {...this.props} />;
+  }
+});
+
+
+var READ_HEIGHT = 13;
+var READ_SPACING = 2;  // vertical pixels between reads
+
+var READ_STRAND_ARROW_WIDTH = 6;
+
+// Returns an SVG path string for the read, with an arrow indicating strand.
+function makeArrow(scale, pos, refLength, direction) {
+  var left = scale(pos + 1),
+      top = 0,
+      right = scale(pos + refLength + 1),
+      bottom = READ_HEIGHT,
+      path = direction == 'R' ? [
+        [left, top],
+        [right - READ_STRAND_ARROW_WIDTH, top],
+        [right, (top + bottom) / 2],
+        [right - READ_STRAND_ARROW_WIDTH, bottom],
+        [left, bottom]
+      ] : [
+        [right, top],
+        [left + READ_STRAND_ARROW_WIDTH, top],
+        [left, (top + bottom) / 2],
+        [left + READ_STRAND_ARROW_WIDTH, bottom],
+        [right, bottom]
+      ];
+  return d3.svg.line()(path);
+}
+
+// Create the SVG element for a single Cigar op in an alignment.
+function enterSegment(parentNode, op, scale) {
+  var parent = d3.select(parentNode);
+  switch (op.op) {
+    case CigarOp.MATCH:
+      return parent.append(op.arrow ? 'path' : 'rect')
+                   .attr('class', 'segment match');
+
+    case CigarOp.DELETE:
+      return parent.append('line')
+                   .attr('class', 'segment delete');
+
+    case CigarOp.INSERT:
+      return parent.append('line')
+                   .attr('class', 'segment insert');
+
+    default:
+      throw `Invalid op! ${op.op}`;
+  }
+}
+
+// Update the selection for a single Cigar op, e.g. in response to a pan or zoom.
+function updateSegment(node, op, scale) {
+  switch (op.op) {
+    case CigarOp.MATCH:
+      if (op.arrow) {
+        // an arrow pointing in the direction of the alignment
+        d3.select(node).attr('d', makeArrow(scale, op.pos, op.length, op.arrow));
+      } else {
+        // a rectangle (interior part of an alignment)
+        d3.select(node)
+          .attr({
+            'x': scale(op.pos + 1),
+            'height': READ_HEIGHT,
+            'width': scale(op.length) - scale(0)
+          });
+      }
+      break;
+
+    case CigarOp.DELETE:
+      // A thin line in the middle of the alignments indicating the deletion.
+      d3.select(node)
+        .attr({
+          'x1': scale(op.pos + 1),
+          'x2': scale(op.pos + 1 + op.length),
+          'y1': READ_HEIGHT / 2 - 0.5,
+          'y2': READ_HEIGHT / 2 - 0.5
+        });
+      break;
+
+    case CigarOp.INSERT:
+      // A thin vertical line. This is shifted to the left so that it's not
+      // hidden by the segment following it.
+      d3.select(node)
+        .attr({
+          'x1': scale(op.pos + 1) - 2,  // to cover a bit of the previous segment
+          'x2': scale(op.pos + 1) - 2,
+          'y1': -1,
+          'y2': READ_HEIGHT + 2
+        });
+      break;
+
+    default:
+      throw `Invalid op! ${op.op}`;
+  }
+}
+
+// Should the Cigar op be rendered to the screen?
+function isRendered(op) {
+  return (op.op == CigarOp.MATCH ||
+          op.op == CigarOp.DELETE ||
+          op.op == CigarOp.INSERT);
+}
+
+function readClass(vread: VisualAlignment) {
+  return 'alignment ' + (vread.strand == Strand.NEGATIVE ? 'negative' : 'positive');
+}
+
+// Copied from pileuputils.js
+type BasePair = {
+  pos: number;
+  basePair: string;
+}
+
+// This bundles everything intrinsic to the alignment that we need to display
+// it, i.e. everything not dependend on scale/viewport.
+type VisualAlignment = {
+  key: string;
+  read: SamRead;
+  strand: number;  // see Strand below
+  row: number;  // pileup row.
+  refLength: number;  // span on the reference (accounting for indels)
+  mismatches: Array<BasePair>;
+};
+var Strand = {
+  POSITIVE: 0,
+  NEGATIVE: 1
+};
+
+
+function yForRow(row) {
+  return row * (READ_HEIGHT + READ_SPACING);
+}
+
+class NonEmptyCoverageTrack extends React.Component {
+  pileup: Array<Interval[]>;
+  keyToVisualAlignment: {[key:string]: VisualAlignment};
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      width: 0,
+      height: 0,
+      reads: []
+    };
+    this.pileup = [];
+    this.keyToVisualAlignment = {};
+  }
+
+  render(): any {
+    // These styles allow vertical scrolling to see the full pileup.
+    // Adding a vertical scrollbar shrinks the visible area, but we have to act
+    // as though it doesn't, since adjusting the scale would put it out of sync
+    // with other tracks.
+    var containerStyles = {
+      'height': '100%'
+    };
+
+    var statusEl = null,
+        networkStatus = this.state.networkStatus;
+    if (networkStatus) {
+      var message = this.formatStatus(networkStatus);
+      statusEl = (
+        <div ref='status' className='network-status'>
+          <div className='network-status-message'>
+            Loading alignments… ({message})
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        {statusEl}
+        <div ref='container' style={containerStyles}></div>
+      </div>
+    );
+  }
+
+  formatStatus(state): string {
+    if (state.numRequests) {
+      var pluralS = state.numRequests > 1 ? 's' : '';
+      return `issued ${state.numRequests} request${pluralS}`;
+    } else if (state.status) {
+      return state.status;
+    }
+    throw 'invalid';
+  }
+
+  updateSize() {
+    var parentDiv = this.refs.container.getDOMNode().parentNode;
+    this.setState({
+      width: parentDiv.offsetWidth,
+      height: parentDiv.offsetHeight
+    });
+  }
+
+  componentDidMount() {
+    window.addEventListener('resize', () => this.updateSize());
+    this.updateSize();
+
+    var div = this.refs.container.getDOMNode();
+    d3.select(div)
+      .append('svg');
+
+    this.props.source.on('newdata', () => {
+      var range = this.props.range,
+          ci = new ContigInterval(range.contig, range.start, range.stop);
+      this.setState({
+        reads: this.props.source.getAlignmentsInRange(ci)
+      });
+    });
+    this.props.referenceSource.on('newdata', () => {
+      this.updateMismatches();
+      this.updateVisualization();
+    });
+    this.props.source.on('networkprogress', e => {
+      this.setState({networkStatus: e});
+    }).on('networkdone', e => {
+      this.setState({networkStatus: null});
+    });
+
+    this.updateVisualization();
+  }
+
+  getScale() {
+    var range = this.props.range,
+        width = this.state.width,
+        offsetPx = range.offsetPx || 0;
+    var scale = d3.scale.linear()
+            .domain([range.start, range.stop + 1])  // 1 bp wide
+            .range([-offsetPx, width - offsetPx]);
+    return scale;
+  }
+
+  componentDidUpdate(prevProps: any, prevState: any) {
+    if (!shallowEquals(this.props, prevProps) ||
+        !shallowEquals(this.state, prevState)) {
+      this.updateVisualization();
+    }
+  }
+
+  // Attach visualization info to the read and cache it.
+  addRead(read: SamRead, referenceSource): VisualAlignment {
+    var k = read.offset.toString();
+    if (k in this.keyToVisualAlignment) {
+      return this.keyToVisualAlignment[k];
+    }
+
+    var refLength = read.getReferenceLength();
+    var range = read.getInterval();
+    var key = read.offset.toString();
+
+    var opInfo = getOpInfo(read, referenceSource);
+
+    var visualAlignment = {
+      key,
+      read,
+      strand: read.getStrand() == '+' ? Strand.POSITIVE : Strand.NEGATIVE,
+      row: addToPileup(range.interval, this.pileup),
+      refLength,
+      ops: opInfo.ops,
+      mismatches: opInfo.mismatches
+    };
+
+    this.keyToVisualAlignment[k] = visualAlignment;
+    return visualAlignment;
+  }
+
+  updateMismatches() {
+    // TODO: dedupe with addRead()
+    var referenceSource = this.props.referenceSource;
+    for (var k in this.keyToVisualAlignment) {
+      var vRead = this.keyToVisualAlignment[k],
+          read = vRead.read,
+          opInfo = getOpInfo(read, referenceSource);
+
+      vRead.mismatches = opInfo.mismatches;
+    }
+  }
+
+  updateVisualization() {
+    var div = this.refs.container.getDOMNode(),
+        width = this.state.width,
+        svg = d3.select(div).select('svg');
+
+    // Hold off until height & width are known.
+    if (width === 0) return;
+
+    var referenceSource = this.props.referenceSource;
+    var vReads = this.state.reads.map(
+            read => this.addRead(read, referenceSource))
+        .filter(read => read.refLength);  // drop alignments w/o CIGARs
+
+    // Height can only be computed after the pileup has been updated.
+    var height = yForRow(this.pileup.length);
+    var scale = this.getScale();
+
+    svg.attr('width', width)
+       .attr('height', height);
+
+    var reads = svg.selectAll('.alignment')
+       .data(vReads, vRead => vRead.key);
+
+    // Enter
+    var readsG = reads.enter()
+        .append('g')
+        .attr('class', readClass)
+        .attr('transform', vRead => `translate(0, ${yForRow(vRead.row)})`)
+        .on('click', vRead => {
+          window.alert(vRead.read.debugString());
+        });
+
+    var segments = reads.selectAll('.segment')
+        .data(read => read.ops.filter(isRendered));
+
+    // This is like segments.append(), but allows for different types of
+    // elements depending on the datum.
+    segments.enter().call(function(sel) {
+      sel.forEach(function(el) {
+        el.forEach(function(op) {
+          var d = d3.select(op).datum();
+          var element = enterSegment(el.parentNode, d, scale);
+          updateSegment(element[0][0], d, scale);
+        });
+      });
+    });
+
+    readsG.append('path');  // the alignment arrow
+
+    var mismatchTexts = reads.selectAll('text.basepair')
+        .data(vRead => vRead.mismatches, m => m.pos + m.basePair);
+
+    mismatchTexts
+        .enter()
+        .append('text')
+          .attr('class', mismatch => utils.basePairClass(mismatch.basePair))
+          .text(mismatch => mismatch.basePair);
+
+    // Update
+    segments.each(function(d, i) {
+      updateSegment(this, d, scale);
+    });
+    reads.selectAll('text')
+         .attr('x', mismatch => scale(1 + 0.5 + mismatch.pos));  // 0.5 = centered
+
+    // Exit
+    reads.exit().remove();
+    mismatchTexts.exit().remove();
+    segments.exit().remove();
+  }
+
+}
+
+NonEmptyCoverageTrack.propTypes = {
+  range: types.GenomeRange.isRequired,
+  source: React.PropTypes.object.isRequired,
+  referenceSource: React.PropTypes.object.isRequired,
+  onRangeChange: React.PropTypes.func.isRequired
+};
+
+
+var EmptyTrack = React.createClass({
+  render: function() {
+    return <div className='coverage empty'>Zoom in to see alignments</div>;
+  }
+});
+
+module.exports = CoverageTrack;

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -161,7 +161,7 @@ class NonEmptyCoverageTrack extends React.Component {
       .range([0, axisHeight]);
 
     // Select the group we created first
-    var histBars = svg.select('g.bin-group').selectAll("rect.covbin")
+    var histBars = svg.select('g.bin-group').selectAll('rect.covbin')
       .data(binCounts, d => d.key);
 
     // D3 logic for our histogram bars
@@ -183,19 +183,27 @@ class NonEmptyCoverageTrack extends React.Component {
     // Logic for our axis
     var yAxis = d3.svg.axis()
       .scale(yScale)
-      .orient('left')  // this is gonna be at the far right
+      .orient('right')  // this is gonna be at the far left
       .tickSize(5)  // Make our ticks much more visible
       .outerTickSize(0)  // Remove the default range ticks (they are ugly)
       .tickFormat(t => t + 'X')  // X -> times in coverage terminology
       .tickValues([0, maxCoverage/2, maxCoverage]);  // show min, avg and max
     var yAxisEl = svg.selectAll('g.y-axis');
     if(yAxisEl.empty()) {  // no axis element yet
-      svg.append('g')
-        .attr('class', 'y-axis')
-        .attr('transform', 'translate(' + width + ', 0)');
-    }
-    yAxisEl.call(yAxis);  // update the axis
+      svg.append('rect').attr('class', 'y-axis-background');
+      // add this the second so it is on top of the background
+      svg.append('g').attr('class', 'y-axis');
+    } else {
+      yAxisEl.call(yAxis);  // update the axis
 
+      // Resize the background box according to the axis dimensions
+      var bbox = yAxisEl.node().getBBox();
+      svg.selectAll('rect.y-axis-background')
+        .attr('x', bbox.x)
+        .attr('y', bbox.y)
+        .attr('width', bbox.width * 1.2)  // %20 bigger box
+        .attr('height', bbox.height);
+    }
   }
 }
 

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -1,5 +1,5 @@
 /**
- * Coverage visualization of BAM sources.
+ * Coverage visualization of Alignment sources.
  * @flow
  */
 'use strict';

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -217,7 +217,7 @@ NonEmptyCoverageTrack.propTypes = {
 
 var EmptyTrack = React.createClass({
   render: function() {
-    return <div className='coverage empty'>Zoom in to see alignments</div>;
+    return <div className='coverage empty'>Zoom in to see the coverage</div>;
   }
 });
 

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -126,7 +126,7 @@ class NonEmptyCoverageTrack extends React.Component {
   /**
    * Extract summary statistics from the read data.
    */
-  extractSummaryStatistics(reads: Array<SamRead>, range: ContigInterval<string>) {
+  extractSummaryStatistics(reads: Array<SamRead>, range: types.GenomeRange) {
     // Keep track of the start/stop points of our view
     var rstart = range.start - 1,  // this is to account for 0 vs 1-based pos.
         rstop = range.stop;

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -216,7 +216,7 @@ class NonEmptyCoverageTrack extends React.Component {
       .tickSize(5)  // Make our ticks much more visible
       .outerTickSize(0)  // Remove the default range ticks (they are ugly)
       .tickFormat(t => t + 'X')  // X -> times in coverage terminology
-      .tickValues([0, Math.round(axisMax/2), axisMax]);  // show min, avg, max
+      .tickValues([0, Math.round(axisMax / 2), axisMax]);  // show min, avg, max
     var yAxisEl = svg.selectAll('g.y-axis');
     if(yAxisEl.empty()) {  // no axis element yet
       svg.append('rect').attr('class', 'y-axis-background');

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -193,20 +193,24 @@ class NonEmptyCoverageTrack extends React.Component {
     var histBars = svg.select('g.bin-group').selectAll('rect.bin')
       .data(binCounts, d => d.key);
 
+    var calcBarHeight = (d) => Math.max(0, yScale(axisMax - d.count)),
+        calcBarPos = (d) => yScale(d.count) - yScale(axisMax),
+        calcBarWidth = (d) => xScale(d.key) - xScale(d.key - 1);
+
     // D3 logic for our histogram bars
     histBars
       .enter()
       .append('rect')
       .attr('x', d => xScale(d.key))
-      .attr('y', d => yScale(d.count) - yScale(axisMax))
-      .attr('width', d => xScale(d.key) - xScale(d.key - 1))
-      .attr('height', d => yScale(axisMax - d.count))
+      .attr('y', calcBarPos)
+      .attr('width', calcBarWidth)
+      .attr('height', calcBarHeight)
       .attr('class', 'bin');
     histBars
       .attr('x', d => xScale(d.key))
-      .attr('y', d => yScale(d.count) - yScale(axisMax))
-      .attr('width', d => xScale(d.key) - xScale(d.key - 1))
-      .attr('height', d => yScale(axisMax - d.count))
+      .attr('y', calcBarPos)
+      .attr('width', calcBarWidth)
+      .attr('height', calcBarHeight)
     histBars.exit().remove();
 
     // Logic for our axis

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -148,10 +148,10 @@ class NonEmptyCoverageTrack extends React.Component {
                 istart = interval.start,
                 istop = interval.stop;
 
-            for(var j = Math.max(istart, rstart);  // don't go beyond start
+            for (var j = Math.max(istart, rstart);  // don't go beyond start
                 j <= Math.min(istop, rstop);  // don't go beyond stop
                 j++) {
-              binCounts[j-rstart] += 1;
+              binCounts[j - rstart] += 1;
             }
         });
     // binCounts is a simple array now, so let's find the max val right away
@@ -190,7 +190,7 @@ class NonEmptyCoverageTrack extends React.Component {
     // Let's get our domain max back from the nicified scale
     var axisMax = yScale.domain()[0];
     // Select the group we created first
-    var histBars = svg.select('g.bin-group').selectAll('rect.covbin')
+    var histBars = svg.select('g.bin-group').selectAll('rect.bin')
       .data(binCounts, d => d.key);
 
     // D3 logic for our histogram bars
@@ -201,7 +201,7 @@ class NonEmptyCoverageTrack extends React.Component {
       .attr('y', d => yScale(d.count) - yScale(axisMax))
       .attr('width', d => xScale(d.key) - xScale(d.key - 1))
       .attr('height', d => yScale(axisMax - d.count))
-      .attr('class', 'covbin');
+      .attr('class', 'bin');
     histBars
       .attr('x', d => xScale(d.key))
       .attr('y', d => yScale(d.count) - yScale(axisMax))
@@ -213,12 +213,12 @@ class NonEmptyCoverageTrack extends React.Component {
     var yAxis = d3.svg.axis()
       .scale(yScale)
       .orient('right')  // this is gonna be at the far left
-      .tickSize(5)  // Make our ticks much more visible
+      .innerTickSize(5)  // Make our ticks much more visible
       .outerTickSize(0)  // Remove the default range ticks (they are ugly)
       .tickFormat(t => t + 'X')  // X -> times in coverage terminology
       .tickValues([0, Math.round(axisMax / 2), axisMax]);  // show min, avg, max
     var yAxisEl = svg.selectAll('g.y-axis');
-    if(yAxisEl.empty()) {  // no axis element yet
+    if (yAxisEl.empty()) {  // no axis element yet
       svg.append('rect').attr('class', 'y-axis-background');
       // add this the second so it is on top of the background
       svg.append('g').attr('class', 'y-axis');

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -105,25 +105,13 @@ class NonEmptyCoverageTrack extends React.Component {
     }
   }
 
-  visualizeCoverage() {
-    var div = this.refs.container.getDOMNode(),
-        width = this.state.width,
-        height = this.state.height,
-        range = this.props.range,
-        xScale = this.getScale(),
-        svg = d3.select(div).select('svg');
-
-    // Hold off until height & width are known.
-    if (width === 0) return;
-
-    svg.attr('width', width).attr('height', height);
-
-    /*
-      The following extacts the summary statistics from the read data.
-      It might look ugly and you might have the temptation to convert
-      this into a functional form; but, please don't. We need these hacky
-      optimizations not to chug the browser with histogram data generation.
-    */
+  /*
+    The following extacts the summary statistics from the read data.
+    It might look ugly and you might have the temptation to convert
+    this into a functional form; but, please don't. We need these hacky
+    optimizations not to chug the browser with histogram data generation.
+  */
+  extractSummaryStatistics(reads: Array<SamRead>, range: GenomeRange) {
     // Keep track of the start/stop points of our view
     var rstart = range.start,
         rstop = range.stop;
@@ -149,8 +137,25 @@ class NonEmptyCoverageTrack extends React.Component {
     binCounts = _.map(binCounts,
       (val, idx) => ({key: rstart + idx, count: val})
     );
-    /* Here ends the summary stat extraction part */
 
+    return {binCounts, maxCoverage};
+  }
+
+  visualizeCoverage() {
+    var div = this.refs.container.getDOMNode(),
+        width = this.state.width,
+        height = this.state.height,
+        range = this.props.range,
+        reads = this.state.reads,
+        xScale = this.getScale(),
+        svg = d3.select(div).select('svg');
+
+    // Hold off until height & width are known.
+    if (width === 0) return;
+
+    svg.attr('width', width).attr('height', height);
+
+    var {binCounts, maxCoverage} = this.extractSummaryStatistics(reads, range);
     // Now that we know the max coverage, we now want to create a visually
     // appealing axis to make it easy to comprehend for us, humans
     // Rule: if maxCoverage is smaller than 10X,

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -11,7 +11,6 @@ var React = require('./react-shim'),
     d3 = require('d3'),
     shallowEquals = require('shallow-equals'),
     types = require('./react-types'),
-    utils = require('./utils'),
     d3utils = require('./d3utils'),
     _ = require("underscore"),
     ContigInterval = require('./ContigInterval');

--- a/src/main/GA4GHDataSource.js
+++ b/src/main/GA4GHDataSource.js
@@ -7,11 +7,9 @@
 import type {Alignment, AlignmentDataSource} from './Alignment';
 
 var Events = require('backbone').Events,
-    _ = require('underscore'),
-    Q = require('q');
+    _ = require('underscore');
 
 var ContigInterval = require('./ContigInterval'),
-    SamRead = require('./SamRead'),
     GA4GHAlignment = require('./GA4GHAlignment');
 
 var ALIGNMENTS_PER_REQUEST = 200;  // TODO: explain this choice.

--- a/src/main/GeneTrack.js
+++ b/src/main/GeneTrack.js
@@ -12,6 +12,7 @@ var React = require('./react-shim'),
     bedtools = require('./bedtools'),
     Interval = require('./Interval'),
     utils = require('./utils'),
+    d3utils = require('./d3utils'),
     ContigInterval = require('./ContigInterval');
 
 var GeneTrack = React.createClass({
@@ -110,7 +111,7 @@ var NonEmptyGeneTrack = React.createClass({
     this.updateVisualization();
   },
   getScale: function() {
-    return utils.getTrackScale(this.props.range, this.state.width);
+    return d3utils.getTrackScale(this.props.range, this.state.width);
   },
   componentDidUpdate: function(prevProps: any, prevState: any) {
     if (!shallowEquals(prevProps, this.props) ||

--- a/src/main/GeneTrack.js
+++ b/src/main/GeneTrack.js
@@ -11,6 +11,7 @@ var React = require('./react-shim'),
     types = require('./react-types'),
     bedtools = require('./bedtools'),
     Interval = require('./Interval'),
+    utils = require('./utils'),
     ContigInterval = require('./ContigInterval');
 
 var GeneTrack = React.createClass({
@@ -109,12 +110,7 @@ var NonEmptyGeneTrack = React.createClass({
     this.updateVisualization();
   },
   getScale: function() {
-    var range = this.props.range,
-        offsetPx = range.offsetPx || 0;
-    var scale = d3.scale.linear()
-            .domain([range.start, range.stop + 1])  // 1 bp wide
-            .range([-offsetPx, this.state.width - offsetPx]);
-    return scale;
+    return utils.getTrackScale(this.props.range, this.state.width);
   },
   componentDidUpdate: function(prevProps: any, prevState: any) {
     if (!shallowEquals(prevProps, this.props) ||

--- a/src/main/GeneTrack.js
+++ b/src/main/GeneTrack.js
@@ -11,7 +11,6 @@ var React = require('./react-shim'),
     types = require('./react-types'),
     bedtools = require('./bedtools'),
     Interval = require('./Interval'),
-    utils = require('./utils'),
     d3utils = require('./d3utils'),
     ContigInterval = require('./ContigInterval');
 

--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -116,14 +116,8 @@ var NonEmptyGenomeTrack = React.createClass({
     this.updateVisualization();
   },
   getScale: function() {
-    var div = this.getDOMNode(),
-        range = this.props.range,
-        width = div.offsetWidth,
-        offsetPx = range.offsetPx || 0;
-    var scale = d3.scale.linear()
-            .domain([range.start, range.stop + 1])  // 1 bp wide
-            .range([-offsetPx, width - offsetPx]);
-    return scale;
+    var width = this.getDOMNode().offsetWidth;
+    return utils.getTrackScale(this.props.range, this.state.width);
   },
   componentDidUpdate: function(prevProps: any, prevState: any) {
     if (!shallowEquals(prevProps, this.props) ||

--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -10,6 +10,7 @@ var React = require('./react-shim'),
     shallowEquals = require('shallow-equals'),
     types = require('./react-types'),
     utils = require('./utils'),
+    d3utils = require('./d3utils'),
     DisplayMode = require('./DisplayMode');
 
 
@@ -117,7 +118,7 @@ var NonEmptyGenomeTrack = React.createClass({
   },
   getScale: function() {
     var width = this.getDOMNode().offsetWidth;
-    return utils.getTrackScale(this.props.range, width);
+    return d3utils.getTrackScale(this.props.range, width);
   },
   componentDidUpdate: function(prevProps: any, prevState: any) {
     if (!shallowEquals(prevProps, this.props) ||

--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -117,7 +117,7 @@ var NonEmptyGenomeTrack = React.createClass({
   },
   getScale: function() {
     var width = this.getDOMNode().offsetWidth;
-    return utils.getTrackScale(this.props.range, this.state.width);
+    return utils.getTrackScale(this.props.range, width);
   },
   componentDidUpdate: function(prevProps: any, prevState: any) {
     if (!shallowEquals(prevProps, this.props) ||

--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -117,8 +117,7 @@ var NonEmptyGenomeTrack = React.createClass({
     this.updateVisualization();
   },
   getScale: function() {
-    var width = this.getDOMNode().offsetWidth;
-    return d3utils.getTrackScale(this.props.range, width);
+    return d3utils.getTrackScale(this.props.range, this.state.width);
   },
   componentDidUpdate: function(prevProps: any, prevState: any) {
     if (!shallowEquals(prevProps, this.props) ||

--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -174,7 +174,7 @@ var NonEmptyGenomeTrack = React.createClass({
        .data(absBasePairs, bp => bp.pos);
 
     // Enter
-    var basePairGs = letter.enter()
+    letter.enter()
       .append(showText ? 'text' : 'rect');
 
     // Enter & update

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -12,6 +12,7 @@ var React = require('./react-shim'),
     shallowEquals = require('shallow-equals'),
     types = require('./react-types'),
     utils = require('./utils'),
+    d3utils = require('./d3utils'),
     {addToPileup, getOpInfo, CigarOp} = require('./pileuputils'),
     ContigInterval = require('./ContigInterval'),
     DisplayMode = require('./DisplayMode');
@@ -274,7 +275,7 @@ class NonEmptyPileupTrack extends React.Component {
   }
 
   getScale() {
-    return utils.getTrackScale(this.props.range, this.state.width);
+    return d3utils.getTrackScale(this.props.range, this.state.width);
   }
 
   componentDidUpdate(prevProps: any, prevState: any) {

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -346,7 +346,7 @@ class NonEmptyPileupTrack extends React.Component {
        .data(vReads, vRead => vRead.key);
 
     // Enter
-    var readsG = reads.enter()
+    reads.enter()
         .append('g')
         .attr('class', readClass)
         .attr('transform', vRead => `translate(0, ${yForRow(vRead.row)})`)
@@ -373,7 +373,6 @@ class NonEmptyPileupTrack extends React.Component {
     var pxPerLetter = scale(1) - scale(0),
         mode = DisplayMode.getDisplayMode(pxPerLetter),
         showText = DisplayMode.isText(mode),
-        modeData = [mode],
         modeWrapper = reads.selectAll('.mode-wrapper')
                            .data(vRead => vRead.mismatches.length ? [{vRead,mode}] : [],
                                  x => x.mode);

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -274,13 +274,7 @@ class NonEmptyPileupTrack extends React.Component {
   }
 
   getScale() {
-    var range = this.props.range,
-        width = this.state.width,
-        offsetPx = range.offsetPx || 0;
-    var scale = d3.scale.linear()
-            .domain([range.start, range.stop + 1])  // 1 bp wide
-            .range([-offsetPx, width - offsetPx]);
-    return scale;
+    return utils.getTrackScale(this.props.range, this.state.width);
   }
 
   componentDidUpdate(prevProps: any, prevState: any) {

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -387,7 +387,7 @@ class NonEmptyPileupTrack extends React.Component {
 
     var letter = modeWrapper.selectAll('.basepair')
         .data(d => d.vRead.mismatches, m => m.pos + m.basePair);
-    
+
     letter.enter().append(showText ? 'text' : 'rect')
     if (showText) {
       letter.text(mismatch => mismatch.basePair)

--- a/src/main/d3utils.js
+++ b/src/main/d3utils.js
@@ -1,0 +1,24 @@
+/**
+ * D3/DOM-related utility functions.
+ * @flow
+ */
+'use strict';
+
+var d3 = require('d3'),
+    ContigInterval = require('./ContigInterval');
+
+/**
+ * Shared x-axis scaling logic for tracks
+ */
+function getTrackScale(range: ContigInterval<string>, width: number) {
+  if (!range) return d3.scale.linear();
+  var offsetPx = range.offsetPx || 0;
+  var scale = d3.scale.linear()
+          .domain([range.start, range.stop + 1])  // 1 bp wide
+          .range([-offsetPx, width - offsetPx]);
+  return scale;
+}
+
+module.exports = {
+  getTrackScale
+};

--- a/src/main/d3utils.js
+++ b/src/main/d3utils.js
@@ -4,14 +4,14 @@
  */
 'use strict';
 
-var d3 = require('d3'),
-    types = require('./react-types'),
-    ContigInterval = require('./ContigInterval');
+import type {GenomeRange} from './react-types';
+
+var d3 = require('d3');
 
 /**
  * Shared x-axis scaling logic for tracks
  */
-function getTrackScale(range: types.GenomeRange, width: number) {
+function getTrackScale(range: GenomeRange, width: number) {
   if (!range) return d3.scale.linear();
   var offsetPx = range.offsetPx || 0;
   var scale = d3.scale.linear()

--- a/src/main/d3utils.js
+++ b/src/main/d3utils.js
@@ -5,12 +5,13 @@
 'use strict';
 
 var d3 = require('d3'),
+    types = require('./react-types'),
     ContigInterval = require('./ContigInterval');
 
 /**
  * Shared x-axis scaling logic for tracks
  */
-function getTrackScale(range: ContigInterval<string>, width: number) {
+function getTrackScale(range: types.GenomeRange, width: number) {
   if (!range) return d3.scale.linear();
   var offsetPx = range.offsetPx || 0;
   var scale = d3.scale.linear()

--- a/src/main/pileup.js
+++ b/src/main/pileup.js
@@ -13,6 +13,7 @@ var _ = require('underscore'),
     BamDataSource = require('./BamDataSource'),
     GA4GHDataSource = require('./GA4GHDataSource'),
     // Visualizations
+    CoverageTrack = require('./CoverageTrack'),
     GenomeTrack = require('./GenomeTrack'),
     GeneTrack = require('./GeneTrack'),
     PileupTrack = require('./PileupTrack'),
@@ -86,6 +87,7 @@ var pileup = {
     bigBed: BigBedDataSource.create
   },
   viz: {
+    coverage: () => CoverageTrack,
     genome: () => GenomeTrack,
     genes: () => GeneTrack,
     variants: () => VariantTrack,

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -7,7 +7,9 @@
 import type {InflatedBlock} from './types';
 import type * as Q from 'q';
 
-var pako = require('pako');
+var pako = require('pako'),
+    d3 = require('d3'),
+    types = require('./react-types');
 
 // Compare two tuples of equal length. Is t1 <= t2?
 // TODO: make this tupleLessOrEqual<T> -- it works with strings or booleans, too.
@@ -161,6 +163,18 @@ function pipePromise<T>(deferred: Q.Deferred<T>, promise: Q.Promise<T>) {
   promise.then(deferred.resolve, deferred.reject, deferred.notify);
 }
 
+/**
+ * Shared x-axis scaling logic for tracks
+ */
+function getTrackScale(range: types.GenomeRange, width: number) {
+  if(!range) return d3.scale.linear();
+  var offsetPx = range.offsetPx || 0;
+  var scale = d3.scale.linear()
+          .domain([range.start, range.stop + 1])  // 1 bp wide
+          .range([-offsetPx, width - offsetPx]);
+  return scale;
+}
+
 module.exports = {
   tupleLessOrEqual,
   tupleRangeOverlaps,
@@ -169,5 +183,6 @@ module.exports = {
   inflateGzip,
   basePairClass,
   altContigName,
-  pipePromise
+  pipePromise,
+  getTrackScale
 };

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -7,9 +7,7 @@
 import type {InflatedBlock} from './types';
 import type * as Q from 'q';
 
-var pako = require('pako'),
-    d3 = require('d3'),
-    ContigInterval = require('./ContigInterval');
+var pako = require('pako');
 
 // Compare two tuples of equal length. Is t1 <= t2?
 // TODO: make this tupleLessOrEqual<T> -- it works with strings or booleans, too.

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -163,18 +163,6 @@ function pipePromise<T>(deferred: Q.Deferred<T>, promise: Q.Promise<T>) {
   promise.then(deferred.resolve, deferred.reject, deferred.notify);
 }
 
-/**
- * Shared x-axis scaling logic for tracks
- */
-function getTrackScale(range: ContigInterval<string>, width: number) {
-  if(!range) return d3.scale.linear();
-  var offsetPx = range.offsetPx || 0;
-  var scale = d3.scale.linear()
-          .domain([range.start, range.stop + 1])  // 1 bp wide
-          .range([-offsetPx, width - offsetPx]);
-  return scale;
-}
-
 module.exports = {
   tupleLessOrEqual,
   tupleRangeOverlaps,
@@ -184,5 +172,4 @@ module.exports = {
   basePairClass,
   altContigName,
   pipePromise,
-  getTrackScale
 };

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -9,7 +9,7 @@ import type * as Q from 'q';
 
 var pako = require('pako'),
     d3 = require('d3'),
-    types = require('./react-types');
+    ContigInterval = require('./ContigInterval');
 
 // Compare two tuples of equal length. Is t1 <= t2?
 // TODO: make this tupleLessOrEqual<T> -- it works with strings or booleans, too.
@@ -166,7 +166,7 @@ function pipePromise<T>(deferred: Q.Deferred<T>, promise: Q.Promise<T>) {
 /**
  * Shared x-axis scaling logic for tracks
  */
-function getTrackScale(range: types.GenomeRange, width: number) {
+function getTrackScale(range: ContigInterval<string>, width: number) {
   if(!range) return d3.scale.linear();
   var offsetPx = range.offsetPx || 0;
   var scale = d3.scale.linear()

--- a/src/test/CoverageTrack-test.js
+++ b/src/test/CoverageTrack-test.js
@@ -86,8 +86,10 @@ describe('CoverageTrack', function() {
     testSetup();
     return waitFor(hasCoverage, 2000).then(() => {
       var labelTexts = testDiv.querySelectorAll('.coverage .y-axis text');
-      expect(labelTexts[0].innerHTML).to.equal('0X');
-      expect(labelTexts[labelTexts.length-1].innerHTML).to.equal('50X');
+      expect(labelTexts[0].textContent).to.equal('0X');
+      if(labelTexts.length > 1) {  // headless mode only draws a single label
+        expect(labelTexts[labelTexts.length-1].textContent).to.equal('50X');
+      }
     });
   });
 

--- a/src/test/CoverageTrack-test.js
+++ b/src/test/CoverageTrack-test.js
@@ -26,8 +26,6 @@ var pileup = require('../main/pileup'),
 describe('CoverageTrack', function() {
   var testDiv = document.getElementById('testdiv');
 
-  var testDiv = document.getElementById('testdiv');
-
   beforeEach(() => {
     // A fixed width container results in predictable x-positions for mismatches.
     testDiv.style.width = '800px';
@@ -42,10 +40,6 @@ describe('CoverageTrack', function() {
   var twoBitFile = new MappedRemoteFile('/test-data/hg19.chr17.7500000-7501000.2bit.mapped',
                             [[0, 16383], [691179834, 691183928], [694008946, 694009197]]),
       referenceSource = TwoBitDataSource.createFromTwoBitFile(new TwoBit(twoBitFile));
-
-  var findCoverageBins = () => {
-      return testDiv.querySelectorAll('.coverage .covbin');
-  };
 
   var findCoverageBins = () => {
       return testDiv.querySelectorAll('.coverage .covbin');

--- a/src/test/CoverageTrack-test.js
+++ b/src/test/CoverageTrack-test.js
@@ -31,7 +31,25 @@ describe('CoverageTrack', function() {
   beforeEach(() => {
     // A fixed width container results in predictable x-positions for mismatches.
     testDiv.style.width = '800px';
-    testSetup();
+    var p = pileup.create(testDiv, {
+      range: range,
+      tracks: [
+        {
+          data: referenceSource,
+          viz: pileup.viz.genome(),
+          isReference: true
+        },
+        {
+          viz: pileup.viz.coverage(),
+          data: pileup.formats.bam({
+            url: '/test-data/synth3.normal.17.7500000-7515000.bam',
+            indexUrl: '/test-data/synth3.normal.17.7500000-7515000.bam.bai'
+          }),
+          cssClass: 'tumor-coverage',
+          name: 'Coverage'
+        }
+      ]
+    });
   });
 
   afterEach(() => {
@@ -55,28 +73,6 @@ describe('CoverageTrack', function() {
   var hasCoverage = () => {
     // Check whether the coverage bins are loaded yet
     return findCoverageBins().length > 1 && findCoverageLabels().length > 1;
-  };
-
-  var testSetup = () => {
-    var p = pileup.create(testDiv, {
-      range: range,
-      tracks: [
-        {
-          data: referenceSource,
-          viz: pileup.viz.genome(),
-          isReference: true
-        },
-        {
-          viz: pileup.viz.coverage(),
-          data: pileup.formats.bam({
-            url: '/test-data/synth3.normal.17.7500000-7515000.bam',
-            indexUrl: '/test-data/synth3.normal.17.7500000-7515000.bam.bai'
-          }),
-          cssClass: 'tumor-coverage',
-          name: 'Coverage'
-        }
-      ]
-    });
   };
 
   it('should create coverage information for all bases shown in the view', function() {

--- a/src/test/CoverageTrack-test.js
+++ b/src/test/CoverageTrack-test.js
@@ -1,0 +1,100 @@
+/**
+ * This tests that pileup mismatches are rendered correctly, regardless of the
+ * order in which the alignment and reference data come off the network.
+ * @flow
+ */
+'use strict';
+
+var expect = require('chai').expect;
+
+var Q = require('q'),
+    _ = require('underscore'),
+    d3 = require('d3');
+
+import type * as SamRead from '../main/SamRead';
+
+var pileup = require('../main/pileup'),
+    TwoBit = require('../main/TwoBit'),
+    TwoBitDataSource = require('../main/TwoBitDataSource'),
+    Bam = require('../main/bam'),
+    BamDataSource = require('../main/BamDataSource'),
+    RemoteFile = require('../main/RemoteFile'),
+    MappedRemoteFile = require('./MappedRemoteFile'),
+    ContigInterval = require('../main/ContigInterval'),
+    {waitFor} = require('./async');
+
+describe('CoverageTrack', function() {
+  var testDiv = document.getElementById('testdiv');
+
+  var testDiv = document.getElementById('testdiv');
+
+  beforeEach(() => {
+    // A fixed width container results in predictable x-positions for mismatches.
+    testDiv.style.width = '800px';
+  });
+
+  afterEach(() => {
+    // avoid pollution between tests.
+    testDiv.innerHTML = '';
+    testDiv.style.width = '';
+  });
+
+  var twoBitFile = new MappedRemoteFile('/test-data/hg19.chr17.7500000-7501000.2bit.mapped',
+                            [[0, 16383], [691179834, 691183928], [694008946, 694009197]]),
+      referenceSource = TwoBitDataSource.createFromTwoBitFile(new TwoBit(twoBitFile));
+
+  var findCoverageBins = () => {
+      return testDiv.querySelectorAll('.coverage .covbin');
+  };
+
+  var findCoverageBins = () => {
+      return testDiv.querySelectorAll('.coverage .covbin');
+  };
+
+  var hasCoverage = () => {
+    // Check whether the coverage bins are loaded yet
+    return findCoverageBins().length > 0;
+  };
+
+  var testSetup = () => {
+    var range = {contig: '17', start: 7500730, stop: 7500790};
+    var p = pileup.create(testDiv, {
+      range: range,
+      tracks: [
+        {
+          data: referenceSource,
+          viz: pileup.viz.genome(),
+          isReference: true
+        },
+        {
+          viz: pileup.viz.coverage(),
+          data: pileup.formats.bam({
+            url: '/test-data/synth3.normal.17.7500000-7515000.bam',
+            indexUrl: '/test-data/synth3.normal.17.7500000-7515000.bam.bai'
+          }),
+          cssClass: 'tumor-coverage',
+          name: 'Coverage'
+        }
+      ]
+    });
+    return range;
+  };
+
+  it('should create coverage information for all bases shown in the view', function() {
+    var range = testSetup();
+    return waitFor(hasCoverage, 2000).then(() => {
+      var bins = findCoverageBins();
+      expect(bins).to.have.length.above(range.stop - range.start + 1);
+    });
+  });
+
+  it('should create correct labels for coverage', function() {
+    testSetup();
+    return waitFor(hasCoverage, 2000).then(() => {
+      var labelTexts = testDiv.querySelectorAll('.coverage .y-axis text');
+      expect(labelTexts[0].innerHTML).to.equal('0X');
+      expect(labelTexts[labelTexts.length-1].innerHTML).to.equal('50X');
+    });
+  });
+
+});

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -167,8 +167,7 @@
 .coverage rect.covbin {
   stroke-width: 0.1;
   stroke: white;
-  fill: gray;
-  opacity: 0.7;
+  fill: #c8c8c8;
 }
 .coverage .y-axis {
   stroke: black;

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -177,6 +177,9 @@
   color: black;
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: x-small;
+  stroke: whitesmoke;
+  stroke-width: 2;
+  paint-order: stroke;
 }
 .coverage .y-axis path {
   stroke-width: 0;

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -171,13 +171,18 @@
   opacity: 0.7;
 }
 .coverage .y-axis {
-  fill: white;
   stroke: black;
   stroke-width: 1;
-  shapre-rendering: crispEdges;
 }
 .coverage .y-axis g.tick text {
   color: black;
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: x-small;
+}
+.coverage .y-axis path {
+  stroke-width: 0;
+}
+.coverage rect.y-axis-background {
+  fill: white;
+  opacity: 0.5;
 }

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -168,4 +168,16 @@
   stroke-width: 0.1;
   stroke: white;
   fill: gray;
+  opacity: 0.7;
+}
+.coverage .y-axis {
+  fill: white;
+  stroke: black;
+  stroke-width: 1;
+  shapre-rendering: crispEdges;
+}
+.coverage .y-axis g.tick text {
+  color: black;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: x-small;
 }

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -164,7 +164,7 @@
 .pileup-root > .coverage {
   flex: 0 0 50px;  /* fixed height */
 }
-.coverage rect.covbin {
+.coverage rect.bin {
   stroke-width: 0.1;
   stroke: white;
   fill: #c8c8c8;

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -159,3 +159,13 @@
   fill: #ddd;
   stroke: blue;
 }
+
+/* coverage track */
+.pileup-root > .coverage {
+  flex: 0 0 50px;  /* fixed height */
+}
+.coverage rect.covbin {
+  stroke-width: 0.1;
+  stroke: white;
+  fill: gray;
+}

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -167,7 +167,7 @@
 .coverage rect.bin {
   stroke-width: 0.1;
   stroke: white;
-  fill: #c8c8c8;
+  fill: #a0a0a0;
 }
 .coverage .y-axis {
   stroke: black;


### PR DESCRIPTION
This is a new track implementation that uses BAM format as input and plots a histogram-like graph that shows how many reads overlap with each nucleotide within the visible range. If the range changes (zoom in/out or panning), it adjusts the size of the bars and the information shown on the Y axis accordingly.

![screen shot 2015-07-10 at 6 21 40 pm](https://cloud.githubusercontent.com/assets/7809/8630263/7db04b56-2731-11e5-9aac-15a40b807e0a.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/229)
<!-- Reviewable:end -->
