### PR TITLE
Fix the version for mocha-phantomjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "lcov-parse": "0.0.9",
     "mocha": "^2.1.0",
     "mocha-lcov-reporter": ">=0.0.2",
-    "mocha-phantomjs": "^3.5.3",
+    "mocha-phantomjs": "3.5.3",
     "mocha-phantomjs-istanbul": "0.0.2",
     "parse-data-uri": "^0.2.0",
     "phantomjs": "^1.9.17",


### PR DESCRIPTION
The newer version of the `mocha-phantomjs` (v3.6.0) requires an older version of phantomjs and this create a dependency conflict, causing [our build to fail](https://travis-ci.org/hammerlab/pileup.js/builds/71798433). This change fixes the version of our `mocha-phantomjs` dependency to resolve that issue.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/236)
<!-- Reviewable:end -->
