### PR TITLE
Consolidate duplicated code across Visualization tracks

### DIFF
--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -70,15 +70,7 @@ class CoverageTrack extends React.Component {
   }
 
   getScale() {
-    return d3utils.getTrackScale(this.props.range, this.state.width);
-  }
-
-  updateSize() {
-    var parentDiv = this.refs.container.getDOMNode();
-    this.setState({
-      width: parentDiv.parentNode.offsetWidth,
-      height: parentDiv.offsetHeight
-    });
+    return d3utils.getTrackScale(this.props.range, this.props.width);
   }
 
   /**
@@ -104,9 +96,6 @@ class CoverageTrack extends React.Component {
   }
 
   componentDidMount() {
-    window.addEventListener('resize', () => this.updateSize());
-    this.updateSize();
-
     var div = this.refs.container.getDOMNode();
     var svg = d3.select(div).append('svg');
     this.calculateLabelSize(svg);
@@ -144,8 +133,8 @@ class CoverageTrack extends React.Component {
 
   visualizeCoverage() {
     var div = this.refs.container.getDOMNode(),
-        width = this.state.width,
-        height = this.state.height,
+        width = this.props.width,
+        height = this.props.height,
         range = this.props.range,
         padding = this.state.labelSize.height / 2,  // half the text height
         xScale = this.getScale(),

--- a/src/main/GeneTrack.js
+++ b/src/main/GeneTrack.js
@@ -14,23 +14,6 @@ var React = require('./react-shim'),
     d3utils = require('./d3utils'),
     ContigInterval = require('./ContigInterval');
 
-var GeneTrack = React.createClass({
-  displayName: 'genes',
-  propTypes: {
-    range: types.GenomeRange,
-    source: React.PropTypes.object.isRequired,
-    onRangeChange: React.PropTypes.func.isRequired,
-  },
-  render: function(): any {
-    var range = this.props.range;
-    if (!range) {
-      return <EmptyTrack />;
-    }
-
-    return <NonEmptyGeneTrack {...this.props} />;
-  }
-});
-
 
 // D3 function to hide overlapping elements in a selection.
 // nb: this is O(n^2) in the number of transcripts on-screen.
@@ -51,7 +34,8 @@ function removeOverlapping(selection) {
   });
 }
 
-var NonEmptyGeneTrack = React.createClass({
+var GeneTrack = React.createClass({
+  displayName: 'genes',
   propTypes: {
     range: types.GenomeRange.isRequired,
     source: React.PropTypes.object.isRequired,
@@ -61,10 +45,10 @@ var NonEmptyGeneTrack = React.createClass({
     return {
       width: 0,
       height: 0,
-      genes: []
+      genes: ([]: Object[])  // TODO: import Gene type from BigBedDataSource
     };
   },
-  render: function() {
+  render: function(): any {
     return <div></div>;
   },
   updateSize: function() {
@@ -211,12 +195,6 @@ var NonEmptyGeneTrack = React.createClass({
 
     // Exit
     genes.exit().remove();
-  }
-});
-
-var EmptyTrack = React.createClass({
-  render: function() {
-    return <div className="genes empty">Zoom in to see genes</div>;
   }
 });
 

--- a/src/main/GeneTrack.js
+++ b/src/main/GeneTrack.js
@@ -43,28 +43,16 @@ var GeneTrack = React.createClass({
   },
   getInitialState: function() {
     return {
-      width: 0,
-      height: 0,
       genes: ([]: Object[])  // TODO: import Gene type from BigBedDataSource
     };
   },
   render: function(): any {
     return <div></div>;
   },
-  updateSize: function() {
-    var parentDiv = this.getDOMNode().parentNode;
-    this.setState({
-      width: parentDiv.offsetWidth,
-      height: parentDiv.offsetHeight
-    });
-  },
   componentDidMount: function() {
     var div = this.getDOMNode(),
         svg = d3.select(div)
                 .append('svg');
-
-    window.addEventListener('resize', () => this.updateSize());
-    this.updateSize();
 
     // Visualize new reference data as it comes in from the network.
     this.props.source.on('newdata', () => {
@@ -94,7 +82,7 @@ var GeneTrack = React.createClass({
     this.updateVisualization();
   },
   getScale: function() {
-    return d3utils.getTrackScale(this.props.range, this.state.width);
+    return d3utils.getTrackScale(this.props.range, this.props.width);
   },
   componentDidUpdate: function(prevProps: any, prevState: any) {
     if (!shallowEquals(prevProps, this.props) ||
@@ -104,8 +92,8 @@ var GeneTrack = React.createClass({
   },
   updateVisualization: function() {
     var div = this.getDOMNode(),
-        width = this.state.width,
-        height = this.state.height,
+        width = this.props.width,
+        height = this.props.height,
         svg = d3.select(div).select('svg');
 
     // Hold off until height & width are known.

--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -26,25 +26,13 @@ var GenomeTrack = React.createClass({
   },
   getInitialState: function() {
     return {
-      width: 0,
-      height: 0,
       basePairs: {}
     };
   },
   render: function(): any {
     return <div></div>;
   },
-  updateSize: function() {
-    var parentDiv = this.getDOMNode().parentNode;
-    this.setState({
-      width: parentDiv.offsetWidth,
-      height: parentDiv.offsetHeight
-    });
-  },
   componentDidMount: function() {
-    window.addEventListener('resize', () => this.updateSize());
-    this.updateSize();
-
     var div = this.getDOMNode(),
         svg = d3.select(div)
                 .append('svg');
@@ -101,7 +89,7 @@ var GenomeTrack = React.createClass({
     this.updateVisualization();
   },
   getScale: function() {
-    return d3utils.getTrackScale(this.props.range, this.state.width);
+    return d3utils.getTrackScale(this.props.range, this.props.width);
   },
   componentDidUpdate: function(prevProps: any, prevState: any) {
     if (!shallowEquals(prevProps, this.props) ||
@@ -112,8 +100,8 @@ var GenomeTrack = React.createClass({
   updateVisualization: function() {
     var div = this.getDOMNode(),
         range = this.props.range,
-        width = this.state.width,
-        height = this.state.height,
+        width = this.props.width,
+        height = this.props.height,
         svg = d3.select(div).select('svg');
 
     // Hold off until height & width are known.

--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -15,25 +15,9 @@ var React = require('./react-shim'),
 
 
 var GenomeTrack = React.createClass({
-  displayName: 'reference',
-  propTypes: {
-    range: types.GenomeRange,
-    source: React.PropTypes.object.isRequired,
-    onRangeChange: React.PropTypes.func.isRequired,
-  },
-  render: function(): any {
-    var range = this.props.range;
-    if (!range) {
-      return <EmptyTrack />;
-    }
-
-    return <NonEmptyGenomeTrack {...this.props} />;
-  }
-});
-
-var NonEmptyGenomeTrack = React.createClass({
   // This prevents updates if state & props have not changed.
   mixins: [React.addons.PureRenderMixin],
+  displayName: 'reference',
 
   propTypes: {
     range: types.GenomeRange.isRequired,
@@ -44,7 +28,7 @@ var NonEmptyGenomeTrack = React.createClass({
     return {
       width: 0,
       height: 0,
-      basePairs: []
+      basePairs: {}
     };
   },
   render: function(): any {
@@ -196,12 +180,6 @@ var NonEmptyGenomeTrack = React.createClass({
 
     // Exit
     letter.exit().remove();
-  }
-});
-
-var EmptyTrack = React.createClass({
-  render: function() {
-    return <div className="reference empty">Zoom in to see bases</div>;
   }
 });
 

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -18,24 +18,6 @@ var React = require('./react-shim'),
     ContigInterval = require('./ContigInterval'),
     DisplayMode = require('./DisplayMode');
 
-var PileupTrack = React.createClass({
-  displayName: 'pileup',
-  propTypes: {
-    range: types.GenomeRange,
-    onRangeChange: React.PropTypes.func.isRequired,
-    source: React.PropTypes.object.isRequired,
-    referenceSource: React.PropTypes.object.isRequired
-  },
-  render: function(): any {
-    var range = this.props.range;
-    if (!range) {
-      return <EmptyTrack />;
-    }
-
-    return <NonEmptyPileupTrack {...this.props} />;
-  }
-});
-
 
 var READ_HEIGHT = 13;
 var READ_SPACING = 2;  // vertical pixels between reads
@@ -184,11 +166,11 @@ function opacityForQuality(quality: number): number {
   return Math.min(1.0, alpha);
 }
 
-class NonEmptyPileupTrack extends React.Component {
+class PileupTrack extends React.Component {
   pileup: Array<Interval[]>;
   keyToVisualAlignment: {[key:string]: VisualAlignment};
 
-  constructor(props) {
+  constructor(props: Object) {
     super(props);
     this.state = {
       width: 0,
@@ -229,7 +211,7 @@ class NonEmptyPileupTrack extends React.Component {
     );
   }
 
-  formatStatus(state): string {
+  formatStatus(state: Object): string {
     if (state.numRequests) {
       var pluralS = state.numRequests > 1 ? 's' : '';
       return `issued ${state.numRequests} request${pluralS}`;
@@ -284,7 +266,7 @@ class NonEmptyPileupTrack extends React.Component {
   }
 
   // Attach visualization info to the read and cache it.
-  addRead(read: SamRead, referenceSource): VisualAlignment {
+  addRead(read: SamRead, referenceSource: any): VisualAlignment {
     var key = read.getKey();
     if (key in this.keyToVisualAlignment) {
       return this.keyToVisualAlignment[key];
@@ -422,18 +404,13 @@ class NonEmptyPileupTrack extends React.Component {
 
 }
 
-NonEmptyPileupTrack.propTypes = {
+PileupTrack.propTypes = {
   range: types.GenomeRange.isRequired,
   source: React.PropTypes.object.isRequired,
   referenceSource: React.PropTypes.object.isRequired,
   onRangeChange: React.PropTypes.func.isRequired
 };
+PileupTrack.displayName = 'pileup';
 
-
-var EmptyTrack = React.createClass({
-  render: function() {
-    return <div className='pileup empty'>Zoom in to see alignments</div>;
-  }
-});
 
 module.exports = PileupTrack;

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -173,8 +173,6 @@ class PileupTrack extends React.Component {
   constructor(props: Object) {
     super(props);
     this.state = {
-      width: 0,
-      height: 0,
       reads: []
     };
     this.pileup = [];
@@ -221,18 +219,7 @@ class PileupTrack extends React.Component {
     throw 'invalid';
   }
 
-  updateSize() {
-    var parentDiv = this.refs.container.getDOMNode().parentNode;
-    this.setState({
-      width: parentDiv.offsetWidth,
-      height: parentDiv.offsetHeight
-    });
-  }
-
   componentDidMount() {
-    window.addEventListener('resize', () => this.updateSize());
-    this.updateSize();
-
     var div = this.refs.container.getDOMNode();
     d3.select(div)
       .append('svg');
@@ -255,7 +242,7 @@ class PileupTrack extends React.Component {
   }
 
   getScale() {
-    return d3utils.getTrackScale(this.props.range, this.state.width);
+    return d3utils.getTrackScale(this.props.range, this.props.width);
   }
 
   componentDidUpdate(prevProps: any, prevState: any) {
@@ -315,7 +302,7 @@ class PileupTrack extends React.Component {
   // currently-visible range.
   updateVisualization() {
     var div = this.refs.container.getDOMNode(),
-        width = this.state.width,
+        width = this.props.width,
         svg = d3.select(div).select('svg');
 
     // Hold off until height & width are known.

--- a/src/main/Root.js
+++ b/src/main/Root.js
@@ -8,7 +8,8 @@ import type * as SamRead from './SamRead';
 import type {VisualizedTrack} from './types';
 
 var React = require('./react-shim'),
-    Controls = require('./Controls');
+    Controls = require('./Controls'),
+    VisualizationWrapper = require('./VisualizationWrapper');
 
 
 var Root = React.createClass({
@@ -50,12 +51,13 @@ var Root = React.createClass({
     }).done();
   },
   makeDivForTrack(key: string, track: VisualizedTrack): React.Element {
-    var trackEl = React.createElement(track.visualization, {
-      range: this.state.range,
-      onRangeChange: this.handleRangeChange,
-      source: track.source,
-      referenceSource: this.props.referenceSource
-    });
+    var trackEl = (
+        <VisualizationWrapper visualization={track.visualization}
+            range={this.state.range}
+            onRangeChange={this.handleRangeChange}
+            source={track.source}
+            referenceSource={this.props.referenceSource}
+          />);
 
     var className = ['track', track.visualization.displayName || '', track.track.cssClass || ''].join(' ');
 

--- a/src/main/VariantTrack.js
+++ b/src/main/VariantTrack.js
@@ -30,28 +30,12 @@ type VcfDataSource = {
   trigger: (event: string, ...args:any) => void;
 };
 
-var VariantTrack = React.createClass({
-  displayName: 'variants',
-  propTypes: {
-    range: types.GenomeRange,
-    onRangeChange: React.PropTypes.func.isRequired,
-    source: React.PropTypes.object.isRequired
-  },
-  render: function(): any {
-    var range = this.props.range;
-    if (!range) {
-      return <EmptyTrack />;
-    }
-
-    return <NonEmptyVariantTrack {...this.props} />;
-  }
-});
-
 function variantKey(v: Variant): string {
   return `${v.contig}:${v.position}`;
 }
 
-var NonEmptyVariantTrack = React.createClass({
+var VariantTrack = React.createClass({
+  displayName: 'variants',
   propTypes: {
     range: types.GenomeRange.isRequired,
     source: React.PropTypes.object.isRequired,
@@ -146,12 +130,6 @@ var NonEmptyVariantTrack = React.createClass({
 
     // Exit
     variantRects.exit().remove();
-  }
-});
-
-var EmptyTrack = React.createClass({
-  render: function() {
-    return <div className='variants empty'>Zoom in to see variants</div>;
   }
 });
 

--- a/src/main/VariantTrack.js
+++ b/src/main/VariantTrack.js
@@ -41,29 +41,13 @@ var VariantTrack = React.createClass({
     source: React.PropTypes.object.isRequired,
     onRangeChange: React.PropTypes.func.isRequired
   },
-  getInitialState: function() {
-    return {
-      width: 0,
-      height: 0
-    };
-  },
   render: function(): any {
     return <div></div>;
   },
   getVariantSource(): VcfDataSource {
     return this.props.source;
   },
-  updateSize: function() {
-    var parentDiv = this.getDOMNode().parentNode;
-    this.setState({
-      width: parentDiv.offsetWidth,
-      height: parentDiv.offsetHeight
-    });
-  },
   componentDidMount: function() {
-    window.addEventListener('resize', () => this.updateSize());
-    this.updateSize();
-
     var div = this.getDOMNode();
     d3.select(div)
       .append('svg');
@@ -75,7 +59,7 @@ var VariantTrack = React.createClass({
   },
   getScale: function() {
     var range = this.props.range,
-        width = this.state.width,
+        width = this.props.width,
         offsetPx = range.offsetPx || 0;
     var scale = d3.scale.linear()
             .domain([range.start, range.stop + 1])  // 1 bp wide
@@ -93,8 +77,8 @@ var VariantTrack = React.createClass({
   },
   updateVisualization: function() {
     var div = this.getDOMNode(),
-        width = this.state.width,
-        height = this.state.height,
+        width = this.props.width,
+        height = this.props.height,
         svg = d3.select(div).select('svg');
 
     // Hold off until height & width are known.

--- a/src/main/VisualizationWrapper.js
+++ b/src/main/VisualizationWrapper.js
@@ -1,0 +1,38 @@
+/**
+ * @flow
+ */
+
+var React = require('./react-shim'),
+    types = require('./react-types');
+
+var VisualizationWrapper = React.createClass({
+  propTypes: {
+    range: types.GenomeRange,
+    onRangeChange: React.PropTypes.func.isRequired,
+    source: React.PropTypes.object.isRequired,
+    referenceSource: React.PropTypes.object.isRequired,
+    visualization: React.PropTypes.func.isRequired
+  },
+  render: function(): any {
+    var range = this.props.range;
+    if (!range) {
+      return <EmptyTrack className={this.props.visualization.displayName} />;
+    }
+
+    return React.createElement(this.props.visualization, {
+      range: this.props.range,
+      onRangeChange: this.props.onRangeChange,
+      source: this.props.source,
+      referenceSource: this.props.referenceSource
+    });
+  }
+});
+
+var EmptyTrack = React.createClass({
+  render: function() {
+    var className = this.props.className + ' empty';
+    return <div className={className}></div>;
+  }
+});
+
+module.exports = VisualizationWrapper;

--- a/src/main/VisualizationWrapper.js
+++ b/src/main/VisualizationWrapper.js
@@ -13,6 +13,27 @@ var VisualizationWrapper = React.createClass({
     referenceSource: React.PropTypes.object.isRequired,
     visualization: React.PropTypes.func.isRequired
   },
+
+  getInitialState: function() {
+    return {
+      width: 0,
+      height: 0
+    }
+  },
+
+  updateSize() {
+    var parentDiv = this.getDOMNode().parentNode;
+    this.setState({
+      width: parentDiv.offsetWidth,
+      height: parentDiv.offsetHeight
+    });
+  },
+
+  componentDidMount() {
+    window.addEventListener('resize', () => this.updateSize());
+    this.updateSize();
+  },
+
   render: function(): any {
     var range = this.props.range;
     if (!range) {
@@ -23,7 +44,9 @@ var VisualizationWrapper = React.createClass({
       range: this.props.range,
       onRangeChange: this.props.onRangeChange,
       source: this.props.source,
-      referenceSource: this.props.referenceSource
+      referenceSource: this.props.referenceSource,
+      width: this.state.width,
+      height: this.state.height
     });
   }
 });

--- a/src/main/types.js
+++ b/src/main/types.js
@@ -14,7 +14,7 @@
 import type * as React from 'react';
 
 export type Track = {
-  viz: Object;  // for now, a React class
+  viz: any;  // for now, a React class
   data: Object;  // This is a DataSource object
   name?: string;
   cssClass?: string;


### PR DESCRIPTION
This eliminates two sources of duplicated code:

- The empty / non-empty track dance that each component had to do. This is now done by a new component, `VisualizationWrapper`.
- Caching the track's size. The last-measured size is passed down via `props.{width,height}` now.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/237)
<!-- Reviewable:end -->
