### PR TITLE
GA4GH data source

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -3,3 +3,4 @@ declare function it(expectation: string, assertion: (done: () => void) => void):
 declare function beforeEach(fn: () => void): void;
 declare function afterEach(fn: () => void): void;
 declare function before(fn: () => void): void;
+declare function after(fn: () => void): void;

--- a/src/main/Alignment.js
+++ b/src/main/Alignment.js
@@ -5,6 +5,8 @@
 
 import type * as ContigInterval from './ContigInterval';
 
+// "CIGAR" operations express how a sequence aligns to the reference: does it
+// have insertions? deletions? For more background, see the SAM/BAM paper.
 export type CigarOp = {
   op: string;  // M, I, D, N, S, H, P, =, X
   length: number

--- a/src/main/Alignment.js
+++ b/src/main/Alignment.js
@@ -1,0 +1,24 @@
+/**
+ * Interface for alignments, shared between BAM and GA4GH backends.
+ * @flow
+ */
+
+import type * as ContigInterval from './ContigInterval';
+
+export type CigarOp = {
+  op: string;  // M, I, D, N, S, H, P, =, X
+  length: number
+}
+
+export type Alignment = {
+  pos: number;
+  ref: string;
+
+  getKey(): string;
+  getName(): string;
+  getStrand(): string;
+  getCigarOps(): CigarOp[];
+  getQualityScores(): number[];
+  getSequence(): string;
+  getInterval: ContigInterval<string>;
+};

--- a/src/main/Alignment.js
+++ b/src/main/Alignment.js
@@ -22,3 +22,10 @@ export type Alignment = {
   getSequence(): string;
   getInterval: ContigInterval<string>;
 };
+
+export type AlignmentDataSource = {
+  rangeChanged: (newRange: GenomeRange) => void;
+  getAlignmentsInRange: (range: ContigInterval<string>) => Alignment[];
+  on: (event: string, handler: Function) => void;
+  off: (event: string) => void;
+};

--- a/src/main/BamDataSource.js
+++ b/src/main/BamDataSource.js
@@ -9,11 +9,11 @@ var ContigInterval = require('./ContigInterval'),
     BamFile = require('./bam'),
     RemoteFile = require('./RemoteFile');
 
-import type * as SamRead from './SamRead';
+import type {Alignment} from './Alignment';
 
 type BamDataSource = {
   rangeChanged: (newRange: GenomeRange) => void;
-  getAlignmentsInRange: (range: ContigInterval<string>) => SamRead[];
+  getAlignmentsInRange: (range: ContigInterval<string>) => Alignment[];
   on: (event: string, handler: Function) => void;
   off: (event: string) => void;
   trigger: (event: string, ...args:any) => void;
@@ -35,7 +35,7 @@ function expandRange(range: ContigInterval<string>) {
 
 function createFromBamFile(remoteSource: BamFile): BamDataSource {
   // Keys are virtualOffset.toString()
-  var reads: {[key:string]: SamRead} = {};
+  var reads: {[key:string]: Alignment} = {};
 
   // Mapping from contig name to canonical contig name.
   var contigNames: {[key:string]: string} = {};
@@ -43,8 +43,8 @@ function createFromBamFile(remoteSource: BamFile): BamDataSource {
   // Ranges for which we have complete information -- no need to hit network.
   var coveredRanges: ContigInterval<string>[] = [];
 
-  function addRead(read: SamRead) {
-    var key = read.offset.toString();
+  function addRead(read: Alignment) {
+    var key = read.getKey();
     if (!reads[key]) {
       reads[key] = read;
     }
@@ -99,7 +99,7 @@ function createFromBamFile(remoteSource: BamFile): BamDataSource {
     });
   }
 
-  function getAlignmentsInRange(range: ContigInterval<string>): SamRead[] {
+  function getAlignmentsInRange(range: ContigInterval<string>): Alignment[] {
     if (!range) return [];
     if (_.isEmpty(contigNames)) return [];
 

--- a/src/main/BamDataSource.js
+++ b/src/main/BamDataSource.js
@@ -9,15 +9,7 @@ var ContigInterval = require('./ContigInterval'),
     BamFile = require('./bam'),
     RemoteFile = require('./RemoteFile');
 
-import type {Alignment} from './Alignment';
-
-type BamDataSource = {
-  rangeChanged: (newRange: GenomeRange) => void;
-  getAlignmentsInRange: (range: ContigInterval<string>) => Alignment[];
-  on: (event: string, handler: Function) => void;
-  off: (event: string) => void;
-  trigger: (event: string, ...args:any) => void;
-};
+import type {Alignment, AlignmentDataSource} from './Alignment';
 
 // Genome ranges are rounded to multiples of this for fetching.
 // This reduces network activity while fetching.
@@ -33,8 +25,7 @@ function expandRange(range: ContigInterval<string>) {
 }
 
 
-function createFromBamFile(remoteSource: BamFile): BamDataSource {
-  // Keys are virtualOffset.toString()
+function createFromBamFile(remoteSource: BamFile): AlignmentDataSource {
   var reads: {[key:string]: Alignment} = {};
 
   // Mapping from contig name to canonical contig name.
@@ -133,7 +124,7 @@ type BamSpec = {
   indexChunks?: Object;
 }
 
-function create(spec: BamSpec): BamDataSource {
+function create(spec: BamSpec): AlignmentDataSource {
   var url = spec.url;
   if (!url) {
     throw new Error(`Missing URL from track data: ${JSON.stringify(spec)}`);

--- a/src/main/GA4GHAlignment.js
+++ b/src/main/GA4GHAlignment.js
@@ -1,0 +1,93 @@
+/**
+ * This serves as a bridge between org.ga4gh.GAReadAlignment and the
+ * pileup.js Alignment type.
+ * @flow
+ */
+
+import type {CigarOp} from './Alignment';
+
+var ContigInterval = require('./ContigInterval'),
+    SamRead = require('./SamRead');
+
+// See https://github.com/ga4gh/schemas/blob/v0.5.1/src/main/resources/avro/common.avdl
+var OP_MAP = {
+  ALIGNMENT_MATCH: 'M',
+  INSERT: 'I',
+  DELETE: 'D',
+  SKIP: 'N',
+  CLIP_SOFT: 'S',
+  CLIP_HARD: 'H',
+  PAD: 'P',
+  SEQUENCE_MATCH: '=',
+  SEQUENCE_MISMATCH: 'X'
+};
+
+/**
+ * This class acts as a bridge between org.ga4gh.GAReadAlignment and the
+ * pileup.js Alignment type.
+ */
+class GA4GHAlignment /* implements Alignment */ {
+  pos: number;
+  ref: string;
+  alignment: Object;
+  _cigarOps: CigarOp[];
+  _interval: ContigInterval<string>;
+
+  // alignment follows org.ga4gh.GAReadAlignment
+  // https://github.com/ga4gh/schemas/blob/v0.5.1/src/main/resources/avro/reads.avdl
+  constructor(alignment: Object) {
+    this.alignment = alignment;
+    this.pos = alignment.alignment.position.position;
+    this.ref = alignment.alignment.position.referenceName;
+
+    this._cigarOps = alignment.alignment.cigar.map(
+        ({operation, operationLength: length}) => ({ op: OP_MAP[operation], length }));
+    this._interval = new ContigInterval(this.ref,
+                                        this.pos,
+                                        this.pos + this.getReferenceLength() - 1);
+  }
+
+  getKey(): string {
+    return GA4GHAlignment.keyFromGA4GHResponse(this.alignment);
+  }
+
+  getName(): string {
+    return this.alignment.fragmentName;
+  }
+
+  getStrand(): string {
+    return this.alignment.alignment.position.reverseStrand ? '-' : '+';
+  }
+
+  getCigarOps(): CigarOp[] {
+    return this._cigarOps;
+  }
+
+  getQualityScores(): number[] {
+    return this.alignment.alignedQuality;
+  }
+
+  getSequence(): string {
+    return this.alignment.alignedSequence;
+  }
+
+  getInterval(): ContigInterval<string> {
+    return this._interval;
+  }
+
+  intersects(interval: ContigInterval<string>): boolean {
+    return interval.intersects(this.getInterval());
+  }
+
+  getReferenceLength(): number {
+    return SamRead.referenceLengthFromOps(this.getCigarOps());
+  }
+
+  // This is exposed as a static method to facilitate an optimization in GA4GHDataSource.
+  static keyFromGA4GHResponse(alignment: Object): string {
+    // this.alignment.id would be appealing here, but it's not actually unique!
+    return alignment.fragmentName + ':' + alignment.readNumber;
+  }
+};
+
+module.exports = GA4GHAlignment;

--- a/src/main/GA4GHDataSource.js
+++ b/src/main/GA4GHDataSource.js
@@ -1,0 +1,153 @@
+/**
+ * A data source which implements the GA4GH protocol.
+ * Currently only used to load alignments.
+ * @flow
+ */
+
+import type {Alignment, AlignmentDataSource} from './Alignment';
+
+var Events = require('backbone').Events,
+    _ = require('underscore'),
+    Q = require('q');
+
+var ContigInterval = require('./ContigInterval'),
+    SamRead = require('./SamRead'),
+    GA4GHAlignment = require('./GA4GHAlignment');
+
+var ALIGNMENTS_PER_REQUEST = 200;  // TODO: explain this choice.
+
+
+// Genome ranges are rounded to multiples of this for fetching.
+// This reduces network activity while fetching.
+// TODO: tune this value -- setting it close to the read length will result in
+// lots of reads being fetched twice, but setting it too large will result in
+// bulkier requests.
+var BASE_PAIRS_PER_FETCH = 100;
+
+function expandRange(range: ContigInterval<string>) {
+  var roundDown = x => x - x % BASE_PAIRS_PER_FETCH;
+  var newStart = Math.max(1, roundDown(range.start())),
+      newStop = roundDown(range.stop() + BASE_PAIRS_PER_FETCH - 1);
+
+  return new ContigInterval(range.contig, newStart, newStop);
+}
+
+type GA4GHSpec = {
+  endpoint: string;
+  readGroupId: string;
+  // HACK if set, strips "chr" from reference names.
+  // See https://github.com/ga4gh/schemas/issues/362
+  killChr: boolean;
+};
+
+function create(spec: GA4GHSpec): AlignmentDataSource {
+  if (spec.endpoint.slice(-6) != 'v0.5.1') {
+    throw new Error('Only v0.5.1 of the GA4GH API is supported by pileup.js');
+  }
+
+  var url = spec.endpoint + '/reads/search';
+
+  var reads: {[key:string]: GA4GHAlignment} = {};
+
+  // Ranges for which we have complete information -- no need to hit network.
+  var coveredRanges: ContigInterval<string>[] = [];
+
+  function addReadsFromResponse(response: Object) {
+    response.alignments.forEach(alignment => {
+      // optimization: don't bother constructing a GA4GHAlignment unless it's new.
+      var key = GA4GHAlignment.keyFromGA4GHResponse(alignment);
+      if (key in reads) return;
+
+      var ga4ghAlignment = new GA4GHAlignment(alignment);
+      reads[key] = ga4ghAlignment;
+    });
+  }
+
+  function rangeChanged(newRange: GenomeRange) {
+    // HACK FOR DEMO
+    var contig = spec.killChr ? newRange.contig.replace(/^chr/, '') : newRange.contig;
+    var interval = new ContigInterval(contig, newRange.start, newRange.stop);
+    if (interval.isCoveredBy(coveredRanges)) return;
+
+    interval = expandRange(interval);
+
+    // We "cover" the interval immediately (before the reads have arrived) to
+    // prevent duplicate network requests.
+    coveredRanges.push(interval);
+    coveredRanges = ContigInterval.coalesce(coveredRanges);
+    fetchAlignmentsForInterval(interval, null, 1 /* first request */);
+  }
+
+  function notifyFailure(message: string) {
+    o.trigger('networkfailure', message);
+    o.trigger('networkdone');
+    console.warn(message);
+  }
+
+  function fetchAlignmentsForInterval(range: ContigInterval<string>,
+                                      pageToken: ?string,
+                                      numRequests: number) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('POST', url);
+    xhr.responseType = 'json';
+    xhr.setRequestHeader('Content-Type', 'application/json');
+
+    xhr.addEventListener('load', function(e) {
+      var response = this.response;
+      if (this.status >= 400) {
+        notifyFailure(this.status + ' ' + this.statusText + ' ' + JSON.stringify(response));
+      } else {
+        if (response.errorCode) {
+          notifyFailure('Error from GA4GH endpoint: ' + JSON.stringify(response));
+        } else {
+          addReadsFromResponse(response);
+          o.trigger('newdata');  // display data as it comes in.
+          if (response.nextPageToken) {
+            fetchAlignmentsForInterval(range, response.nextPageToken, numRequests + 1);
+          } else {
+            o.trigger('networkdone');
+          }
+        }
+      }
+    });
+    xhr.addEventListener('error', function(e) {
+      notifyFailure('Request failed with status: ' + this.status);
+    });
+
+    o.trigger('networkprogress', {numRequests});
+    xhr.send(JSON.stringify({
+      pageToken: pageToken,
+      pageSize: ALIGNMENTS_PER_REQUEST,
+      readGroupIds: [spec.readGroupId],
+      referenceName: range.contig,
+      start: range.start(),
+      end: range.stop()
+    }));
+  }
+
+  function getAlignmentsInRange(range: ContigInterval<string>): Alignment[] {
+    if (!range) return [];
+
+    // HACK FOR DEMO
+    if (spec.killChr) {
+      range = new ContigInterval(range.contig.replace(/^chr/, ''), range.start(), range.stop());
+    }
+    return _.filter(reads, read => read.intersects(range));
+  }
+
+  var o = {
+    rangeChanged,
+    getAlignmentsInRange,
+
+    // These are here to make Flow happy.
+    on: () => {},
+    off: () => {},
+    trigger: () => {}
+  };
+  _.extend(o, Events);  // Make this an event emitter
+  return o;
+}
+
+module.exports = {
+  create
+};

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -292,16 +292,14 @@ class NonEmptyPileupTrack extends React.Component {
 
   // Attach visualization info to the read and cache it.
   addRead(read: SamRead, referenceSource): VisualAlignment {
-    var k = read.offset.toString();
-    if (k in this.keyToVisualAlignment) {
-      return this.keyToVisualAlignment[k];
+    var key = read.getKey();
+    if (key in this.keyToVisualAlignment) {
+      return this.keyToVisualAlignment[key];
     }
 
-    var refLength = read.getReferenceLength();
-    var range = read.getInterval();
-    var key = read.offset.toString();
-
-    var opInfo = getOpInfo(read, referenceSource);
+    var range = read.getInterval(),
+        refLength = range.length(),
+        opInfo = getOpInfo(read, referenceSource);
 
     var visualAlignment = {
       key,
@@ -313,7 +311,7 @@ class NonEmptyPileupTrack extends React.Component {
       mismatches: opInfo.mismatches
     };
 
-    this.keyToVisualAlignment[k] = visualAlignment;
+    this.keyToVisualAlignment[key] = visualAlignment;
     return visualAlignment;
   }
 

--- a/src/main/SamRead.js
+++ b/src/main/SamRead.js
@@ -110,11 +110,10 @@ class SamRead /* implements Alignment */ {
   }
 
   getInterval(): ContigInterval<string> {
-    if (this._interval) return this._interval;
+    if (this._interval) return this._interval;  // use the cache
     var interval = new ContigInterval(this.ref,
                                       this.pos,
                                       this.pos + this.getReferenceLength() - 1);
-    this._interval;
     return interval;
   }
 

--- a/src/main/pileup.js
+++ b/src/main/pileup.js
@@ -11,6 +11,7 @@ var _ = require('underscore'),
     BigBedDataSource = require('./BigBedDataSource'),
     VcfDataSource = require('./VcfDataSource'),
     BamDataSource = require('./BamDataSource'),
+    GA4GHDataSource = require('./GA4GHDataSource'),
     // Visualizations
     GenomeTrack = require('./GenomeTrack'),
     GeneTrack = require('./GeneTrack'),
@@ -79,6 +80,7 @@ var pileup = {
   create: create,
   formats: {
     bam: BamDataSource.create,
+    ga4gh: GA4GHDataSource.create,
     vcf: VcfDataSource.create,
     twoBit: TwoBitDataSource.create,
     bigBed: BigBedDataSource.create

--- a/src/test/GA4GHAlignment-test.js
+++ b/src/test/GA4GHAlignment-test.js
@@ -1,0 +1,57 @@
+/** @flow */
+
+var expect = require('chai').expect;
+
+var GA4GHAlignment = require('../main/GA4GHAlignment'),
+    RemoteFile = require('../main/RemoteFile'),
+    SamRead = require('../main/SamRead'),
+    Bam = require('../main/bam.js');
+
+describe('GA4GHAlignment', function() {
+  var sampleAlignments = [];
+
+  before(function() {
+    return new RemoteFile('/test-data/chr17.1-250.json').getAllString().then(data => {
+      sampleAlignments = JSON.parse(data).alignments;
+    });
+  });
+
+  it('should read the sample alignments', function() {
+    expect(sampleAlignments).to.have.length(14);
+  });
+
+  it('should provide basic accessors', function() {
+    var a = new GA4GHAlignment(sampleAlignments[0]);
+    expect(a.getName()).to.equal('r000');
+    expect(a.getSequence()).to.equal('ATTTAGCTAC');
+    expect(a.getQualityScores()).to.deep.equal([32,32,32,32,32,32,32,32,32,32]);
+    expect(a.getStrand()).to.equal('+');
+    expect(a.getInterval().toString()).to.equal('chr17:4-13');  // 0-based
+    expect(a.getCigarOps()).to.deep.equal([
+      {op: 'M', length: 10}
+    ]);
+  });
+
+  it('should match SamRead', function() {
+    var bam = new Bam(new RemoteFile('/test-data/chr17.1-250.bam'));
+    return bam.readAll().then(({alignments: samReads}) => {
+      // This is a workaround. See https://github.com/ga4gh/server/issues/488
+      samReads.splice(-1, 1);
+
+      expect(sampleAlignments.length).to.equal(samReads.length);
+      for (var i = 0; i < sampleAlignments.length; i++) {
+        var ga4gh = new GA4GHAlignment(sampleAlignments[i]),
+            bam = samReads[i];
+        expect(ga4gh.getSequence()).to.equal(bam.getSequence());
+        // See https://github.com/ga4gh/server/issues/491
+        // expect(ga4gh.getStrand()).to.equal(bam.getStrand());
+        // For the if statement, see https://github.com/ga4gh/server/issues/492
+        var quality = ga4gh.getQualityScores();
+        if (quality.length) {
+          expect(quality).to.deep.equal(bam.getQualityScores());
+        }
+        expect(ga4gh.getCigarOps()).to.deep.equal(bam.getCigarOps());
+      }
+    });
+  });
+});

--- a/src/test/GA4GHAlignment-test.js
+++ b/src/test/GA4GHAlignment-test.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 var GA4GHAlignment = require('../main/GA4GHAlignment'),
     RemoteFile = require('../main/RemoteFile'),
     SamRead = require('../main/SamRead'),
-    Bam = require('../main/bam.js');
+    Bam = require('../main/bam');
 
 describe('GA4GHAlignment', function() {
   var sampleAlignments = [];

--- a/src/test/GA4GHDataSource-test.js
+++ b/src/test/GA4GHDataSource-test.js
@@ -1,0 +1,54 @@
+/** @flow */
+
+var expect = require('chai').expect;
+
+var sinon = require('sinon');
+
+var ContigInterval = require('../main/ContigInterval'),
+    GA4GHDataSource = require('../main/GA4GHDataSource'),
+    RemoteFile = require('../main/RemoteFile'),
+    SamRead = require('../main/SamRead'),
+    Bam = require('../main/bam');
+
+describe('GA4GHDataSource', function() {
+  var server: any = null, response;
+
+  before(function () {
+    return new RemoteFile('/test-data/chr17.1-250.json').getAllString().then(data => {
+      response = data;
+      server = sinon.fakeServer.create();  // _after_ we do a real XHR!
+    });
+  });
+
+  after(function () {
+    server.restore();
+  });
+
+  it('should fetch alignments from a server', function(done) {
+    server.respondWith('POST', '/v0.5.1/reads/search',
+                       [200, { "Content-Type": "application/json" }, response]);
+
+    var source = GA4GHDataSource.create({
+      endpoint: '/v0.5.1',
+      readGroupId: 'some-group-set:some-read-group',
+      killChr: false
+    });
+
+    var requestInterval = new ContigInterval('chr17', 10, 20);
+    expect(source.getAlignmentsInRange(requestInterval))
+        .to.deep.equal([]);
+
+    var progress = [];
+    source.on('networkprogress', e => { progress.push(e); });
+    source.on('networkdone', e => { progress.push('done'); });
+    source.on('newdata', () => {
+      var reads = source.getAlignmentsInRange(requestInterval);
+      expect(reads).to.have.length(1);
+      done();
+    });
+
+    source.rangeChanged({contig: 'chr17', start: 1, stop: 30});
+    server.respond();
+  });
+
+});

--- a/test-data/README.md
+++ b/test-data/README.md
@@ -52,10 +52,14 @@ This is a subset of `ensembl.chr17.bb`, shifted to match the coordinates in
 These BAM and BAI files come from the [samtools][1] tests. You can find
 corresponding SAM files for them in the same repo.
 
-#### chr17.1-250.bam
+#### chr17.1-250.bam, chr17.1-250.json
 
 This was hand-edited from the SAM equivalent of `test_input_1_a.bam` to have
 reads in chr17:1-250. It was then converted back to BAM/BAI using `samtools view`.
+
+The JSON variant was formed by loading `chr17.1-250.bam` into v0.5.1 of the [GA4GH demo server][ga4gh] and querying for all the reads via:
+
+    curl --data '{"readGroupIds":["pileup.js:chr17.1-250"]}' --header 'Content-Type: application/json' http://localhost:8000/v0.5.1/reads/search > chr17.1-250.json
 
 #### index_test.bam
 
@@ -72,3 +76,4 @@ BAI files have been reduced to a small portion of the originals using
 [1]: https://github.com/samtools/samtools/tree/develop/test/dat
 [2]: https://github.com/samtools/htsjdk/blob/afecd5fa959087d5bdd5d5a701e415a72d629282/testdata/htsjdk/samtools/BAMFileIndexTest/index_test.bam
 [3]: https://www.synapse.org/#%21Synapse:syn312572
+[ga4gh]: http://ga4gh-reference-implementation.readthedocs.org/en/stable/index.html

--- a/test-data/chr17.1-250.json
+++ b/test-data/chr17.1-250.json
@@ -1,0 +1,811 @@
+{
+  "nextPageToken": null,
+  "alignments": [
+    {
+      "info": {
+        "RG": [
+          "cow"
+        ],
+        "PG": [
+          "bull"
+        ]
+      },
+      "duplicateFragment": false,
+      "alignedQuality": [
+        32,
+        32,
+        32,
+        32,
+        32,
+        32,
+        32,
+        32,
+        32,
+        32
+      ],
+      "failedVendorQualityChecks": false,
+      "fragmentName": "r000",
+      "readNumber": 0,
+      "properPlacement": true,
+      "nextMatePosition": {
+        "position": 79,
+        "reverseStrand": false,
+        "referenceName": "chr17"
+      },
+      "supplementaryAlignment": false,
+      "numberReads": 2,
+      "fragmentLength": 30,
+      "secondaryAlignment": false,
+      "alignedSequence": "ATTTAGCTAC",
+      "id": "pileup.js:chr17.1-250:r000",
+      "alignment": {
+        "position": {
+          "position": 4,
+          "reverseStrand": false,
+          "referenceName": "chr17"
+        },
+        "cigar": [
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 10
+          }
+        ],
+        "mappingQuality": 30
+      },
+      "readGroupId": "pileup.js:chr17.1-250"
+    },
+    {
+      "info": {
+        "RG": [
+          "cow"
+        ],
+        "PG": [
+          "bull"
+        ]
+      },
+      "duplicateFragment": false,
+      "alignedQuality": [
+        32,
+        32,
+        32,
+        32,
+        32,
+        32,
+        32,
+        32,
+        32,
+        32
+      ],
+      "failedVendorQualityChecks": false,
+      "fragmentName": "r000",
+      "readNumber": 0,
+      "properPlacement": true,
+      "nextMatePosition": {
+        "position": 49,
+        "reverseStrand": false,
+        "referenceName": "chr17"
+      },
+      "supplementaryAlignment": false,
+      "numberReads": 2,
+      "fragmentLength": -30,
+      "secondaryAlignment": false,
+      "alignedSequence": "CCCAATCATT",
+      "id": "pileup.js:chr17.1-250:r000",
+      "alignment": {
+        "position": {
+          "position": 19,
+          "reverseStrand": false,
+          "referenceName": "chr17"
+        },
+        "cigar": [
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 10
+          }
+        ],
+        "mappingQuality": 30
+      },
+      "readGroupId": "pileup.js:chr17.1-250"
+    },
+    {
+      "info": {
+        "YY": [
+          "100"
+        ],
+        "XX": [
+          "[12561, 2, 20, 112]"
+        ],
+        "RG": [
+          "fish"
+        ],
+        "PG": [
+          "colt"
+        ]
+      },
+      "duplicateFragment": false,
+      "alignedQuality": [],
+      "failedVendorQualityChecks": false,
+      "fragmentName": "r001",
+      "readNumber": 1,
+      "properPlacement": true,
+      "nextMatePosition": {
+        "position": 36,
+        "reverseStrand": false,
+        "referenceName": "chr17"
+      },
+      "supplementaryAlignment": false,
+      "numberReads": 2,
+      "fragmentLength": 39,
+      "secondaryAlignment": false,
+      "alignedSequence": "TTAGATAAAGAGGATACTG",
+      "id": "pileup.js:chr17.1-250:r001",
+      "alignment": {
+        "position": {
+          "position": 24,
+          "reverseStrand": false,
+          "referenceName": "chr17"
+        },
+        "cigar": [
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 8
+          },
+          {
+            "referenceSequence": null,
+            "operation": "INSERT",
+            "operationLength": 4
+          },
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 4
+          },
+          {
+            "referenceSequence": null,
+            "operation": "DELETE",
+            "operationLength": 1
+          },
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 3
+          }
+        ],
+        "mappingQuality": 30
+      },
+      "readGroupId": "pileup.js:chr17.1-250"
+    },
+    {
+      "info": {
+        "XB": [
+          "-10"
+        ],
+        "XA": [
+          "abc"
+        ],
+        "PG": [
+          "colt"
+        ]
+      },
+      "duplicateFragment": false,
+      "alignedQuality": [],
+      "failedVendorQualityChecks": false,
+      "fragmentName": "r002",
+      "readNumber": null,
+      "properPlacement": false,
+      "nextMatePosition": null,
+      "supplementaryAlignment": false,
+      "numberReads": null,
+      "fragmentLength": 0,
+      "secondaryAlignment": false,
+      "alignedSequence": "AAAAGATAAGGGATAAA",
+      "id": "pileup.js:chr17.1-250:r002",
+      "alignment": {
+        "position": {
+          "position": 34,
+          "reverseStrand": false,
+          "referenceName": "chr17"
+        },
+        "cigar": [
+          {
+            "referenceSequence": null,
+            "operation": "CLIP_SOFT",
+            "operationLength": 1
+          },
+          {
+            "referenceSequence": null,
+            "operation": "INSERT",
+            "operationLength": 2
+          },
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 6
+          },
+          {
+            "referenceSequence": null,
+            "operation": "PAD",
+            "operationLength": 1
+          },
+          {
+            "referenceSequence": null,
+            "operation": "INSERT",
+            "operationLength": 1
+          },
+          {
+            "referenceSequence": null,
+            "operation": "PAD",
+            "operationLength": 1
+          },
+          {
+            "referenceSequence": null,
+            "operation": "INSERT",
+            "operationLength": 1
+          },
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 4
+          },
+          {
+            "referenceSequence": null,
+            "operation": "INSERT",
+            "operationLength": 2
+          }
+        ],
+        "mappingQuality": 30
+      },
+      "readGroupId": "pileup.js:chr17.1-250"
+    },
+    {
+      "info": {
+        "RG": [
+          "cow"
+        ]
+      },
+      "duplicateFragment": false,
+      "alignedQuality": [],
+      "failedVendorQualityChecks": false,
+      "fragmentName": "r003",
+      "readNumber": null,
+      "properPlacement": false,
+      "nextMatePosition": null,
+      "supplementaryAlignment": false,
+      "numberReads": null,
+      "fragmentLength": 0,
+      "secondaryAlignment": false,
+      "alignedSequence": "AGCTAA",
+      "id": "pileup.js:chr17.1-250:r003",
+      "alignment": {
+        "position": {
+          "position": 44,
+          "reverseStrand": false,
+          "referenceName": "chr17"
+        },
+        "cigar": [
+          {
+            "referenceSequence": null,
+            "operation": "CLIP_HARD",
+            "operationLength": 5
+          },
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 6
+          }
+        ],
+        "mappingQuality": 30
+      },
+      "readGroupId": "pileup.js:chr17.1-250"
+    },
+    {
+      "info": {
+        "RG": [
+          "colt"
+        ],
+        "PG": [
+          "colt"
+        ]
+      },
+      "duplicateFragment": false,
+      "alignedQuality": [],
+      "failedVendorQualityChecks": false,
+      "fragmentName": "r004",
+      "readNumber": null,
+      "properPlacement": false,
+      "nextMatePosition": null,
+      "supplementaryAlignment": false,
+      "numberReads": null,
+      "fragmentLength": 0,
+      "secondaryAlignment": false,
+      "alignedSequence": "ATAGCTCTCAGC",
+      "id": "pileup.js:chr17.1-250:r004",
+      "alignment": {
+        "position": {
+          "position": 55,
+          "reverseStrand": false,
+          "referenceName": "chr17"
+        },
+        "cigar": [
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 6
+          },
+          {
+            "referenceSequence": null,
+            "operation": "SKIP",
+            "operationLength": 14
+          },
+          {
+            "referenceSequence": null,
+            "operation": "INSERT",
+            "operationLength": 1
+          },
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 5
+          }
+        ],
+        "mappingQuality": 30
+      },
+      "readGroupId": "pileup.js:chr17.1-250"
+    },
+    {
+      "info": {
+        "RG": [
+          "cow"
+        ],
+        "PG": [
+          "colt"
+        ]
+      },
+      "duplicateFragment": false,
+      "alignedQuality": [],
+      "failedVendorQualityChecks": false,
+      "fragmentName": "r003",
+      "readNumber": null,
+      "properPlacement": false,
+      "nextMatePosition": null,
+      "supplementaryAlignment": false,
+      "numberReads": null,
+      "fragmentLength": 0,
+      "secondaryAlignment": false,
+      "alignedSequence": "TAGGC",
+      "id": "pileup.js:chr17.1-250:r003",
+      "alignment": {
+        "position": {
+          "position": 68,
+          "reverseStrand": false,
+          "referenceName": "chr17"
+        },
+        "cigar": [
+          {
+            "referenceSequence": null,
+            "operation": "CLIP_HARD",
+            "operationLength": 6
+          },
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 5
+          }
+        ],
+        "mappingQuality": 30
+      },
+      "readGroupId": "pileup.js:chr17.1-250"
+    },
+    {
+      "info": {
+        "RG": [
+          "fish"
+        ],
+        "PG": [
+          "colt"
+        ]
+      },
+      "duplicateFragment": false,
+      "alignedQuality": [],
+      "failedVendorQualityChecks": false,
+      "fragmentName": "r001",
+      "readNumber": 0,
+      "properPlacement": true,
+      "nextMatePosition": {
+        "position": 6,
+        "reverseStrand": false,
+        "referenceName": "chr17"
+      },
+      "supplementaryAlignment": false,
+      "numberReads": 2,
+      "fragmentLength": -39,
+      "secondaryAlignment": false,
+      "alignedSequence": "CAGCGCCAT",
+      "id": "pileup.js:chr17.1-250:r001",
+      "alignment": {
+        "position": {
+          "position": 76,
+          "reverseStrand": false,
+          "referenceName": "chr17"
+        },
+        "cigar": [
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 9
+          }
+        ],
+        "mappingQuality": 30
+      },
+      "readGroupId": "pileup.js:chr17.1-250"
+    },
+    {
+      "info": {
+        "RG": [
+          "colt"
+        ],
+        "PG": [
+          "bull"
+        ]
+      },
+      "duplicateFragment": false,
+      "alignedQuality": [],
+      "failedVendorQualityChecks": false,
+      "fragmentName": "x1",
+      "readNumber": null,
+      "properPlacement": false,
+      "nextMatePosition": null,
+      "supplementaryAlignment": false,
+      "numberReads": null,
+      "fragmentLength": 0,
+      "secondaryAlignment": false,
+      "alignedSequence": "AGGTTTTATAAAACAAATAA",
+      "id": "pileup.js:chr17.1-250:x1",
+      "alignment": {
+        "position": {
+          "position": 79,
+          "reverseStrand": false,
+          "referenceName": "chr17"
+        },
+        "cigar": [
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 20
+          }
+        ],
+        "mappingQuality": 30
+      },
+      "readGroupId": "pileup.js:chr17.1-250"
+    },
+    {
+      "info": {
+        "RG": [
+          "colt"
+        ],
+        "PG": [
+          "bull"
+        ]
+      },
+      "duplicateFragment": false,
+      "alignedQuality": [
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30
+      ],
+      "failedVendorQualityChecks": false,
+      "fragmentName": "x2",
+      "readNumber": null,
+      "properPlacement": false,
+      "nextMatePosition": null,
+      "supplementaryAlignment": false,
+      "numberReads": null,
+      "fragmentLength": 0,
+      "secondaryAlignment": false,
+      "alignedSequence": "GGTTTTATAAAACAAATAATT",
+      "id": "pileup.js:chr17.1-250:x2",
+      "alignment": {
+        "position": {
+          "position": 90,
+          "reverseStrand": false,
+          "referenceName": "chr17"
+        },
+        "cigar": [
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 21
+          }
+        ],
+        "mappingQuality": 30
+      },
+      "readGroupId": "pileup.js:chr17.1-250"
+    },
+    {
+      "info": {
+        "RG": [
+          "fish"
+        ],
+        "PG": [
+          "bull"
+        ]
+      },
+      "duplicateFragment": false,
+      "alignedQuality": [
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30
+      ],
+      "failedVendorQualityChecks": false,
+      "fragmentName": "x3",
+      "readNumber": null,
+      "properPlacement": false,
+      "nextMatePosition": null,
+      "supplementaryAlignment": false,
+      "numberReads": null,
+      "fragmentLength": 0,
+      "secondaryAlignment": false,
+      "alignedSequence": "TTATAAAACAAATAATTAAGTCTACA",
+      "id": "pileup.js:chr17.1-250:x3",
+      "alignment": {
+        "position": {
+          "position": 103,
+          "reverseStrand": false,
+          "referenceName": "chr17"
+        },
+        "cigar": [
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 9
+          },
+          {
+            "referenceSequence": null,
+            "operation": "INSERT",
+            "operationLength": 4
+          },
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 13
+          }
+        ],
+        "mappingQuality": 30
+      },
+      "readGroupId": "pileup.js:chr17.1-250"
+    },
+    {
+      "info": {
+        "RG": [
+          "fish"
+        ],
+        "PG": [
+          "bull"
+        ]
+      },
+      "duplicateFragment": false,
+      "alignedQuality": [
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30
+      ],
+      "failedVendorQualityChecks": false,
+      "fragmentName": "x4",
+      "readNumber": null,
+      "properPlacement": false,
+      "nextMatePosition": null,
+      "supplementaryAlignment": false,
+      "numberReads": null,
+      "fragmentLength": 0,
+      "secondaryAlignment": false,
+      "alignedSequence": "CAAATAATTAAGTCTACAGAGCAAC",
+      "id": "pileup.js:chr17.1-250:x4",
+      "alignment": {
+        "position": {
+          "position": 114,
+          "reverseStrand": false,
+          "referenceName": "chr17"
+        },
+        "cigar": [
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 25
+          }
+        ],
+        "mappingQuality": 30
+      },
+      "readGroupId": "pileup.js:chr17.1-250"
+    },
+    {
+      "info": {
+        "RG": [
+          "fish"
+        ],
+        "PG": [
+          "bull"
+        ]
+      },
+      "duplicateFragment": false,
+      "alignedQuality": [
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30
+      ],
+      "failedVendorQualityChecks": false,
+      "fragmentName": "x5",
+      "readNumber": null,
+      "properPlacement": false,
+      "nextMatePosition": null,
+      "supplementaryAlignment": false,
+      "numberReads": null,
+      "fragmentLength": 0,
+      "secondaryAlignment": false,
+      "alignedSequence": "AATAATTAAGTCTACAGAGCAACT",
+      "id": "pileup.js:chr17.1-250:x5",
+      "alignment": {
+        "position": {
+          "position": 134,
+          "reverseStrand": false,
+          "referenceName": "chr17"
+        },
+        "cigar": [
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 24
+          }
+        ],
+        "mappingQuality": 30
+      },
+      "readGroupId": "pileup.js:chr17.1-250"
+    },
+    {
+      "info": {
+        "RG": [
+          "cow"
+        ]
+      },
+      "duplicateFragment": false,
+      "alignedQuality": [
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30
+      ],
+      "failedVendorQualityChecks": false,
+      "fragmentName": "x6",
+      "readNumber": null,
+      "properPlacement": false,
+      "nextMatePosition": null,
+      "supplementaryAlignment": false,
+      "numberReads": null,
+      "fragmentLength": 0,
+      "secondaryAlignment": false,
+      "alignedSequence": "TAATTAAGTCTACAGAGCAACTA",
+      "id": "pileup.js:chr17.1-250:x6",
+      "alignment": {
+        "position": {
+          "position": 164,
+          "reverseStrand": false,
+          "referenceName": "chr17"
+        },
+        "cigar": [
+          {
+            "referenceSequence": null,
+            "operation": "ALIGNMENT_MATCH",
+            "operationLength": 23
+          }
+        ],
+        "mappingQuality": 30
+      },
+      "readGroupId": "pileup.js:chr17.1-250"
+    }
+  ]
+}


### PR DESCRIPTION
As demoed last Friday.

Highlights:
- I factored out a common interface for alignments, shared between BAM & GA4GH sources.
- GA4GHDataSource is currently untested. I'm thinking about how to best remedy that.
- The BAM↔GA4GH equivalency test surfaced many issues with the GA4GH server.
- This isn't surfaced via the playground example. I'm not sure how it could be (you'd have to run a GA4GH server). Maybe there's a public one running that we could point to.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/230)
<!-- Reviewable:end -->
