### PR TITLE
Show paired reads in PileupTrack.

### DIFF
--- a/examples/playground.js
+++ b/examples/playground.js
@@ -64,6 +64,6 @@ var sources = [
 ];
 
 var p = pileup.create(yourDiv, {
-  range: {contig: 'chr17', start: 7512384, stop: 7512544},
+  range: {contig: 'chr17', start: 7512284, stop: 7512644},
   tracks: sources
 });

--- a/lib/underscore.js
+++ b/lib/underscore.js
@@ -1,6 +1,7 @@
 // type definitions for (some of) underscore
 
 declare module "underscore" {
+  declare function find<T>(list: T[], predicate: (val: T)=>boolean): ?T;
   declare function findWhere<T>(list: Array<T>, properties: {}): ?T;
   declare function clone<T>(obj: T): T;
 
@@ -38,5 +39,8 @@ declare module "underscore" {
 
   declare function min<T>(a: Array<T>|{[key:any]: T}): T;
   declare function max<T>(a: Array<T>|{[key:any]: T}): T;
+
+  declare function values<T>(o: {[key: any]: T}): T[];
+  declare function flatten(a: Array<any>): Array<any>;
 }
 

--- a/src/main/PileupCache.js
+++ b/src/main/PileupCache.js
@@ -1,0 +1,183 @@
+/**
+ * Data management for PileupTrack.
+ *
+ * This class groups paired reads and piles them up.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {Strand, Alignment, AlignmentDataSource} from './Alignment';
+import type {TwoBitSource} from './TwoBitDataSource';
+import type {BasePair} from './pileuputils';
+
+var _ = require('underscore'),
+    ContigInterval = require('./ContigInterval'),
+    Interval = require('./Interval'),
+    {addToPileup, getOpInfo, CigarOp} = require('./pileuputils'),
+    utils = require('./utils');
+
+// This bundles everything intrinsic to the alignment that we need to display
+// it, i.e. everything not dependend on scale/viewport.
+export type VisualAlignment = {
+  read: Alignment;
+  strand: Strand;
+  refLength: number;  // span on the reference (accounting for indels)
+  mismatches: Array<BasePair>;
+};
+
+// This is typically a read pair, but may be a single read in some situations.
+type VisualGroup = {
+  key: string;
+  row: number;  // pileup row.
+  span: ContigInterval<string>;  // tip-to-tip span for the read group
+  insert: ?Interval;  // interval for the connector, if applicable.
+  alignments: VisualAlignment[];
+};
+
+// read name would make a good key, but paired reads from different contigs
+// shouldn't be grouped visually. Hence we use read name + contig.
+function groupKey(read: Alignment): string {
+  return `${read.getName()}:${read.ref}`;
+}
+
+// This class provides data management for the visualization, grouping paired
+// reads and managing the pileup.
+class PileupCache {
+  // maps groupKey to VisualGroup
+  groups: {[key: string]: VisualGroup};
+  refToPileup: {[key: string]: Array<Interval[]>};
+  referenceSource: TwoBitSource;
+
+  constructor(referenceSource: TwoBitSource) {
+    this.groups = {};
+    this.refToPileup = {};
+    this.referenceSource = referenceSource;
+  }
+
+  // Load a new read into the visualization cache.
+  // Calling this multiple times with the same read is a no-op.
+  addAlignment(read: Alignment) {
+    var key = groupKey(read),
+        range = read.getInterval(),
+        iv = range.interval;
+
+    if (!(key in this.groups)) {
+      this.groups[key] = {
+        key: key,
+        row: -1,  // TBD
+        insert: null,  // TBD
+        span: range,
+        alignments: []
+      };
+    }
+    var group = this.groups[key];
+
+    if (_.find(group.alignments, a => a.read == read)) {
+      return;  // we've already got it.
+    }
+
+    var opInfo = getOpInfo(read, this.referenceSource);
+    var visualAlignment = {
+      read,
+      strand: read.getStrand(),
+      refLength: range.length(),
+      ops: opInfo.ops,
+      mismatches: opInfo.mismatches
+    };
+    group.alignments.push(visualAlignment);
+
+    if (group.alignments.length == 1) {
+      // This is the first read in the group. Infer its span from its mate properties.
+      // TODO: if the mate Alignment is also available, it would be better to use that.
+      var intervals = [range];
+      var mateProps = read.getMateProperties();
+      if (mateProps && mateProps.ref && mateProps.ref == read.ref) {
+        var mateInterval = new ContigInterval(mateProps.ref, mateProps.pos, mateProps.pos + range.length());
+        intervals.push(mateInterval);
+      }
+      var {span, insert} = spanAndInsert(intervals);
+      group.insert = insert;
+      group.span = span;
+
+      if (!(read.ref in this.refToPileup)) {
+        this.refToPileup[read.ref] = [];
+      }
+      var pileup = this.refToPileup[read.ref];
+      group.row = addToPileup(span.interval, pileup);
+    } else if (group.alignments.length == 2) {
+      // Refine the connector
+      var mateInterval = group.alignments[0].read.getInterval();
+      var {span, insert} = spanAndInsert([range, mateInterval]);
+      group.insert = insert;
+      if (insert) {
+        group.span = span;
+      }
+    } else {
+      // this must be a chimeric read.
+    }
+  }
+
+  // Updates reference mismatch information for previously-loaded reads.
+  updateMismatches(range: ContigInterval<string>) {
+    for (var k in this.groups) {
+      var reads = this.groups[k].alignments;
+      for (var vRead of reads) {
+        var read = vRead.read;
+        if (read.getInterval().chrIntersects(range)) {
+          var opInfo = getOpInfo(read, this.referenceSource);
+          vRead.mismatches = opInfo.mismatches;
+        }
+      }
+    }
+  }
+
+  // How many rows tall is the pileup for a given ref? This is related to the
+  // maximum read depth. This is 'chr'-agnostic.
+  pileupHeightForRef(ref: string): number {
+    if (ref in this.refToPileup) {
+      return this.refToPileup[ref].length;
+    } else {
+      var alt = utils.altContigName(ref);
+      if (alt in this.refToPileup) {
+        return this.refToPileup[alt].length;
+      } else {
+        return 0;
+      }
+    }
+  }
+
+  // Find groups overlapping the range. This is 'chr'-agnostic.
+  getGroupsOverlapping(range: ContigInterval<string>): VisualGroup[] {
+    // TODO: speed this up using an interval tree
+    return _.filter(this.groups, group => group.span.chrIntersects(range));
+  }
+}
+
+// Helper method for addRead.
+// Given 1-2 intervals, compute their span and insert (interval between them).
+// For one interval, these are both trivial.
+function spanAndInsert(intervals: ContigInterval<string>[]) {
+  if (intervals.length == 1) {
+    return {insert: null, span: intervals[0]};
+  } else if (intervals.length !=2) {
+    throw `Called spanAndInsert with ${intervals.length} \in [1, 2]`;
+  }
+
+  if (!intervals[0].chrOnContig(intervals[1].contig)) {
+    return spanAndInsert([intervals[0]]);
+  }
+  var iv1 = intervals[0].interval,
+      iv2 = intervals[1].interval,
+      insert = iv1.start < iv2.start ?
+          new Interval(iv1.stop, iv2.start) :
+          new Interval(iv2.stop, iv1.start);
+
+  var span = Interval.boundingInterval([iv1, iv2]);
+  return {
+    insert,
+    span: new ContigInterval(intervals[0].contig, span.start, span.stop)
+  };
+}
+
+module.exports = PileupCache;

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -4,8 +4,10 @@
  */
 'use strict';
 
-import type * as SamRead from './SamRead';
-import type * as Interval from './Interval';
+import type {Strand, Alignment, AlignmentDataSource} from './Alignment';
+import type {TwoBitSource} from './TwoBitDataSource';
+import type {BasePair} from './pileuputils';
+import type {VisualAlignment} from './PileupCache';
 
 var React = require('./react-shim'),
     d3 = require('d3'),
@@ -16,7 +18,9 @@ var React = require('./react-shim'),
     d3utils = require('./d3utils'),
     {addToPileup, getOpInfo, CigarOp} = require('./pileuputils'),
     ContigInterval = require('./ContigInterval'),
-    DisplayMode = require('./DisplayMode');
+    Interval = require('./Interval'),
+    DisplayMode = require('./DisplayMode'),
+    PileupCache = require('./PileupCache');
 
 
 var READ_HEIGHT = 13;
@@ -121,30 +125,8 @@ function isRendered(op) {
 }
 
 function readClass(vread: VisualAlignment) {
-  return 'alignment ' + (vread.strand == Strand.NEGATIVE ? 'negative' : 'positive');
+  return 'alignment ' + (vread.strand == '-' ? 'negative' : 'positive');
 }
-
-// Copied from pileuputils.js
-type BasePair = {
-  pos: number;
-  basePair: string;
-  quality: number;
-}
-
-// This bundles everything intrinsic to the alignment that we need to display
-// it, i.e. everything not dependend on scale/viewport.
-type VisualAlignment = {
-  key: string;
-  read: SamRead;
-  strand: number;  // see Strand below
-  row: number;  // pileup row.
-  refLength: number;  // span on the reference (accounting for indels)
-  mismatches: Array<BasePair>;
-};
-var Strand = {
-  POSITIVE: 0,
-  NEGATIVE: 1
-};
 
 
 function yForRow(row) {
@@ -167,16 +149,13 @@ function opacityForQuality(quality: number): number {
 }
 
 class PileupTrack extends React.Component {
-  pileup: Array<Interval[]>;
-  keyToVisualAlignment: {[key:string]: VisualAlignment};
+  cache: PileupCache;
 
   constructor(props: Object) {
     super(props);
     this.state = {
       reads: []
     };
-    this.pileup = [];
-    this.keyToVisualAlignment = {};
   }
 
   render(): any {
@@ -224,12 +203,13 @@ class PileupTrack extends React.Component {
     d3.select(div)
       .append('svg');
 
+    this.cache = new PileupCache(this.props.referenceSource);
     this.props.source.on('newdata', range => {
       this.updateReads(range);
       this.updateVisualization();
     });
-    this.props.referenceSource.on('newdata', () => {
-      this.updateMismatches();
+    this.props.referenceSource.on('newdata', range => {
+      this.cache.updateMismatches(range);
       this.updateVisualization();
     });
     this.props.source.on('networkprogress', e => {
@@ -252,50 +232,11 @@ class PileupTrack extends React.Component {
     }
   }
 
-  // Attach visualization info to the read and cache it.
-  addRead(read: SamRead, referenceSource: any): VisualAlignment {
-    var key = read.getKey();
-    if (key in this.keyToVisualAlignment) {
-      return this.keyToVisualAlignment[key];
-    }
-
-    var range = read.getInterval(),
-        refLength = range.length(),
-        opInfo = getOpInfo(read, referenceSource);
-
-    var visualAlignment = {
-      key,
-      read,
-      strand: read.getStrand() == '+' ? Strand.POSITIVE : Strand.NEGATIVE,
-      row: addToPileup(range.interval, this.pileup),
-      refLength,
-      ops: opInfo.ops,
-      mismatches: opInfo.mismatches
-    };
-
-    this.keyToVisualAlignment[key] = visualAlignment;
-    return visualAlignment;
-  }
-
-  // Updates reference mismatch information for previously-loaded reads.
-  updateMismatches() {
-    // TODO: dedupe with addRead()
-    var referenceSource = this.props.referenceSource;
-    for (var k in this.keyToVisualAlignment) {
-      var vRead = this.keyToVisualAlignment[k],
-          read = vRead.read,
-          opInfo = getOpInfo(read, referenceSource);
-
-      vRead.mismatches = opInfo.mismatches;
-    }
-  }
-
   // Load new reads into the visualization cache.
   updateReads(range: ContigInterval<string>) {
-    var newReads = this.props.source.getAlignmentsInRange(range);
-
-    var referenceSource = this.props.referenceSource;
-    newReads.forEach(read => this.addRead(read, referenceSource));
+    var source = (this.props.source : AlignmentDataSource);
+    source.getAlignmentsInRange(range)
+          .forEach(read => this.cache.addAlignment(read));
   }
 
   // Update the D3 visualization to reflect the cached reads &
@@ -309,27 +250,35 @@ class PileupTrack extends React.Component {
     if (width === 0) return;
 
     // Height can only be computed after the pileup has been updated.
-    var height = yForRow(this.pileup.length);
+    var height = yForRow(this.cache.pileupHeightForRef(this.props.range.contig));
     var scale = this.getScale();
 
     svg.attr('width', width)
        .attr('height', height);
 
-    // TODO: speed this up using an interval tree
     var genomeRange = this.props.range,
         range = new ContigInterval(genomeRange.contig, genomeRange.start, genomeRange.stop);
-    var vReads = _.filter(this.keyToVisualAlignment,
-                          vRead => vRead.refLength > 0 &&  // drop alignments w/o CIGARs
-                                   vRead.read.getInterval().chrIntersects(range))
-
-    var reads = svg.selectAll('.alignment')
-       .data(vReads, vRead => vRead.key);
+    var vGroups = this.cache.getGroupsOverlapping(range);
 
     // Enter
+    var groups = svg.selectAll('.read-group').data(vGroups, vGroup => vGroup.key);
+
+    groups.enter()
+        .append('g')
+        .attr('class', 'read-group')
+        .attr('transform', vGroup => `translate(0, ${yForRow(vGroup.row)})`);
+
+    var connectors = groups.selectAll('.mate-connector')
+        .data(vGroup => vGroup.insert ? [vGroup.insert] : []);
+    connectors.enter().append('line').attr('class', 'mate-connector');
+
+    var reads = groups.selectAll('.alignment')
+        // drop alignments w/o CIGARs
+        .data(vGroup => vGroup.alignments.filter(vRead => vRead.refLength > 0));
+
     reads.enter()
         .append('g')
         .attr('class', readClass)
-        .attr('transform', vRead => `translate(0, ${yForRow(vRead.row)})`)
         .on('click', vRead => {
           window.alert(vRead.read.debugString());
         });
@@ -357,7 +306,6 @@ class PileupTrack extends React.Component {
                            .data(vRead => vRead.mismatches.length ? [{vRead,mode}] : [],
                                  x => x.mode);
     modeWrapper.enter().append('g').attr('class', 'mode-wrapper');
-    modeWrapper.exit().remove();
 
     var letter = modeWrapper.selectAll('.basepair')
         .data(d => d.vRead.mismatches, m => m.pos + m.basePair);
@@ -374,6 +322,14 @@ class PileupTrack extends React.Component {
           .attr('fill-opacity', mismatch => opacityForQuality(mismatch.quality));
 
     // Update
+    connectors.each(function(interval, i) {
+      d3.select(this).attr({
+        x1: scale(interval.start),
+        x2: scale(interval.stop + 1),
+        y1: READ_HEIGHT / 2,
+        y2: READ_HEIGHT / 2
+      })
+    });
     segments.each(function(d, i) {
       updateSegment(this, d, scale);
     });
@@ -381,12 +337,15 @@ class PileupTrack extends React.Component {
          .attr('x', mismatch => scale(1 + 0.5 + mismatch.pos));  // 0.5 = centered
     reads.selectAll('rect.basepair')
           .attr('x', mismatch => scale(1 + mismatch.pos))
-          .attr('width', pxPerLetter - 1)
+          .attr('width', pxPerLetter - 1);
 
     // Exit
+    groups.exit().remove();
+    connectors.exit().remove();
     reads.exit().remove();
     letter.exit().remove();
     segments.exit().remove();
+    modeWrapper.exit().remove();
   }
 
 }

--- a/src/main/Root.js
+++ b/src/main/Root.js
@@ -4,7 +4,6 @@
  */
 'use strict';
 
-import type * as SamRead from './SamRead';
 import type {VisualizedTrack} from './types';
 
 var React = require('./react-shim'),

--- a/src/main/SamRead.js
+++ b/src/main/SamRead.js
@@ -100,7 +100,7 @@ class SamRead /* implements Alignment */ {
     return this._getJDataView().getUint16(14);
   }
 
-  getStrand(): string {
+  getStrand(): Strand {
     return strandFlagToString(this.getFlag() & bamTypes.Flags.READ_STRAND);
   }
 

--- a/src/main/TwoBitDataSource.js
+++ b/src/main/TwoBitDataSource.js
@@ -34,7 +34,7 @@ var MAX_BASE_PAIRS_TO_FETCH = 2000;
 
 
 // Flow type for export.
-type TwoBitSource = {
+export type TwoBitSource = {
   rangeChanged: (newRange: GenomeRange) => void;
   getRange: (range: GenomeRange) => ?{[key:string]: string};
   getRangeAsString: (range: GenomeRange) => string;

--- a/src/main/pileuputils.js
+++ b/src/main/pileuputils.js
@@ -2,6 +2,7 @@
 'use strict';
 
 import type * as SamRead from './SamRead';
+import type {Alignment} from './Alignment';
 import type * as Interval from './Interval';
 
 /**
@@ -65,7 +66,7 @@ function addToPileup(read: Interval, pileup: Array<Interval[]>): number {
   return chosenRow;
 }
 
-type BasePair = {
+export type BasePair = {
   pos: number;
   basePair: string;
   quality: number;
@@ -95,7 +96,7 @@ type OpInfo = {
 
 // Determine which alignment segment to render as an arrow.
 // This is either the first or last 'M' section, excluding soft clipping.
-function getArrowIndex(read: SamRead): number {
+function getArrowIndex(read: Alignment): number {
   var i, op, ops = read.getCigarOps();
   if (read.getStrand() == '-') {
     for (i = 0; i < ops.length; i++) {
@@ -129,7 +130,7 @@ var CigarOp = {
 };
 
 // Breaks the read down into Cigar Ops suitable for display
-function getOpInfo(read: SamRead, referenceSource: Object): OpInfo {
+function getOpInfo(read: Alignment, referenceSource: Object): OpInfo {
   var ops = read.getCigarOps();
 
   var range = read.getInterval(),

--- a/src/test/PileupCache-test.js
+++ b/src/test/PileupCache-test.js
@@ -1,0 +1,177 @@
+/**
+ * @flow
+ */
+'use strict';
+
+import type {Alignment, CigarOp, MateProperties, Strand} from '../main/Alignment';
+
+var expect = require('chai').expect;
+var _ = require('underscore');
+
+var PileupCache = require('../main/PileupCache'),
+    ContigInterval = require('../main/ContigInterval'),
+    Interval = require('../main/Interval');
+
+var numAlignments = 1;
+class TestAlignment /* implements Alignment */ {
+  pos: number;
+  ref: string;
+  key: string;
+  interval: ContigInterval<string>;
+  mateProps: ?MateProperties;
+  name: string;
+  strand: Strand;
+
+  constructor(interval: ContigInterval<string>, name: string, strand: Strand, mateProps: ?MateProperties) {
+    this.interval = interval;
+    this.ref = interval.contig;
+    this.pos = interval.start();
+    this.name = name;
+    this.strand = strand;
+    this.key = 'align:' + (numAlignments++);
+    this.mateProps = mateProps;
+  }
+
+  getKey(): string { return this.key; }
+  getName(): string { return this.name; }
+  getStrand(): Strand { return this.strand; }
+  getCigarOps(): CigarOp[] { return []; }
+  getQualityScores(): number[] { return []; }
+  getSequence(): string { return ''; }
+  getInterval(): ContigInterval<string> { return this.interval; }
+  getReferenceLength(): number { return this.interval.length(); }
+  getMateProperties(): ?MateProperties { return this.mateProps; }
+
+  intersects(interval: ContigInterval<string>): boolean {
+    return interval.intersects(this.getInterval());
+  }
+}
+
+var nameCounter = 1;
+function makeReadPair(range1: ContigInterval<string>, range2: ContigInterval<string>): Alignment[] {
+  var name = 'group:' + (nameCounter++);
+  return [
+    new TestAlignment(range1, name, '+', {ref: range2.contig, pos: range2.start(), strand: '-' }),
+    new TestAlignment(range2, name, '-', {ref: range1.contig, pos: range1.start(), strand: '+' })
+  ];
+}
+
+function makeUnpairedRead(range: ContigInterval<string>, strand: Strand): Alignment {
+  var name = 'group:' + (nameCounter++);
+  return new TestAlignment(range, name, strand, null);
+}
+
+function dieFn() { throw 'Should not have called this.'; }
+var fakeSource = {
+  rangeChanged: dieFn,
+  getRange: function() { return {}; },
+  getRangeAsString: function() { return ''; },
+  contigList: function() { return []; },
+  normalizeRange: function() { },
+  on: dieFn,
+  off: dieFn,
+  once: dieFn,
+  trigger: dieFn
+};
+
+describe('PileupCache', function() {
+  function ci(...x: any) { return new ContigInterval(...x); }
+
+  function makeCache(args) {
+    var cache = new PileupCache(fakeSource);
+    _.flatten(args).forEach(read => cache.addAlignment(read));
+    return cache;
+  }
+
+  it('should group read pairs', function() {
+    var cache = makeCache(makeReadPair(ci('chr1', 100, 200),
+                                       ci('chr1', 300, 400)));
+
+    var groups = _.values(cache.groups);
+    expect(groups).to.have.length(1);
+    var g = groups[0];
+    expect(g.row).to.equal(0);
+    expect(g.insert).to.not.be.null;
+    if (!g.insert) return;  // for flow
+    expect(g.insert.toString()).to.equal('[200, 300]');
+    expect(g.alignments).to.have.length(2);
+    expect(g.alignments[0].read.getInterval().toString()).to.equal('chr1:100-200');
+    expect(g.alignments[1].read.getInterval().toString()).to.equal('chr1:300-400');
+    expect(g.span.toString()).to.equal('chr1:100-400');
+    expect(cache.pileupHeightForRef('chr1')).to.equal(1);
+    expect(cache.pileupHeightForRef('chr2')).to.equal(0);
+  });
+
+  it('should group pile up pairs', function() {
+    // A & B overlap, B & C overlap, but A & C do not. So two rows will suffice.
+    var cache = makeCache([
+      makeReadPair(ci('chr1', 100, 200), ci('chr1', 300, 400)),  // A
+      makeReadPair(ci('chr1', 300, 400), ci('chr1', 500, 600)),  // B
+      makeReadPair(ci('chr1', 700, 800), ci('chr1', 500, 600))   // C
+    ]);
+
+    var groups = _.values(cache.groups);
+    expect(groups).to.have.length(3);
+    expect(groups[0].row).to.equal(0);
+    expect(groups[1].row).to.equal(1);
+    expect(groups[2].row).to.equal(0);
+    expect(cache.pileupHeightForRef('chr1')).to.equal(2);
+  });
+
+  it('should pile pairs which overlap only in their inserts', function() {
+    // No individual reads overlap, but they do when their inserts are included.
+    var cache = makeCache([
+      makeReadPair(ci('chr1', 100, 200), ci('chr1', 800, 900)),
+      makeReadPair(ci('chr1', 300, 400), ci('chr1', 500, 600))
+    ]);
+
+    var groups = _.values(cache.groups);
+    expect(groups).to.have.length(2);
+    expect(groups[0].row).to.equal(0);
+    expect(groups[1].row).to.equal(1);
+    expect(cache.pileupHeightForRef('chr1')).to.equal(2);
+  });
+
+  it('should separate pairs on differing contigs', function() {
+    var cache = makeCache(makeReadPair(ci('chr1', 100, 200),
+                                       ci('chr2', 150, 250)));
+
+    var groups = _.values(cache.groups);
+    expect(groups).to.have.length(2);
+    expect(groups[0].row).to.equal(0);
+    expect(groups[1].row).to.equal(0);
+    expect(groups[0].alignments).to.have.length(1);
+    expect(groups[1].alignments).to.have.length(1);
+    expect(groups[0].insert).to.be.null;
+    expect(groups[1].insert).to.be.null;
+    expect(cache.pileupHeightForRef('chr1')).to.equal(1);
+    expect(cache.pileupHeightForRef('chr2')).to.equal(1);
+    expect(cache.pileupHeightForRef('1')).to.equal(1);
+    expect(cache.pileupHeightForRef('2')).to.equal(1);
+  });
+
+  it('should find overlapping reads', function() {
+    var cache = makeCache([
+      makeReadPair(ci('chr1', 100, 200), ci('chr1', 800, 900)),
+      makeReadPair(ci('chr1', 300, 400), ci('chr1', 500, 600)),
+      makeReadPair(ci('chr2', 100, 200), ci('chr2', 300, 400))
+    ]);
+
+    expect(cache.getGroupsOverlapping(ci('chr1', 50, 150))).to.have.length(1);
+    expect(cache.getGroupsOverlapping(ci('chr1', 50, 350))).to.have.length(2);
+    expect(cache.getGroupsOverlapping(ci('chr1', 300, 400))).to.have.length(2);
+    expect(cache.getGroupsOverlapping(ci('chr1', 850, 950))).to.have.length(1);
+    expect(cache.getGroupsOverlapping(ci('chr1', 901, 950))).to.have.length(0);
+    expect(cache.getGroupsOverlapping(ci('chr2', 50, 150))).to.have.length(1);
+    expect(cache.getGroupsOverlapping(ci('chr2', 250, 260))).to.have.length(1);
+    expect(cache.getGroupsOverlapping(ci('chr3', 250, 260))).to.have.length(0);
+
+    // 'chr'-tolerance
+    expect(cache.getGroupsOverlapping(ci('1', 50, 150))).to.have.length(1);
+    expect(cache.getGroupsOverlapping(ci('1', 50, 350))).to.have.length(2);
+  });
+
+  // TODO:
+  // - a mate with an insertion or deletion
+  // - unpaired reads
+});

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -150,6 +150,10 @@
   font-size: small;
 }
 
+.pileup .mate-connector {
+  stroke: #c8c8c8;  /* matches IGV */
+}
+
 /* variants */
 .pileup-root > .variants {
   flex: 0 0 25px;  /* fixed height */


### PR DESCRIPTION
This factors out a PileupCache class, which manages the data being visualized by PileupTrack.

Here's what it looks like:
![pairs in pileup](https://cloud.githubusercontent.com/assets/98301/9919289/e0c7c488-5c99-11e5-83f9-36a2cada6b1a.png)

Remaining work, probably for follow-up PRs:
- Make "view as pairs" optional (includes some design & API work, too)
- Performance optimizations (there seems to be a bit of a regression)
- Pack the reads more intelligently (there's more wasted space now)

Fixes #110 
Fixes #108

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/251)
<!-- Reviewable:end -->
