### PR TITLE
Optimizations for alignment tracks

### DIFF
--- a/src/main/BamDataSource.js
+++ b/src/main/BamDataSource.js
@@ -86,6 +86,7 @@ function createFromBamFile(remoteSource: BamFile): AlignmentDataSource {
           coveredRanges = ContigInterval.coalesce(coveredRanges);
           reads.forEach(read => addRead(read));
           o.trigger('networkdone');
+          o.trigger('newdata', range);
         });
     });
   }
@@ -102,9 +103,7 @@ function createFromBamFile(remoteSource: BamFile): AlignmentDataSource {
 
   var o = {
     rangeChanged: function(newRange: GenomeRange) {
-      fetch(newRange)
-          .then(() => o.trigger('newdata', newRange))
-          .done();
+      fetch(newRange).done();
     },
     getAlignmentsInRange,
 

--- a/src/main/BamDataSource.js
+++ b/src/main/BamDataSource.js
@@ -86,7 +86,7 @@ function createFromBamFile(remoteSource: BamFile): AlignmentDataSource {
           coveredRanges = ContigInterval.coalesce(coveredRanges);
           reads.forEach(read => addRead(read));
           o.trigger('networkdone');
-          o.trigger('newdata', range);
+          o.trigger('newdata', interval);
         });
     });
   }

--- a/src/main/ContigInterval.js
+++ b/src/main/ContigInterval.js
@@ -34,6 +34,12 @@ class ContigInterval<T: (number|string)> {
             this.interval.intersects(other.interval));
   }
 
+  // Like intersects(), but allows 'chr17' vs. '17'-style mismatches.
+  chrIntersects(other: ContigInterval<T>): boolean {
+    return (this.chrOnContig(other.contig) &&
+            this.interval.intersects(other.interval));
+  }
+
   containsInterval(other: ContigInterval<T>): boolean {
     return (this.contig === other.contig &&
             this.interval.containsInterval(other.interval));
@@ -58,10 +64,15 @@ class ContigInterval<T: (number|string)> {
 
   // Like containsLocus, but allows 'chr17' vs '17'-style mismatches
   chrContainsLocus(contig: T, position: number): boolean {
+    return this.chrOnContig(contig) &&
+           this.interval.contains(position);
+  }
+
+  // Is this read on the given contig? (allowing for chr17 vs 17-style mismatches)
+  chrOnContig(contig: T): boolean {
     return (this.contig === contig ||
             this.contig === 'chr' + contig ||
-            'chr' + this.contig === contig) &&
-           this.interval.contains(position);
+            'chr' + this.contig === contig);
   }
 
   /*

--- a/src/main/GA4GHDataSource.js
+++ b/src/main/GA4GHDataSource.js
@@ -99,7 +99,7 @@ function create(spec: GA4GHSpec): AlignmentDataSource {
           notifyFailure('Error from GA4GH endpoint: ' + JSON.stringify(response));
         } else {
           addReadsFromResponse(response);
-          o.trigger('newdata');  // display data as it comes in.
+          o.trigger('newdata', range);  // display data as it comes in.
           if (response.nextPageToken) {
             fetchAlignmentsForInterval(range, response.nextPageToken, numRequests + 1);
           } else {

--- a/src/test/CoverageTrack-test.js
+++ b/src/test/CoverageTrack-test.js
@@ -78,7 +78,7 @@ describe('CoverageTrack', function() {
   it('should create coverage information for all bases shown in the view', function() {
     return waitFor(hasCoverage, 2000).then(() => {
       var bins = findCoverageBins();
-      expect(bins).to.have.length.above(range.stop - range.start + 1);
+      expect(bins).to.have.length.at.least(range.stop - range.start + 1);
     });
   });
 


### PR DESCRIPTION
This makes `BamDataSource`'s `newdata` event fire only when new data becomes available (previously it fired when a cached region was requested, too). This should significantly reduce re-computation in `PileupTrack`.

I also reworked the data flow in `CoverageTrack` so that it only computes summary statistics when `newdata` fires.

Performance numbers while panning on the playground demo:
Before: 4-5fps
After: 9-10fps

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/232)
<!-- Reviewable:end -->
