### PR TITLE
Add support for location and scale tracks

### DIFF
--- a/examples/playground.js
+++ b/examples/playground.js
@@ -16,6 +16,10 @@ var sources = [
     name: 'Reference'
   },
   {
+    viz: pileup.viz.scale(),
+    name: 'Scale'
+  },
+  {
     viz: pileup.viz.location(),
     name: 'Location'
   },

--- a/examples/playground.js
+++ b/examples/playground.js
@@ -16,6 +16,10 @@ var sources = [
     name: 'Reference'
   },
   {
+    viz: pileup.viz.location(),
+    name: 'Location'
+  },
+  {
     viz: pileup.viz.variants(),
     data: pileup.formats.vcf({
       url: '/test-data/snv.chr17.vcf'

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -36,7 +36,7 @@ function extractSummaryStatistics(reads: Array<SamRead>, contig: string) {
   var maxCoverage = _.max(binCounts);
 
   binCounts = _.map(binCounts, (count, position) => ({position: Number(position), count}));
-  binCounts = _.sortBy(binCounts, ({position, count}) => position);
+  binCounts = _.sortBy(binCounts, bin => bin.position);
 
   return {binCounts, maxCoverage};
 }
@@ -134,7 +134,6 @@ class CoverageTrack extends React.Component {
     var div = this.refs.container.getDOMNode(),
         width = this.props.width,
         height = this.props.height,
-        range = this.props.range,
         padding = this.state.labelSize.height / 2,  // half the text height
         xScale = this.getScale(),
         svg = d3.select(div).select('svg');

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -41,7 +41,6 @@ function extractSummaryStatistics(reads: Array<SamRead>, contig: string) {
   return {binCounts, maxCoverage};
 }
 
-
 class CoverageTrack extends React.Component {
   constructor(props: Object) {
     super(props);

--- a/src/main/EmptySource.js
+++ b/src/main/EmptySource.js
@@ -12,10 +12,10 @@ type EmptySource = {
 }
 
 var create = (): EmptySource => ({
-    rangeChanged: () => {},
-    on: () => {},
-    off: () => {},
-    trigger: () => {}
+  rangeChanged: () => {},
+  on: () => {},
+  off: () => {},
+  trigger: () => {}
 });
 
 module.exports = {

--- a/src/main/EmptySource.js
+++ b/src/main/EmptySource.js
@@ -1,0 +1,23 @@
+/*
+ * This is a dummy data source to be used by tracks that do not depend on data.
+ * @flow
+ */
+'use strict';
+
+type EmptySource = {
+  rangeChanged: (newRange: GenomeRange) => void;
+  on: (event: string, handler: Function) => void;
+  off: (event: string) => void;
+  trigger: (event: string, ...args:any) => void;
+}
+
+var create = (): EmptySource => ({
+    rangeChanged: () => {},
+    on: () => {},
+    off: () => {},
+    trigger: () => {}
+});
+
+module.exports = {
+  create
+};

--- a/src/main/LocationTrack.js
+++ b/src/main/LocationTrack.js
@@ -46,7 +46,7 @@ class LocationTrack extends React.Component {
   }
 
   getDOMNode(): any {
-    return this.refs.container.getDOMNode();
+    return React.findDOMNode(this);
   }
 
   updateVisualization() {

--- a/src/main/LocationTrack.js
+++ b/src/main/LocationTrack.js
@@ -7,7 +7,7 @@
 var React = require('./react-shim'),
     _ = require('underscore'),
     d3 = require('d3'),
-    shallowEquals = require('shallow-equals'),
+    EmptySource = require('./EmptySource'),
     types = require('./react-types'),
     d3utils = require('./d3utils');
 
@@ -112,6 +112,7 @@ LocationTrack.propTypes = {
   range: types.GenomeRange.isRequired,
   onRangeChange: React.PropTypes.func.isRequired,
 };
-LocationTrack.displayName = 'location';
+LocationTrack.displayName = 'location'
+LocationTrack.defaultSource = EmptySource.create();
 
 module.exports = LocationTrack;

--- a/src/main/LocationTrack.js
+++ b/src/main/LocationTrack.js
@@ -5,7 +5,6 @@
 'use strict';
 
 var React = require('./react-shim'),
-    _ = require('underscore'),
     d3 = require('d3'),
     EmptySource = require('./EmptySource'),
     types = require('./react-types'),

--- a/src/main/LocationTrack.js
+++ b/src/main/LocationTrack.js
@@ -38,7 +38,7 @@ class LocationTrack extends React.Component {
     var {height, width} = label.text("0").node().getBBox();
     // Save the size information for precise calculation
     this.setState({
-          labelSize: {height: height, width: width}
+        labelSize: {height, width}
     });
 
     this.updateVisualization();

--- a/src/main/LocationTrack.js
+++ b/src/main/LocationTrack.js
@@ -13,8 +13,8 @@ var React = require('./react-shim'),
 // This sets the width of the horizontal line (--) that connects the center
 //  marker to the label:
 //     | |-- 42 bp
-var labelPadding = 5,
-    connectorWidth = 10;
+var LABEL_PADDING = 5,
+    CONNECTOR_WIDTH = 10;
 
 class LocationTrack extends React.Component {
   constructor(props: Object) {
@@ -91,7 +91,7 @@ class LocationTrack extends React.Component {
       .text(midLabelFormat(midPoint) + ' bp')
       .transition()
       .attr({
-        x: rightLineX + connectorWidth + labelPadding,
+        x: rightLineX + CONNECTOR_WIDTH + LABEL_PADDING,
         y: midY
       });
 
@@ -101,7 +101,7 @@ class LocationTrack extends React.Component {
       .attr({
         x1: rightLineX,
         y1: midY,
-        x2: rightLineX + connectorWidth,
+        x2: rightLineX + CONNECTOR_WIDTH,
         y2: midY
       });
   }

--- a/src/main/LocationTrack.js
+++ b/src/main/LocationTrack.js
@@ -1,0 +1,100 @@
+/**
+ * A track which shows the location of the base in the middle of the view.
+ * @flow
+ */
+'use strict';
+
+var React = require('./react-shim'),
+    _ = require('underscore'),
+    d3 = require('d3'),
+    shallowEquals = require('shallow-equals'),
+    types = require('./react-types'),
+    d3utils = require('./d3utils');
+
+class LocationTrack extends React.Component {
+  constructor(props: Object) {
+    super(props);
+    this.state = {
+      labelSize: {height: 0, width: 0}
+    };
+  }
+
+  getScale() {
+    return d3utils.getTrackScale(this.props.range, this.props.width);
+  }
+
+  render(): any {
+    return <div ref='container'></div>;
+  }
+
+  componentDidMount() {
+    var div = this.getDOMNode(),
+        svg = d3.select(div).append('svg');
+
+    svg.append('line').attr('class', 'location-hline');
+    svg.append('line').attr('class', 'location-vline');
+
+    var label = svg.append('text').attr('class', 'location-label');
+    var {height, width} = label.text("0").node().getBBox();
+    // Save the size information for precise calculation
+    this.setState({
+          labelSize: {height: height, width: width}
+    });
+
+    this.updateVisualization();
+  }
+
+  componentDidUpdate(prevProps: any, prevState: any) {
+    this.updateVisualization();
+  }
+
+  getDOMNode(): any {
+    return this.refs.container.getDOMNode();
+  }
+
+  updateVisualization() {
+    var div = this.getDOMNode(),
+        range = this.props.range,
+        width = this.props.width,
+        height = this.props.height,
+        labelSize = this.state.labelSize,
+        svg = d3.select(div).select('svg');
+
+    svg.attr('width', width).attr('height', height);
+    var scale = this.getScale();
+    var midPoint = (range.stop + range.start) / 2;
+    var midX = width / 2,
+        midY = height / 2;
+
+    var midLabelFormat = d3.format(',d');
+    var midLabel = svg.select('.location-label');
+    var labelHeight = labelSize.height;
+    var labelPadding = 10;
+    midLabel
+      .attr('x', midX + labelPadding + (labelSize.width / 2))
+      .attr('y', midY + (labelHeight / 3))
+      .text(midLabelFormat(Math.floor(midPoint)) + ' bp');
+
+    var midLine = svg.select('.location-vline');
+    midLine
+      .attr('x1', midX)
+      .attr('y1', 0)
+      .attr('x2', midX)
+      .attr('y2', height);
+
+    var hLine = svg.select('.location-hline');
+    hLine
+      .attr('x1', midX)
+      .attr('y1', midY)
+      .attr('x2', midX + labelPadding)
+      .attr('y2', midY);
+  }
+}
+
+LocationTrack.propTypes = {
+  range: types.GenomeRange.isRequired,
+  onRangeChange: React.PropTypes.func.isRequired,
+};
+LocationTrack.displayName = 'location';
+
+module.exports = LocationTrack;

--- a/src/main/Root.js
+++ b/src/main/Root.js
@@ -9,7 +9,6 @@ import type {VisualizedTrack} from './types';
 
 var React = require('./react-shim'),
     Controls = require('./Controls'),
-    EmptySource = require('./EmptySource'),
     VisualizationWrapper = require('./VisualizationWrapper');
 
 

--- a/src/main/Root.js
+++ b/src/main/Root.js
@@ -9,6 +9,7 @@ import type {VisualizedTrack} from './types';
 
 var React = require('./react-shim'),
     Controls = require('./Controls'),
+    EmptySource = require('./EmptySource'),
     VisualizationWrapper = require('./VisualizationWrapper');
 
 

--- a/src/main/ScaleTrack.js
+++ b/src/main/ScaleTrack.js
@@ -13,7 +13,7 @@
 var React = require('./react-shim'),
     _ = require('underscore'),
     d3 = require('d3'),
-    shallowEquals = require('shallow-equals'),
+    EmptySource = require('./EmptySource'),
     types = require('./react-types'),
     d3utils = require('./d3utils');
 
@@ -126,5 +126,7 @@ ScaleTrack.propTypes = {
   onRangeChange: React.PropTypes.func.isRequired,
 };
 ScaleTrack.displayName = 'scale';
+ScaleTrack.defaultSource = EmptySource.create();
+
 
 module.exports = ScaleTrack;

--- a/src/main/ScaleTrack.js
+++ b/src/main/ScaleTrack.js
@@ -11,7 +11,6 @@
 'use strict';
 
 var React = require('./react-shim'),
-    _ = require('underscore'),
     d3 = require('d3'),
     EmptySource = require('./EmptySource'),
     types = require('./react-types'),
@@ -77,18 +76,15 @@ class ScaleTrack extends React.Component {
         svg = d3.select(div).select('svg');
 
     svg.attr('width', width).attr('height', height);
-    var scale = this.getScale();
-    var midPoint = (range.stop + range.start + 1) / 2,
-        viewSize = range.stop - range.start + 1,
+    var viewSize = range.stop - range.start + 1,
         midX = width / 2,
         midY = height / 2;
 
     var {prefix, unit} = this.formatRange(viewSize);
 
     var midLabel = svg.select('.scale-label');
-    var labelHeight = labelSize.height,
-        labelWidth = labelSize.width;
-    var labelPadding = labelWidth;
+    var labelWidth = labelSize.width,
+        labelPadding = labelWidth;
     midLabel
       .attr({
         x: midX,

--- a/src/main/ScaleTrack.js
+++ b/src/main/ScaleTrack.js
@@ -54,7 +54,7 @@ class ScaleTrack extends React.Component {
   }
 
   getDOMNode(): any {
-    return this.refs.container.getDOMNode();
+    return React.findDOMNode(this);
   }
 
   // This formatting follows IGV's conventions regarding range display:

--- a/src/main/ScaleTrack.js
+++ b/src/main/ScaleTrack.js
@@ -61,8 +61,8 @@ class ScaleTrack extends React.Component {
   // This formatting follows IGV's conventions regarding range display:
   //  "1 bp", "101 bp", "1,001 bp", "1,001 kbp", ...
   formatRange(viewSize: number): any {
-    var tmpViewSize = (viewSize / 1000).toFixed() * 1,  // convert to integer
-        fprefix = d3.formatPrefix(tmpViewSize),
+    var tmpViewSize = viewSize / 1000,
+        fprefix = d3.formatPrefix(tmpViewSize < 1 ? 1 : tmpViewSize),
         unit = fprefix.symbol + "bp",  // bp, kbp, Mbp, Gbp
         prefix = d3.format(',f.0')(fprefix.scale(viewSize));
     return {prefix, unit};

--- a/src/main/ScaleTrack.js
+++ b/src/main/ScaleTrack.js
@@ -58,22 +58,14 @@ class ScaleTrack extends React.Component {
     return this.refs.container.getDOMNode();
   }
 
+  // This formatting follows IGV's conventions regarding range display:
+  //  "1 bp", "101 bp", "1,001 bp", "1,001 kbp", ...
   formatRange(viewSize: number): any {
-    var prefix = d3.formatPrefix(viewSize),
-        unit = prefix.symbol + "bp",  // bp, kbp, Mbp, Gbp
-        power = Math.floor(Math.log10(viewSize)),  // x as in nearest 10^x
-        scaleSize = Math.pow(10, power),  // nearest 10^x
-        prefix = prefix.scale(scaleSize).toFixed();
-
-    // If the whole region is smaller than 1kb,
-    //  then round it to the nearest tenth/hundredth instead of thousandth
-    if(power < 3) {
-      scaleSize = Math.pow(10, Math.floor(Math.log10(viewSize)));
-      scaleSize = Math.floor(viewSize / scaleSize) * scaleSize;
-      prefix = scaleSize;
-    }
-
-    return {prefix, unit, scaleSize};
+    var tmpViewSize = (viewSize / 1000).toFixed() * 1,  // convert to integer
+        fprefix = d3.formatPrefix(tmpViewSize),
+        unit = fprefix.symbol + "bp",  // bp, kbp, Mbp, Gbp
+        prefix = d3.format(',f.0')(fprefix.scale(viewSize));
+    return {prefix, unit};
   }
 
   updateVisualization() {
@@ -91,7 +83,7 @@ class ScaleTrack extends React.Component {
         midX = width / 2,
         midY = height / 2;
 
-    var {prefix, unit, scaleSize} = this.formatRange(viewSize);
+    var {prefix, unit} = this.formatRange(viewSize);
 
     var midLabel = svg.select('.scale-label');
     var labelHeight = labelSize.height,
@@ -104,8 +96,8 @@ class ScaleTrack extends React.Component {
       })
       .text(prefix + " " + unit);
 
-    var lineStart = scale(midPoint - (scaleSize / 2));
-    var lineEnd = scale(midPoint + (scaleSize / 2));
+    var lineStart = 0,
+        lineEnd = width;
 
     var leftLine = svg.select('.scale-lline');
     leftLine

--- a/src/main/ScaleTrack.js
+++ b/src/main/ScaleTrack.js
@@ -1,0 +1,127 @@
+/**
+ * A track which shows an approximate
+ * @flow
+ */
+'use strict';
+
+var React = require('./react-shim'),
+    _ = require('underscore'),
+    d3 = require('d3'),
+    shallowEquals = require('shallow-equals'),
+    types = require('./react-types'),
+    d3utils = require('./d3utils');
+
+class ScaleTrack extends React.Component {
+  constructor(props: Object) {
+    super(props);
+    this.state = {
+      labelSize: {height: 0, width: 0}
+    };
+  }
+
+  getScale() {
+    return d3utils.getTrackScale(this.props.range, this.props.width);
+  }
+
+  render(): any {
+    return <div ref='container'></div>;
+  }
+
+  componentDidMount() {
+    var div = this.getDOMNode(),
+        svg = d3.select(div).append('svg');
+
+    svg.append('line').attr('class', 'scale-lline');
+    svg.append('line').attr('class', 'scale-rline');
+
+    var label = svg.append('text').attr('class', 'scale-label');
+    var {height, width} = label.text("100 mb").node().getBBox();
+    // Save the size information for precise calculation
+    this.setState({
+          labelSize: {height: height, width: width}
+    });
+
+    this.updateVisualization();
+  }
+
+  componentDidUpdate(prevProps: any, prevState: any) {
+    this.updateVisualization();
+  }
+
+  getDOMNode(): any {
+    return this.refs.container.getDOMNode();
+  }
+
+  niceifyRange(viewSize: number): any {
+    var shorts = ["bp", "kb", "mb", "gb"],
+        power = Math.floor(Math.log10(viewSize)),
+        thousandth = Math.floor(power / 3),  // 10^3 = 1000
+        unit = shorts[thousandth],
+        nearestThousandth = Math.pow(1000, thousandth),
+        prefix = Math.floor(viewSize / nearestThousandth),
+        scaleSize = nearestThousandth;
+
+    // If the whole region is smaller than 1kb,
+    //  then round it to the nearest tenth/hundredth instead of thousandth
+    if(power < 3) {
+      scaleSize = Math.pow(10, Math.floor(Math.log10(viewSize)));
+      scaleSize = Math.floor(viewSize / scaleSize) * scaleSize;
+      prefix = scaleSize;
+    }
+
+    return {prefix, unit, scaleSize};
+  }
+
+  updateVisualization() {
+    var div = this.getDOMNode(),
+        range = this.props.range,
+        width = this.props.width,
+        height = this.props.height,
+        labelSize = this.state.labelSize,
+        svg = d3.select(div).select('svg');
+
+    svg.attr('width', width).attr('height', height);
+    var scale = this.getScale();
+    var midPoint = (range.stop + range.start + 1) / 2,
+        viewSize = range.stop - range.start + 1,
+        midX = width / 2,
+        midY = height / 2;
+
+    var {prefix, unit, scaleSize} = this.niceifyRange(viewSize);
+
+    var midLabel = svg.select('.scale-label');
+    var labelHeight = labelSize.height,
+        labelWidth = labelSize.width;
+    var labelPadding = labelWidth;
+    midLabel
+      .attr('x', midX)
+      .attr('y', midY + (labelHeight / 3))
+      .attr('text-anchor', 'middle')
+      .text(prefix + " " + unit);
+
+    var lineStart = scale(midPoint - (scaleSize / 2));
+    var lineEnd = scale(midPoint + (scaleSize / 2));
+
+    var leftLine = svg.select('.scale-lline');
+    leftLine
+      .attr('x1', lineStart)
+      .attr('y1', midY)
+      .attr('x2', midX - labelPadding)
+      .attr('y2', midY);
+
+    var rightLine = svg.select('.scale-rline');
+    rightLine
+      .attr('x1', midX + labelPadding)
+      .attr('y1', midY)
+      .attr('x2', lineEnd)
+      .attr('y2', midY);
+  }
+}
+
+ScaleTrack.propTypes = {
+  range: types.GenomeRange.isRequired,
+  onRangeChange: React.PropTypes.func.isRequired,
+};
+ScaleTrack.displayName = 'scale';
+
+module.exports = ScaleTrack;

--- a/src/main/ScaleTrack.js
+++ b/src/main/ScaleTrack.js
@@ -71,7 +71,7 @@ class ScaleTrack extends React.Component {
         midX = width / 2,
         midY = height / 2;
 
-    var {prefix, unit} = utils.formatRange(viewSize);
+    var {prefix, unit} = d3utils.formatRange(viewSize);
 
     var midLabel = svg.select('.scale-label');
     var labelWidth = labelSize.width,

--- a/src/main/ScaleTrack.js
+++ b/src/main/ScaleTrack.js
@@ -2,7 +2,7 @@
  * A track which shows a scale proportional to slice of the genome being
  * shown by the reference track. This track tries to show a scale in kbp,
  * mbp or gbp depending on the size of the view and also tries to round the
- * scale size (e.g. prefers 10bp, 100bp, 200bp over 13bp, 104bp, 232bp)
+ * scale size (e.g. prefers "1,000 bp", "1,000 kbp" over "1 kbp" and "1 mbp")
  *
  *           ---------- 30 chars ----------
  *
@@ -14,6 +14,7 @@ var React = require('./react-shim'),
     d3 = require('d3'),
     EmptySource = require('./EmptySource'),
     types = require('./react-types'),
+    utils = require('./utils'),
     d3utils = require('./d3utils');
 
 class ScaleTrack extends React.Component {
@@ -57,16 +58,6 @@ class ScaleTrack extends React.Component {
     return React.findDOMNode(this);
   }
 
-  // This formatting follows IGV's conventions regarding range display:
-  //  "1 bp", "101 bp", "1,001 bp", "1,001 kbp", ...
-  formatRange(viewSize: number): any {
-    var tmpViewSize = viewSize / 1000,
-        fprefix = d3.formatPrefix(tmpViewSize < 1 ? 1 : tmpViewSize),
-        unit = fprefix.symbol + "bp",  // bp, kbp, Mbp, Gbp
-        prefix = d3.format(',f.0')(fprefix.scale(viewSize));
-    return {prefix, unit};
-  }
-
   updateVisualization() {
     var div = this.getDOMNode(),
         range = this.props.range,
@@ -80,7 +71,7 @@ class ScaleTrack extends React.Component {
         midX = width / 2,
         midY = height / 2;
 
-    var {prefix, unit} = this.formatRange(viewSize);
+    var {prefix, unit} = utils.formatRange(viewSize);
 
     var midLabel = svg.select('.scale-label');
     var labelWidth = labelSize.width,

--- a/src/main/d3utils.js
+++ b/src/main/d3utils.js
@@ -20,6 +20,20 @@ function getTrackScale(range: GenomeRange, width: number) {
   return scale;
 }
 
+/**
+ * Formats the size of a view and infers what prefix/unit to show.
+ * This formatting follows IGV's conventions regarding range display:
+ *  "1 bp", "101 bp", "1,001 bp", "1,001 kbp", ...
+ */
+function formatRange(viewSize: number): any {
+  var tmpViewSize = viewSize / 1000,
+      fprefix = d3.formatPrefix(Math.max(1, tmpViewSize)),
+      unit = fprefix.symbol + "bp",  // bp, kbp, Mbp, Gbp
+      prefix = d3.format(',f.0')(fprefix.scale(viewSize));
+  return {prefix, unit};
+}
+
 module.exports = {
+  formatRange,
   getTrackScale
 };

--- a/src/main/pileup.js
+++ b/src/main/pileup.js
@@ -60,7 +60,6 @@ function create(elOrId: string|Element, params: PileupParams): Pileup {
     source: track.data ? track.data : track.viz.defaultSource,
     track
   }));
-  console.dir(vizTracks);
 
   var referenceTrack = findReference(vizTracks);
   if (!referenceTrack) {

--- a/src/main/pileup.js
+++ b/src/main/pileup.js
@@ -12,10 +12,12 @@ var _ = require('underscore'),
     VcfDataSource = require('./VcfDataSource'),
     BamDataSource = require('./BamDataSource'),
     GA4GHDataSource = require('./GA4GHDataSource'),
+    EmptySource = require('./EmptySource'),
     // Visualizations
     CoverageTrack = require('./CoverageTrack'),
     GenomeTrack = require('./GenomeTrack'),
     GeneTrack = require('./GeneTrack'),
+    LocationTrack = require('./LocationTrack'),
     PileupTrack = require('./PileupTrack'),
     VariantTrack = require('./VariantTrack'),
     Root = require('./Root');
@@ -54,7 +56,7 @@ function create(elOrId: string|Element, params: PileupParams): Pileup {
 
   var vizTracks = params.tracks.map(track => ({
     visualization: track.viz,
-    source: track.data,
+    source: track.data ? track.data : EmptySource.create(),
     track
   }));
 
@@ -84,12 +86,14 @@ var pileup = {
     ga4gh: GA4GHDataSource.create,
     vcf: VcfDataSource.create,
     twoBit: TwoBitDataSource.create,
-    bigBed: BigBedDataSource.create
+    bigBed: BigBedDataSource.create,
+    empty: EmptySource.create
   },
   viz: {
     coverage: () => CoverageTrack,
     genome: () => GenomeTrack,
     genes: () => GeneTrack,
+    location: () => LocationTrack,
     variants: () => VariantTrack,
     pileup: () => PileupTrack
   }

--- a/src/main/pileup.js
+++ b/src/main/pileup.js
@@ -55,11 +55,17 @@ function create(elOrId: string|Element, params: PileupParams): Pileup {
     throw new Error(`Attempted to create pileup with non-existent element ${elOrId}`);
   }
 
-  var vizTracks = params.tracks.map(track => ({
-    visualization: track.viz,
-    source: track.data ? track.data : track.viz.defaultSource,
-    track
-  }));
+  var vizTracks = params.tracks.map(function(track) {
+    var source = track.data ? track.data : track.viz.defaultSource;
+    if(!source) {
+      throw new Error(
+        `Track '${track.viz.displayName}' doesn't have a default ` +
+        `data source; you must specify one when initializing it.`
+      );
+    }
+
+    return {visualization: track.viz, source, track};
+  });
 
   var referenceTrack = findReference(vizTracks);
   if (!referenceTrack) {

--- a/src/main/pileup.js
+++ b/src/main/pileup.js
@@ -19,6 +19,7 @@ var _ = require('underscore'),
     GeneTrack = require('./GeneTrack'),
     LocationTrack = require('./LocationTrack'),
     PileupTrack = require('./PileupTrack'),
+    ScaleTrack = require('./ScaleTrack'),
     VariantTrack = require('./VariantTrack'),
     Root = require('./Root');
 
@@ -94,6 +95,7 @@ var pileup = {
     genome: () => GenomeTrack,
     genes: () => GeneTrack,
     location: () => LocationTrack,
+    scale: () => ScaleTrack,
     variants: () => VariantTrack,
     pileup: () => PileupTrack
   }

--- a/src/main/pileup.js
+++ b/src/main/pileup.js
@@ -57,9 +57,10 @@ function create(elOrId: string|Element, params: PileupParams): Pileup {
 
   var vizTracks = params.tracks.map(track => ({
     visualization: track.viz,
-    source: track.data ? track.data : EmptySource.create(),
+    source: track.data ? track.data : track.viz.defaultSource,
     track
   }));
+  console.dir(vizTracks);
 
   var referenceTrack = findReference(vizTracks);
   if (!referenceTrack) {

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -161,6 +161,19 @@ function pipePromise<T>(deferred: Q.Deferred<T>, promise: Q.Promise<T>) {
   promise.then(deferred.resolve, deferred.reject, deferred.notify);
 }
 
+/**
+ * Formats the size of a view and infers what prefix/unit to show.
+ * This formatting follows IGV's conventions regarding range display:
+ *  "1 bp", "101 bp", "1,001 bp", "1,001 kbp", ...
+ */
+function formatRange(viewSize: number): any {
+  var tmpViewSize = viewSize / 1000,
+      fprefix = d3.formatPrefix(Math.max(1, tmpViewSize)),
+      unit = fprefix.symbol + "bp",  // bp, kbp, Mbp, Gbp
+      prefix = d3.format(',f.0')(fprefix.scale(viewSize));
+  return {prefix, unit};
+}
+
 module.exports = {
   tupleLessOrEqual,
   tupleRangeOverlaps,
@@ -170,4 +183,5 @@ module.exports = {
   basePairClass,
   altContigName,
   pipePromise,
+  formatRange
 };

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -161,19 +161,6 @@ function pipePromise<T>(deferred: Q.Deferred<T>, promise: Q.Promise<T>) {
   promise.then(deferred.resolve, deferred.reject, deferred.notify);
 }
 
-/**
- * Formats the size of a view and infers what prefix/unit to show.
- * This formatting follows IGV's conventions regarding range display:
- *  "1 bp", "101 bp", "1,001 bp", "1,001 kbp", ...
- */
-function formatRange(viewSize: number): any {
-  var tmpViewSize = viewSize / 1000,
-      fprefix = d3.formatPrefix(Math.max(1, tmpViewSize)),
-      unit = fprefix.symbol + "bp",  // bp, kbp, Mbp, Gbp
-      prefix = d3.format(',f.0')(fprefix.scale(viewSize));
-  return {prefix, unit};
-}
-
 module.exports = {
   tupleLessOrEqual,
   tupleRangeOverlaps,
@@ -182,6 +169,5 @@ module.exports = {
   inflateGzip,
   basePairClass,
   altContigName,
-  pipePromise,
-  formatRange
+  pipePromise
 };

--- a/src/test/components-test.js
+++ b/src/test/components-test.js
@@ -35,10 +35,12 @@ describe('pileup', function() {
     },
     {
       viz: pileup.viz.scale(),
+      data: pileup.formats.empty(),
       name: 'Scale'
     },
     {
       viz: pileup.viz.location(),
+      data: pileup.formats.empty(),
       name: 'Location'
     },
     {

--- a/src/test/components-test.js
+++ b/src/test/components-test.js
@@ -34,6 +34,14 @@ describe('pileup', function() {
       cssClass: 'c'
     },
     {
+      viz: pileup.viz.scale(),
+      name: 'Scale'
+    },
+    {
+      viz: pileup.viz.location(),
+      name: 'Location'
+    },
+    {
       viz: pileup.viz.pileup(),
       data: pileup.formats.bam({
         url: '/test-data/chr17.1-250.bam',

--- a/src/test/d3utils-test.js
+++ b/src/test/d3utils-test.js
@@ -1,0 +1,30 @@
+/* @flow */
+'use strict';
+
+var expect = require('chai').expect;
+var d3 = require('d3');
+var d3utils = require('../main/d3utils');
+
+describe('d3utils', function() {
+  describe('formatRange', function() {
+    var formatRange = d3utils.formatRange;
+
+    it('should format view sizes correctly', function() {
+      var r = formatRange(101);
+      expect(r.prefix).to.be.equal("101");
+      expect(r.unit).to.be.equal("bp");
+
+      r = formatRange(10001);
+      expect(r.prefix).to.be.equal("10,001");
+      expect(r.unit).to.be.equal("bp");
+
+      r = formatRange(10001001);
+      expect(r.prefix).to.be.equal("10,001");
+      expect(r.unit).to.be.equal("kbp");
+
+      r = formatRange(10001000001);
+      expect(r.prefix).to.be.equal("10,001");
+      expect(r.unit).to.be.equal("Mbp");
+    });
+  });
+});

--- a/src/test/utils-test.js
+++ b/src/test/utils-test.js
@@ -120,27 +120,4 @@ describe('utils', function() {
     expect(utils.altContigName('chrM')).to.equal('M');
   });
 
-  describe('formatRange', function() {
-    var formatRange = utils.formatRange;
-
-    it('should format view sizes correctly', function() {
-      var r = formatRange(101);
-      expect(r.prefix).to.be.equal("101");
-      expect(r.unit).to.be.equal("bp");
-
-      r = formatRange(10001);
-      expect(r.prefix).to.be.equal("10,001");
-      expect(r.unit).to.be.equal("bp");
-
-      r = formatRange(10001001);
-      expect(r.prefix).to.be.equal("10,001");
-      expect(r.unit).to.be.equal("kbp");
-
-      r = formatRange(10001000001);
-      expect(r.prefix).to.be.equal("10,001");
-      expect(r.unit).to.be.equal("Mbp");
-    });
-    
-  });
-
 });

--- a/src/test/utils-test.js
+++ b/src/test/utils-test.js
@@ -119,4 +119,28 @@ describe('utils', function() {
     expect(utils.altContigName('M')).to.equal('chrM');
     expect(utils.altContigName('chrM')).to.equal('M');
   });
+
+  describe('formatRange', function() {
+    var formatRange = utils.formatRange;
+
+    it('should format view sizes correctly', function() {
+      var r = formatRange(101);
+      expect(r.prefix).to.be.equal("101");
+      expect(r.unit).to.be.equal("bp");
+
+      r = formatRange(10001);
+      expect(r.prefix).to.be.equal("10,001");
+      expect(r.unit).to.be.equal("bp");
+
+      r = formatRange(10001001);
+      expect(r.prefix).to.be.equal("10,001");
+      expect(r.unit).to.be.equal("kbp");
+
+      r = formatRange(10001000001);
+      expect(r.prefix).to.be.equal("10,001");
+      expect(r.unit).to.be.equal("Mbp");
+    });
+    
+  });
+
 });

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -202,3 +202,18 @@
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: smaller;
 }
+
+/* scale track */
+.pileup-root > .scale {
+  flex: 0 0 20px;  /* fixed height */
+}
+.scale .scale-lline, .scale .scale-rline {
+  stroke: gray;
+  stroke-width: 1.5;
+}
+.scale .scale-label {
+  color: black;
+  font-weight: bold;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: smaller;
+}

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -188,3 +188,17 @@
   fill: white;
   opacity: 0.5;
 }
+
+/* location track */
+.pileup-root > .location {
+  flex: 0 0 20px;  /* fixed height */
+}
+.location .location-hline, .location .location-vline {
+  stroke: gray;
+  stroke-width: 1.5;
+}
+.location .location-label {
+  color: black;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: smaller;
+}

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -193,7 +193,7 @@
 .pileup-root > .location {
   flex: 0 0 20px;  /* fixed height */
 }
-.location .location-hline, .location .location-vline {
+.location .location-hline, .location .location-vline-left, .location .location-vline-right {
   stroke: gray;
   stroke-width: 1.5;
 }
@@ -201,6 +201,8 @@
   color: black;
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: smaller;
+  text-anchor: start;
+  dominant-baseline: central;
 }
 
 /* scale track */

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -15,7 +15,7 @@
   flex-direction: row;
 }
 .pileup-root text, .track-label {
-   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 .track-label {
   flex: 0 0 100px;  /* fixed-width track labels */

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -14,10 +14,12 @@
   display: flex;
   flex-direction: row;
 }
+.pileup-root text, .track-label {
+   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
 .track-label {
   flex: 0 0 100px;  /* fixed-width track labels */
   text-align: right;
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 0.9em;
   position: relative;  /* make this an offset parent for positioning the label. */
 }
@@ -73,7 +75,6 @@
 .basepair.T { fill: #F70016; }
 .basepair.U { fill: #F70016; }
 .basepair text, text.basepair {
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   text-anchor: middle;
 }
 .loose text {
@@ -93,7 +94,6 @@
   stroke: blue;
 }
 .gene text {
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 16px;
   text-anchor: middle;
   stroke: black;
@@ -142,7 +142,6 @@
   justify-content: center;
 }
 .pileup .network-status-message {
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   padding: 4px 8px;
   width: auto;
   background: #eee;
@@ -175,7 +174,6 @@
 }
 .coverage .y-axis g.tick text {
   color: black;
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: x-small;
   stroke: whitesmoke;
   stroke-width: 2;
@@ -199,7 +197,6 @@
 }
 .location .location-label {
   color: black;
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: smaller;
   text-anchor: start;
   dominant-baseline: central;
@@ -216,7 +213,6 @@
 .scale .scale-label {
   color: black;
   font-weight: bold;
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: smaller;
   dominant-baseline: central;
   text-anchor: middle;

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -218,4 +218,6 @@
   font-weight: bold;
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: smaller;
+  dominant-baseline: central;
+  text-anchor: middle;
 }


### PR DESCRIPTION
This implements two tracks that do not use data sources, but create helper visualizations based on the visible genomic range (closes #62).

`LocationTrack` marks the middle of the visible range and shows the exact base location next to the line mark:
![screen recording 2015-07-23 at 10 32 pm](https://cloud.githubusercontent.com/assets/7809/8866614/836f1da0-318c-11e5-989e-ff6a23b0889a.gif)

`ScaleTrack` track includes a centered scale bar of which size is determined by the visible range and a `niceify` method that heuristically fine tunes the exact size of the bar. For regions bigger than 1000bp, the visualization creates a scale bar on the order of kilobase (kb), megabase (mb) or gigabase (gb):
![screen recording 2015-07-23 at 10 51 pm](https://cloud.githubusercontent.com/assets/7809/8866705/75ba7b0e-318d-11e5-8380-254884691d79.gif)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/241)
<!-- Reviewable:end -->
