### PR TITLE
Migrate PileupTrack from SVG→canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "chai": "^2.0.0",
     "coveralls": "2.10.x",
     "es5-shim": "^4.1.0",
-    "flow-bin": "^0.15.0",
+    "flow-bin": "^0.16.0",
     "http-server": "^0.8.0",
     "istanbul": "^0.3.17",
     "jscoverage": "^0.5.9",

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-noflow=$(git ls-files | egrep '^(src|test).*\.js$' | grep -v '/canvas.js' | xargs grep --files-without-match '@flow')
+noflow=$(git ls-files | egrep '^(src|test).*\.js$' | grep -v '/data-canvas.js' | xargs grep --files-without-match '@flow')
 if [ -n "$noflow" ]; then
   echo 'These files are missing @flow annotations:'
   echo "$noflow"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-noflow=$(git ls-files | egrep '^(src|test).*\.js$' | xargs grep --files-without-match '@flow')
+noflow=$(git ls-files | egrep '^(src|test).*\.js$' | grep -v '/canvas.js' | xargs grep --files-without-match '@flow')
 if [ -n "$noflow" ]; then
   echo 'These files are missing @flow annotations:'
   echo "$noflow"

--- a/src/main/Alignment.js
+++ b/src/main/Alignment.js
@@ -7,10 +7,12 @@ import type * as ContigInterval from './ContigInterval';
 
 // "CIGAR" operations express how a sequence aligns to the reference: does it
 // have insertions? deletions? For more background, see the SAM/BAM paper.
+export type CigarSymbol = 'M'|'I'|'D'|'N'|'S'|'H'|'P'|'='|'X';
 export type CigarOp = {
-  op: string;  // M, I, D, N, S, H, P, =, X
+  op: CigarSymbol;
   length: number
 }
+
 
 export type Strand = '-' | '+';
 

--- a/src/main/PileupCache.js
+++ b/src/main/PileupCache.js
@@ -28,7 +28,7 @@ export type VisualAlignment = {
 };
 
 // This is typically a read pair, but may be a single read in some situations.
-type VisualGroup = {
+export type VisualGroup = {
   key: string;
   row: number;  // pileup row.
   span: ContigInterval<string>;  // tip-to-tip span for the read group

--- a/src/main/PileupCache.js
+++ b/src/main/PileupCache.js
@@ -24,6 +24,7 @@ export type VisualAlignment = {
   strand: Strand;
   refLength: number;  // span on the reference (accounting for indels)
   mismatches: Array<BasePair>;
+  ops: Object[];
 };
 
 // This is typically a read pair, but may be a single read in some situations.

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -7,7 +7,7 @@
 import type {Strand, Alignment, AlignmentDataSource} from './Alignment';
 import type {TwoBitSource} from './TwoBitDataSource';
 import type {BasePair} from './pileuputils';
-import type {VisualAlignment} from './PileupCache';
+import type {VisualAlignment, VisualGroup} from './PileupCache';
 
 var React = require('./react-shim'),
     d3 = require('d3'),
@@ -20,7 +20,8 @@ var React = require('./react-shim'),
     ContigInterval = require('./ContigInterval'),
     Interval = require('./Interval'),
     DisplayMode = require('./DisplayMode'),
-    PileupCache = require('./PileupCache');
+    PileupCache = require('./PileupCache'),
+    dataCanvas = require('./data-canvas');
 
 
 var READ_HEIGHT = 13;
@@ -29,66 +30,106 @@ var READ_SPACING = 2;  // vertical pixels between reads
 var READ_STRAND_ARROW_WIDTH = 6;
 
 
-function drawArrow(ctx: CanvasRenderingContext2D, scale: (x:number)=>number, pos: number, refLength: number, top: number, direction: 'L' | 'R') {
-  var left = scale(pos + 1),
-      right = scale(pos + refLength + 1),
-      bottom = top + READ_HEIGHT;
-
-  ctx.beginPath();
-  if (direction == 'R') {
-    ctx.moveTo(left, top);
-    ctx.lineTo(right - READ_STRAND_ARROW_WIDTH, top);
-    ctx.lineTo(right, (top + bottom) / 2);
-    ctx.lineTo(right - READ_STRAND_ARROW_WIDTH, bottom);
-    ctx.lineTo(left, bottom);
-  } else {
-    ctx.moveTo(right, top);
-    ctx.lineTo(left + READ_STRAND_ARROW_WIDTH, top);
-    ctx.lineTo(left, (top + bottom) / 2);
-    ctx.lineTo(left + READ_STRAND_ARROW_WIDTH, bottom);
-    ctx.lineTo(right, bottom);
-  }
-  ctx.fill();
-}
-
-function drawSegment(ctx: CanvasRenderingContext2D, op, y, scale) {
-  switch (op.op) {
-    case CigarOp.MATCH:
-      if (op.arrow) {
-        drawArrow(ctx, scale, op.pos, op.length, y, op.arrow);
-      } else {
-        var x = scale(op.pos + 1);
-        ctx.fillRect(x, y, scale(op.pos + op.length + 1) - x, READ_HEIGHT);
-      }
-      break;
-
-    case CigarOp.DELETE:
-      var x1 = scale(op.pos + 1),
-          x2 = scale(op.pos + 1 + op.length),
-          yp = y + READ_HEIGHT / 2 - 0.5;
-      ctx.save();
-      ctx.fillStyle = 'black';
-      ctx.fillRect(x1, yp, x2 - x1, 1);
-      ctx.restore();
-      break;
-
-    case CigarOp.INSERT:
-      ctx.save();
-      ctx.fillStyle = 'rgb(97, 0, 216)';
-      var x = scale(op.pos + 1) - 2,  // to cover a bit of the previous segment
-          y1 = y - 1,
-          y2 = y + READ_HEIGHT + 2;
-      ctx.fillRect(x, y1, 1, y2 - y1);
-      ctx.restore();
-      break;
-  }
-}
 
 // Should the Cigar op be rendered to the screen?
 function isRendered(op) {
   return (op.op == CigarOp.MATCH ||
           op.op == CigarOp.DELETE ||
           op.op == CigarOp.INSERT);
+}
+
+// The renderer pulls out the canvas context and scale into shared variables in a closure.
+function getRenderer(ctx: DataCanvasRenderingContext2D, scale: (num: number) => number) {
+  function drawArrow(pos: number, refLength: number, top: number, direction: 'L' | 'R') {
+    var left = scale(pos + 1),
+        right = scale(pos + refLength + 1),
+        bottom = top + READ_HEIGHT;
+
+    ctx.beginPath();
+    if (direction == 'R') {
+      ctx.moveTo(left, top);
+      ctx.lineTo(right - READ_STRAND_ARROW_WIDTH, top);
+      ctx.lineTo(right, (top + bottom) / 2);
+      ctx.lineTo(right - READ_STRAND_ARROW_WIDTH, bottom);
+      ctx.lineTo(left, bottom);
+    } else {
+      ctx.moveTo(right, top);
+      ctx.lineTo(left + READ_STRAND_ARROW_WIDTH, top);
+      ctx.lineTo(left, (top + bottom) / 2);
+      ctx.lineTo(left + READ_STRAND_ARROW_WIDTH, bottom);
+      ctx.lineTo(right, bottom);
+    }
+    ctx.fill();
+  }
+
+  function drawSegment(op, y) {
+    switch (op.op) {
+      case CigarOp.MATCH:
+        if (op.arrow) {
+          drawArrow(op.pos, op.length, y, op.arrow);
+        } else {
+          var x = scale(op.pos + 1);
+          ctx.fillRect(x, y, scale(op.pos + op.length + 1) - x, READ_HEIGHT);
+        }
+        break;
+
+      case CigarOp.DELETE:
+        var x1 = scale(op.pos + 1),
+            x2 = scale(op.pos + 1 + op.length),
+            yp = y + READ_HEIGHT / 2 - 0.5;
+        ctx.save();
+        ctx.fillStyle = 'black';
+        ctx.fillRect(x1, yp, x2 - x1, 1);
+        ctx.restore();
+        break;
+
+      case CigarOp.INSERT:
+        ctx.save();
+        ctx.fillStyle = 'rgb(97, 0, 216)';
+        var x = scale(op.pos + 1) - 2,  // to cover a bit of the previous segment
+            y1 = y - 1,
+            y2 = y + READ_HEIGHT + 2;
+        ctx.fillRect(x, y1, 1, y2 - y1);
+        ctx.restore();
+        break;
+    }
+  }
+
+  function drawAlignment(vRead: VisualAlignment, y: number) {
+    ctx.pushObject(vRead);
+    vRead.ops.forEach(op => {
+      if (isRendered(op)) {
+        drawSegment(op, y);
+      }
+    });
+    vRead.mismatches.forEach(bp => renderMismatch(bp, y));
+    ctx.popObject();
+  }
+
+  function drawGroup(vGroup: VisualGroup) {
+    ctx.pushObject(vGroup);
+    var y = yForRow(vGroup.row);
+    vGroup.alignments.forEach(vRead => drawAlignment(vRead, y));
+    if (vGroup.insert) {
+      var span = vGroup.insert,
+          x1 = scale(span.start + 1),
+          x2 = scale(span.stop + 1);
+      ctx.fillRect(x1, y + READ_HEIGHT / 2 - 0.5, x2 - x1, 1);
+    }
+    ctx.popObject();
+  }
+
+  function renderMismatch(bp: BasePair, y: number) {
+    ctx.pushObject(bp);
+    ctx.save();
+    ctx.fillStyle = BASE_COLORS[bp.basePair];
+    ctx.globalAlpha = opacityForQuality(bp.quality);
+    ctx.fillText(bp.basePair, scale(bp.pos), y + READ_HEIGHT - 2);
+    ctx.restore();
+    ctx.popObject();
+  }
+
+  return {drawArrow, drawSegment, drawGroup}
 }
 
 
@@ -156,7 +197,7 @@ class PileupTrack extends React.Component {
       <div>
         {statusEl}
         <div ref='container' style={containerStyles}>
-          <canvas ref='canvas' />
+          <canvas ref='canvas' onClick={this.handleClick.bind(this)} />
         </div>
       </div>
     );
@@ -209,6 +250,13 @@ class PileupTrack extends React.Component {
           .forEach(read => this.cache.addAlignment(read));
   }
 
+  getCanvasContext(): CanvasRenderingContext2D {
+    var canvas = (this.refs.canvas.getDOMNode() : HTMLCanvasElement);
+    // The typecast through `any` is because getContext could return a WebGL context.
+    var ctx = ((canvas.getContext('2d') : any) : CanvasRenderingContext2D);
+    return ctx;
+  }
+
   // Update the D3 visualization to reflect the cached reads &
   // currently-visible range.
   updateVisualization() {
@@ -220,45 +268,39 @@ class PileupTrack extends React.Component {
 
     // Height can only be computed after the pileup has been updated.
     var height = yForRow(this.cache.pileupHeightForRef(this.props.range.contig));
-    var scale = this.getScale();
 
     d3.select(canvas).attr({width, height});
 
+    var ctx = this.getCanvasContext();
+    var dtx = dataCanvas.getDataContext(ctx);
+    this.renderScene(dtx);
+  }
+
+  renderScene(ctx: DataCanvasRenderingContext2D) {
     var genomeRange = this.props.range,
         range = new ContigInterval(genomeRange.contig, genomeRange.start, genomeRange.stop);
     var vGroups = this.cache.getGroupsOverlapping(range);
 
-    // The typecast through `any` is because getContext could return a WebGL context.
-    var ctx = ((canvas.getContext('2d') : any) : CanvasRenderingContext2D);
-    ctx.clearRect(0, 0, width, height);
-
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
     ctx.fillStyle = '#c8c8c8';
-    vGroups.forEach(vGroup => {
-      var y = yForRow(vGroup.row);
-      vGroup.alignments.forEach(vRead => {
-        vRead.ops.forEach(op => {
-          if (isRendered(op)) {
-            drawSegment(ctx, op, y, scale);
-          }
-        });
-        // drawArrow(ctx, scale, vRead.read.pos, vRead.refLength, y, vRead.strand == '+' ? 'R' : 'L');
-        vRead.mismatches.forEach(bp => {
-          ctx.save();
-          ctx.fillStyle = BASE_COLORS[bp.basePair];
-          ctx.globalAlpha = opacityForQuality(bp.quality);
-          ctx.fillText(bp.basePair, scale(bp.pos), y + READ_HEIGHT - 2);
-          ctx.restore();
-        });
-      });
-      if (vGroup.insert) {
-        var span = vGroup.insert,
-            x1 = scale(span.start + 1),
-            x2 = scale(span.stop + 1);
-        ctx.fillRect(x1, y + READ_HEIGHT / 2 - 0.5, x2 - x1, 1);
-      }
-    });
+
+    var scale = this.getScale();
+    var renderer = getRenderer(ctx, scale);
+    vGroups.forEach(vGroup => renderer.drawGroup(vGroup));
   }
 
+  handleClick(reactEvent: any) {
+    var ev = reactEvent.nativeEvent,
+        x = ev.offsetX,
+        y = ev.offsetY;
+    var ctx = this.getCanvasContext();
+    var trackingCtx = new dataCanvas.ClickTrackingContext(ctx, x, y);
+    this.renderScene(trackingCtx);
+    var vRead = trackingCtx.hit && trackingCtx.hit[0];
+    if (vRead) {
+      alert(vRead.read.debugString());
+    }
+  }
 }
 
 PileupTrack.propTypes = {

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -28,92 +28,59 @@ var READ_SPACING = 2;  // vertical pixels between reads
 
 var READ_STRAND_ARROW_WIDTH = 6;
 
-// Returns an SVG path string for the read, with an arrow indicating strand.
-function makeArrow(scale, pos, refLength, direction) {
+
+function drawArrow(ctx: CanvasRenderingContext2D, scale: (x:number)=>number, pos: number, refLength: number, top: number, direction: 'L' | 'R') {
   var left = scale(pos + 1),
-      top = 0,
       right = scale(pos + refLength + 1),
-      bottom = READ_HEIGHT,
-      path = direction == 'R' ? [
-        [left, top],
-        [right - READ_STRAND_ARROW_WIDTH, top],
-        [right, (top + bottom) / 2],
-        [right - READ_STRAND_ARROW_WIDTH, bottom],
-        [left, bottom]
-      ] : [
-        [right, top],
-        [left + READ_STRAND_ARROW_WIDTH, top],
-        [left, (top + bottom) / 2],
-        [left + READ_STRAND_ARROW_WIDTH, bottom],
-        [right, bottom]
-      ];
-  return d3.svg.line()(path);
-}
+      bottom = top + READ_HEIGHT;
 
-// Create the SVG element for a single Cigar op in an alignment.
-function enterSegment(parentNode, op, scale) {
-  var parent = d3.select(parentNode);
-  switch (op.op) {
-    case CigarOp.MATCH:
-      return parent.append(op.arrow ? 'path' : 'rect')
-                   .attr('class', 'segment match');
-
-    case CigarOp.DELETE:
-      return parent.append('line')
-                   .attr('class', 'segment delete');
-
-    case CigarOp.INSERT:
-      return parent.append('line')
-                   .attr('class', 'segment insert');
-
-    default:
-      throw `Invalid op! ${op.op}`;
+  ctx.beginPath();
+  if (direction == 'R') {
+    ctx.moveTo(left, top);
+    ctx.lineTo(right - READ_STRAND_ARROW_WIDTH, top);
+    ctx.lineTo(right, (top + bottom) / 2);
+    ctx.lineTo(right - READ_STRAND_ARROW_WIDTH, bottom);
+    ctx.lineTo(left, bottom);
+  } else {
+    ctx.moveTo(right, top);
+    ctx.lineTo(left + READ_STRAND_ARROW_WIDTH, top);
+    ctx.lineTo(left, (top + bottom) / 2);
+    ctx.lineTo(left + READ_STRAND_ARROW_WIDTH, bottom);
+    ctx.lineTo(right, bottom);
   }
+  ctx.fill();
 }
 
-// Update the selection for a single Cigar op, e.g. in response to a pan or zoom.
-function updateSegment(node, op, scale) {
+function drawSegment(ctx: CanvasRenderingContext2D, op, y, scale) {
   switch (op.op) {
     case CigarOp.MATCH:
       if (op.arrow) {
-        // an arrow pointing in the direction of the alignment
-        d3.select(node).attr('d', makeArrow(scale, op.pos, op.length, op.arrow));
+        drawArrow(ctx, scale, op.pos, op.length, y, op.arrow);
       } else {
-        // a rectangle (interior part of an alignment)
-        d3.select(node)
-          .attr({
-            'x': scale(op.pos + 1),
-            'height': READ_HEIGHT,
-            'width': scale(op.length) - scale(0)
-          });
+        var x = scale(op.pos + 1);
+        ctx.fillRect(x, y, scale(op.pos + op.length + 1) - x, READ_HEIGHT);
       }
       break;
 
     case CigarOp.DELETE:
-      // A thin line in the middle of the alignments indicating the deletion.
-      d3.select(node)
-        .attr({
-          'x1': scale(op.pos + 1),
-          'x2': scale(op.pos + 1 + op.length),
-          'y1': READ_HEIGHT / 2 - 0.5,
-          'y2': READ_HEIGHT / 2 - 0.5
-        });
+      var x1 = scale(op.pos + 1),
+          x2 = scale(op.pos + 1 + op.length),
+          yp = y + READ_HEIGHT / 2 - 0.5;
+      ctx.save();
+      ctx.fillStyle = 'black';
+      ctx.fillRect(x1, yp, x2 - x1, 1);
+      ctx.restore();
       break;
 
     case CigarOp.INSERT:
-      // A thin vertical line. This is shifted to the left so that it's not
-      // hidden by the segment following it.
-      d3.select(node)
-        .attr({
-          'x1': scale(op.pos + 1) - 2,  // to cover a bit of the previous segment
-          'x2': scale(op.pos + 1) - 2,
-          'y1': -1,
-          'y2': READ_HEIGHT + 2
-        });
+      ctx.save();
+      ctx.fillStyle = 'rgb(97, 0, 216)';
+      var x = scale(op.pos + 1) - 2,  // to cover a bit of the previous segment
+          y1 = y - 1,
+          y2 = y + READ_HEIGHT + 2;
+      ctx.fillRect(x, y1, 1, y2 - y1);
+      ctx.restore();
       break;
-
-    default:
-      throw `Invalid op! ${op.op}`;
   }
 }
 
@@ -122,10 +89,6 @@ function isRendered(op) {
   return (op.op == CigarOp.MATCH ||
           op.op == CigarOp.DELETE ||
           op.op == CigarOp.INSERT);
-}
-
-function readClass(vread: VisualAlignment) {
-  return 'alignment ' + (vread.strand == '-' ? 'negative' : 'positive');
 }
 
 
@@ -147,6 +110,15 @@ function opacityForQuality(quality: number): number {
   alpha = Math.round(alpha * 10 + 0.5) / 10.0;
   return Math.min(1.0, alpha);
 }
+
+var BASE_COLORS = {
+  'A': '#188712',
+  'G': '#C45C16',
+  'C': '#0600F9',
+  'T': '#F70016',
+  'U': '#F70016',
+  'N': 'black'
+};
 
 class PileupTrack extends React.Component {
   cache: PileupCache;
@@ -183,7 +155,9 @@ class PileupTrack extends React.Component {
     return (
       <div>
         {statusEl}
-        <div ref='container' style={containerStyles}></div>
+        <div ref='container' style={containerStyles}>
+          <canvas ref='canvas' />
+        </div>
       </div>
     );
   }
@@ -199,10 +173,6 @@ class PileupTrack extends React.Component {
   }
 
   componentDidMount() {
-    var div = this.refs.container.getDOMNode();
-    d3.select(div)
-      .append('svg');
-
     this.cache = new PileupCache(this.props.referenceSource);
     this.props.source.on('newdata', range => {
       this.updateReads(range);
@@ -242,9 +212,8 @@ class PileupTrack extends React.Component {
   // Update the D3 visualization to reflect the cached reads &
   // currently-visible range.
   updateVisualization() {
-    var div = this.refs.container.getDOMNode(),
-        width = this.props.width,
-        svg = d3.select(div).select('svg');
+    var canvas = (this.refs.canvas.getDOMNode() : HTMLCanvasElement),
+        width = this.props.width;
 
     // Hold off until height & width are known.
     if (width === 0) return;
@@ -253,99 +222,41 @@ class PileupTrack extends React.Component {
     var height = yForRow(this.cache.pileupHeightForRef(this.props.range.contig));
     var scale = this.getScale();
 
-    svg.attr('width', width)
-       .attr('height', height);
+    d3.select(canvas).attr({width, height});
 
     var genomeRange = this.props.range,
         range = new ContigInterval(genomeRange.contig, genomeRange.start, genomeRange.stop);
     var vGroups = this.cache.getGroupsOverlapping(range);
 
-    // Enter
-    var groups = svg.selectAll('.read-group').data(vGroups, vGroup => vGroup.key);
+    // The typecast through `any` is because getContext could return a WebGL context.
+    var ctx = ((canvas.getContext('2d') : any) : CanvasRenderingContext2D);
+    ctx.clearRect(0, 0, width, height);
 
-    groups.enter()
-        .append('g')
-        .attr('class', 'read-group')
-        .attr('transform', vGroup => `translate(0, ${yForRow(vGroup.row)})`);
-
-    var connectors = groups.selectAll('.mate-connector')
-        .data(vGroup => vGroup.insert ? [vGroup.insert] : []);
-    connectors.enter().append('line').attr('class', 'mate-connector');
-
-    var reads = groups.selectAll('.alignment')
-        // drop alignments w/o CIGARs
-        .data(vGroup => vGroup.alignments.filter(vRead => vRead.refLength > 0));
-
-    reads.enter()
-        .append('g')
-        .attr('class', readClass)
-        .on('click', vRead => {
-          window.alert(vRead.read.debugString());
+    ctx.fillStyle = '#c8c8c8';
+    vGroups.forEach(vGroup => {
+      var y = yForRow(vGroup.row);
+      vGroup.alignments.forEach(vRead => {
+        vRead.ops.forEach(op => {
+          if (isRendered(op)) {
+            drawSegment(ctx, op, y, scale);
+          }
         });
-
-    var segments = reads.selectAll('.segment')
-        .data(read => read.ops.filter(isRendered));
-
-    // This is like segments.append(), but allows for different types of
-    // elements depending on the datum.
-    segments.enter().call(function(sel) {
-      sel.forEach(function(el) {
-        el.forEach(function(op) {
-          var d = d3.select(op).datum();
-          var element = enterSegment(el.parentNode, d, scale);
-          updateSegment(element[0][0], d, scale);
+        // drawArrow(ctx, scale, vRead.read.pos, vRead.refLength, y, vRead.strand == '+' ? 'R' : 'L');
+        vRead.mismatches.forEach(bp => {
+          ctx.save();
+          ctx.fillStyle = BASE_COLORS[bp.basePair];
+          ctx.globalAlpha = opacityForQuality(bp.quality);
+          ctx.fillText(bp.basePair, scale(bp.pos), y + READ_HEIGHT - 2);
+          ctx.restore();
         });
       });
+      if (vGroup.insert) {
+        var span = vGroup.insert,
+            x1 = scale(span.start + 1),
+            x2 = scale(span.stop + 1);
+        ctx.fillRect(x1, y + READ_HEIGHT / 2 - 0.5, x2 - x1, 1);
+      }
     });
-
-    // Mismatched base pairs
-    var pxPerLetter = scale(1) - scale(0),
-        mode = DisplayMode.getDisplayMode(pxPerLetter),
-        showText = DisplayMode.isText(mode),
-        modeWrapper = reads.selectAll('.mode-wrapper')
-                           .data(vRead => vRead.mismatches.length ? [{vRead,mode}] : [],
-                                 x => x.mode);
-    modeWrapper.enter().append('g').attr('class', 'mode-wrapper');
-
-    var letter = modeWrapper.selectAll('.basepair')
-        .data(d => d.vRead.mismatches, m => m.pos + m.basePair);
-
-    letter.enter().append(showText ? 'text' : 'rect')
-    if (showText) {
-      letter.text(mismatch => mismatch.basePair)
-    } else {
-      letter
-          .attr('y', 0)
-          .attr('height', READ_HEIGHT)
-    }
-    letter.attr('class', mismatch => utils.basePairClass(mismatch.basePair))
-          .attr('fill-opacity', mismatch => opacityForQuality(mismatch.quality));
-
-    // Update
-    connectors.each(function(interval, i) {
-      d3.select(this).attr({
-        x1: scale(interval.start),
-        x2: scale(interval.stop + 1),
-        y1: READ_HEIGHT / 2,
-        y2: READ_HEIGHT / 2
-      })
-    });
-    segments.each(function(d, i) {
-      updateSegment(this, d, scale);
-    });
-    reads.selectAll('text.basepair')
-         .attr('x', mismatch => scale(1 + 0.5 + mismatch.pos));  // 0.5 = centered
-    reads.selectAll('rect.basepair')
-          .attr('x', mismatch => scale(1 + mismatch.pos))
-          .attr('width', pxPerLetter - 1);
-
-    // Exit
-    groups.exit().remove();
-    connectors.exit().remove();
-    reads.exit().remove();
-    letter.exit().remove();
-    segments.exit().remove();
-    modeWrapper.exit().remove();
   }
 
 }

--- a/src/main/VariantTrack.js
+++ b/src/main/VariantTrack.js
@@ -4,7 +4,8 @@
  */
 'use strict';
 
-import type * as VcfDataSource from './VcfDataSource';
+import type {VcfDataSource} from './VcfDataSource';
+import type {Variant} from './vcf';
 
 var React = require('./react-shim'),
     _ = require('underscore'),
@@ -12,23 +13,6 @@ var React = require('./react-shim'),
     types = require('./react-types'),
     ContigInterval = require('./ContigInterval');
 
-// Copy from vcf.js
-type Variant = {
-  contig: string;
-  position: number;
-  ref: string;
-  alt: string;
-  vcfLine: string;
-}
-
-// Copied from VcfDataSource
-type VcfDataSource = {
-  rangeChanged: (newRange: GenomeRange) => void;
-  getFeaturesInRange: (range: ContigInterval<string>) => Variant[];
-  on: (event: string, handler: Function) => void;
-  off: (event: string) => void;
-  trigger: (event: string, ...args:any) => void;
-};
 
 function variantKey(v: Variant): string {
   return `${v.contig}:${v.position}`;

--- a/src/main/VcfDataSource.js
+++ b/src/main/VcfDataSource.js
@@ -13,16 +13,9 @@ var ContigInterval = require('./ContigInterval'),
     RemoteFile = require('./RemoteFile'),
     VcfFile = require('./vcf');
 
-// Copy from vcf.js
-type Variant = {
-  contig: string;
-  position: number;
-  ref: string;
-  alt: string;
-  vcfLine: string;
-}
+import type {Variant} from './vcf';
 
-type VcfDataSource = {
+export type VcfDataSource = {
   rangeChanged: (newRange: GenomeRange) => void;
   getFeaturesInRange: (range: ContigInterval<string>) => Variant[];
   on: (event: string, handler: Function) => void;

--- a/src/main/bedtools.js
+++ b/src/main/bedtools.js
@@ -6,7 +6,7 @@ var Interval = require('./Interval');
 
 class CodingInterval extends Interval {
   isCoding: boolean;
-  constructor(start, stop, isCoding: boolean) {
+  constructor(start: number, stop: number, isCoding: boolean) {
     super(start, stop);
     this.isCoding = isCoding;
   }

--- a/src/main/data-canvas.js
+++ b/src/main/data-canvas.js
@@ -1,0 +1,155 @@
+/**
+ * Wrappers around CanvasRenderingContext2D to facilitate testing and click-tracking.
+ *
+ * This adds the concept of a "data stack" to the canvas. When shapes are
+ * drawn, they represent the objects currently on the stack. This stack can be
+ * manipulated using context.pushObject() and context.popObject().
+ *
+ * See test file for sample usage.
+ *
+ * Note: this file does some unusual things with Objects which are hard to
+ * represent within Flow's type system. Hence type checking is disabled for it.
+ */
+
+// Turn obj into a proxy for target. This forwards both function calls and
+// property setters/getters.
+function forward(obj: Object, target: Object, onlyAccessors: ?boolean) {
+  onlyAccessors = onlyAccessors || false;
+  for (var k in target) {
+    (function(k) {
+      if (typeof(target[k]) == 'function') {
+        if (!onlyAccessors) {
+          obj[k] =  target[k].bind(target);
+        }
+      } else {
+        Object.defineProperty(obj, k, {
+          get: function() { return target[k]; },
+          set: function(x) { target[k] = x; }
+        });
+      }
+    })(k);
+  }
+}
+
+// The most basic data-aware canvas. This throws away all data information.
+// Use this for basic drawing
+function DataContext(ctx: CanvasRenderingContext2D) {
+  forward(this, ctx);
+  this.pushObject = this.popObject = function() {};
+}
+
+// This is exposed as a method for easier testing.
+function getDataContext(ctx: CanvasRenderingContext2D) {
+  return new DataContext(ctx);
+}
+
+
+/**
+ * A context which records what it does (for testing).
+ *
+ * This proxies all calls to the underlying canvas, so they do produce visible
+ * drawing. Use `drawnObjectsWith` or `calls` to test what was drawn.
+ */
+function RecordingContext(ctx: CanvasRenderingContext2D) {
+  forward(this, ctx, true /* only foward accessors */);
+
+  var calls = [];
+  this.calls = calls;
+
+  for (var k in ctx) {
+    (k => {
+      if (typeof(ctx[k]) != 'function') return;
+      this[k] = function() {
+        // TODO: record current drawing style
+        var args = Array.prototype.slice.call(arguments);
+        calls.push([k].concat(args));
+        ctx[k].apply(ctx, arguments);
+      };
+    })(k);
+  }
+
+  this.pushObject = function(o) {
+    calls.push(['pushObject', o]);
+  };
+  
+  this.popObject = function() {
+    calls.push(['popObject']);
+  };
+}
+
+RecordingContext.prototype.drawnObjectsWith = function(predicate: (o: Object)=>boolean): Object[] {
+  var matches = [];
+  this.calls.forEach(x => {
+    if (x[0] == 'pushObject' && predicate(x[1])) {
+      matches.push(x[1]);
+    }
+  });
+  return matches;
+};
+
+/**
+ * A context which determines the data at a particular location.
+ *
+ * When drawing methods are called on this class, nothing is rendered. Instead,
+ * each shape is checked to see if it includes the point of interest. If it
+ * does, the current data stack is saved as a "hit".
+ *
+ * The `hits` property records all such hits.
+ * The `hit` property records only the last (top) hit.
+ */
+function ClickTrackingContext(ctx: CanvasRenderingContext2D, px: number, py: number) {
+  forward(this, ctx);
+
+  var stack = [];
+  this.hits = [];
+  this.hit = null;
+  
+  var that = this;
+  function recordHit() {
+    that.hits.unshift(Array.prototype.slice.call(stack));
+    that.hit = that.hits[0];
+  }
+
+  this.pushObject = function(o) {
+    stack.unshift(o);
+  };
+  
+  this.popObject = function() {
+    stack.shift();
+  };
+
+  // These are (most of) the canvas methods which draw something.
+  this.clearRect = function(x: number, y: number, w: number, h: number) { };
+
+  this.fillRect = function(x: number, y: number, w: number, h: number) {
+    if (px >= x && px <= x + w && py >= y && py <= y + h) recordHit();
+  };
+
+  this.strokeRect = function(x: number, y: number, w: number, h: number) {
+    // ...
+  };
+
+  this.fill = function(fillRule?: CanvasFillRule) {
+    // TODO: implement fillRule
+    if (ctx.isPointInPath(px, py)) recordHit();
+  };
+
+  this.stroke = function() {
+    if (ctx.isPointInStroke(px, py)) recordHit();
+  };
+
+  this.fillText = function(text: string, x: number, y: number, maxWidth?: number) {
+    // ...
+  };
+
+  this.strokeText = function(text: string, x: number, y: number, maxWidth?: number) {
+    // ...
+  };
+}
+
+module.exports = {
+  DataContext,
+  RecordingContext,
+  ClickTrackingContext,
+  getDataContext
+};

--- a/src/main/pileuputils.js
+++ b/src/main/pileuputils.js
@@ -2,7 +2,7 @@
 'use strict';
 
 import type * as SamRead from './SamRead';
-import type {Alignment} from './Alignment';
+import type {Alignment, CigarSymbol} from './Alignment';
 import type * as Interval from './Interval';
 
 /**
@@ -89,11 +89,6 @@ function findMismatches(reference: string, seq: string, refPos: number, scores: 
   return out;
 }
 
-type OpInfo = {
-  ops: Object[],
-  mismatches: BasePair[]
-}
-
 // Determine which alignment segment to render as an arrow.
 // This is either the first or last 'M' section, excluding soft clipping.
 function getArrowIndex(read: Alignment): number {
@@ -129,6 +124,18 @@ var CigarOp = {
   SEQMISMATCH: 'X'  // sequence mismatch
 };
 
+type Op = {
+  op: CigarSymbol;
+  length: number;
+  pos: number;
+  arrow: ?('L'|'R');
+}
+
+type OpInfo = {
+  ops: Op[],
+  mismatches: BasePair[]
+}
+
 // Breaks the read down into Cigar Ops suitable for display
 function getOpInfo(read: Alignment, referenceSource: Object): OpInfo {
   var ops = read.getCigarOps();
@@ -158,7 +165,8 @@ function getOpInfo(read: Alignment, referenceSource: Object): OpInfo {
     result.push({
       op: op.op,
       length: op.length,
-      pos: refPos
+      pos: refPos,
+      arrow: null
     });
 
     // These are the cigar operations which advance position in the reference

--- a/src/main/vcf.js
+++ b/src/main/vcf.js
@@ -11,7 +11,7 @@ import type * as ContigInterval from './ContigInterval';
 import type * as RemoteFile from './RemoteFile';
 import type * as Q from 'q';
 
-type Variant = {
+export type Variant = {
   contig: string;
   position: number;
   ref: string;

--- a/src/test/PileupTrack-test.js
+++ b/src/test/PileupTrack-test.js
@@ -6,7 +6,6 @@
 'use strict';
 
 var expect = require('chai').expect;
-var sinon = require('sinon');
 
 var Q = require('q'),
     _ = require('underscore'),

--- a/src/test/PileupTrack-test.js
+++ b/src/test/PileupTrack-test.js
@@ -6,6 +6,7 @@
 'use strict';
 
 var expect = require('chai').expect;
+var sinon = require('sinon');
 
 var Q = require('q'),
     _ = require('underscore'),
@@ -21,7 +22,8 @@ var pileup = require('../main/pileup'),
     RemoteFile = require('../main/RemoteFile'),
     MappedRemoteFile = require('./MappedRemoteFile'),
     ContigInterval = require('../main/ContigInterval'),
-    {waitFor} = require('./async');
+    {waitFor} = require('./async'),
+    dataCanvas = require('../main/data-canvas');
 
 
 // This is like TwoBit, but allows a controlled release of sequence data.
@@ -68,16 +70,27 @@ class FakeBam extends Bam {
 
 describe('PileupTrack', function() {
   var testDiv = document.getElementById('testdiv');
+  var origGetDataContext = dataCanvas.getDataContext,
+      recorder = null;
 
   beforeEach(() => {
     // A fixed width container results in predictable x-positions for mismatches.
     testDiv.style.width = '800px';
+    // Stub in a RecordingContext in place of DataContext
+    recorder = (null : ?RecordingContext);
+    dataCanvas.getDataContext = function(ctx) {
+      if (!recorder) {
+        recorder = new dataCanvas.RecordingContext(ctx);
+      }
+      return recorder;
+    };
   });
 
   afterEach(() => {
     // avoid pollution between tests.
     testDiv.innerHTML = '';
     testDiv.style.width = '';
+    dataCanvas.getDataContext = origGetDataContext;
   });
 
   // Test data files
@@ -133,7 +146,7 @@ describe('PileupTrack', function() {
       return testDiv.querySelectorAll('.reference text.C').length > 0;
     },
     hasAlignments = () => {
-      return testDiv.querySelectorAll('.pileup .alignment').length > 0;
+      return drawnObjectsWith(x => x.span).length > 0;
     },
 
     // Returns SVG elements at the given position by querying D3 data.
@@ -144,19 +157,24 @@ describe('PileupTrack', function() {
                .filter(function(d) { return (d.pos == pos) })[0];
     },
 
+    // Helpers for working with DataCanvas
+    drawnObjectsWith = predicate => recorder ? recorder.drawnObjectsWith(predicate) : [],
+    mismatchesAtPos = pos => drawnObjectsWith(x => x.basePair && x.pos == pos),
+
     // This checks that there are 22 C/T SNVs at chr17:7,500,765
     // XXX: IGV only shows 20
     assertHasColumnOfTs = () => {
       var ref = elementsAtPos('.reference text.basepair', 7500765 - 1);
       expect(ref).to.have.length(1);
       expect(ref[0].textContent).to.equal('C');
-      var mismatches = elementsAtPos('.pileup text.basepair', 7500765 - 1);
+      
+      var mismatches = mismatchesAtPos(7500765 - 1);
       expect(mismatches).to.have.length(22);
       _.each(mismatches, mm => {
-        expect(mm.textContent).to.equal('T');
+        expect(mm.basePair).to.equal('T');
       });
       // Make sure there are no variants in the previous column, just the reference.
-      expect(elementsAtPos('text', 7500764 - 1).length).to.equal(1);
+      expect(mismatchesAtPos(7500764 - 1).length).to.equal(0);
     };
 
   it('should indicate mismatches when the reference loads first', function() {
@@ -172,7 +190,7 @@ describe('PileupTrack', function() {
     }).then(() => {
       // Some number of mismatches are expected, but it should be dramatically
       // lower than the number of total base pairs in alignments.
-      var mismatches = testDiv.querySelectorAll('.pileup .alignment .basepair');
+      var mismatches = drawnObjectsWith(x => x.basePair);
       expect(mismatches).to.have.length.below(60);
       assertHasColumnOfTs();
     });
@@ -190,7 +208,7 @@ describe('PileupTrack', function() {
       fakeTwoBit.release(reference);
       return waitFor(hasReference, 2000);
     }).then(() => {
-      var mismatches = testDiv.querySelectorAll('.pileup .alignment .basepair');
+      var mismatches = drawnObjectsWith(x => x.basePair);
       expect(mismatches).to.have.length.below(60);
       assertHasColumnOfTs();
     });

--- a/src/test/data-canvas-test.js
+++ b/src/test/data-canvas-test.js
@@ -1,0 +1,151 @@
+/* @flow */
+'use strict';
+
+var expect = require('chai').expect;
+
+var pileup = require('../main/pileup'),
+    {waitFor} = require('./async'),
+    dataCanvas = require('../main/data-canvas');
+
+describe('data-canvas', function() {
+  var testDiv = document.getElementById('testdiv');
+  var canvas;
+  before(function() {
+    // See https://github.com/facebook/flow/issues/582 
+    canvas = (document : any).createElement('canvas');
+    canvas.width = 600;
+    canvas.height = 200;
+    document.getElementById('testdiv').appendChild(canvas);
+  });
+
+  after(function() {
+    testDiv.innerHTML = '';  // avoid pollution between tests.
+  });
+
+  function rgbAtPos(im: ImageData, x: number, y: number): [number, number, number] {
+    var index = y * (im.width * 4) + x * 4;
+    return [
+      im.data[index],
+      im.data[index + 1],
+      im.data[index + 2]
+    ];
+  }
+
+  describe('pass-through canvas', function() {
+    it('should put pixels on the canvas', function() {
+      if (!canvas) throw 'bad';  // for flow
+      var ctx = canvas.getContext('2d');
+      var dtx = dataCanvas.getDataContext(ctx);
+
+      dtx.fillStyle = 'red';
+      dtx.fillRect(100, 50, 200, 25);
+      dtx.pushObject({something: 'or other'});
+      dtx.popObject();
+
+      var im = ctx.getImageData(0, 0, 600, 400);
+      expect(rgbAtPos(im, 50, 50)).to.deep.equal([0, 0, 0]);
+      expect(rgbAtPos(im, 200, 60)).to.deep.equal([255, 0, 0]);
+    });
+  });
+
+  describe('click tracking context', function() {
+    var ctx;
+    before(function() {
+      if (!canvas) throw 'bad';  // for flow
+      ctx = canvas.getContext('2d');
+      ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    });
+
+    function getObjectsAt(draw, x, y) {
+      var dtx = new dataCanvas.ClickTrackingContext(ctx, x, y);
+      draw(dtx);
+      return dtx.hits;
+    }
+
+    // To draw any of these:
+    // draw(dataCanvas.getDataContext(ctx));
+
+    it('should track clicks on rects', function() {
+      function draw(dtx: DataCanvasRenderingContext2D) {
+        dtx.pushObject('r');
+        dtx.fillStyle = 'red';
+        dtx.fillRect(100, 50, 100, 25);
+        dtx.popObject();
+        dtx.pushObject('b');
+        dtx.fillStyle = 'blue';
+        dtx.fillRect(300, 100, 200, 25);
+        dtx.popObject();
+      }
+
+      expect(getObjectsAt(draw, 150, 60)).to.deep.equal([['r']]);
+      expect(getObjectsAt(draw, 350, 110)).to.deep.equal([['b']]);
+      expect(getObjectsAt(draw, 250, 110)).to.deep.equal([]);
+    });
+
+    it('should track clicks on complex shapes', function() {
+      function draw(dtx: DataCanvasRenderingContext2D) {
+        // This is the upper right half of a rectangle, i.e. a triangle.
+        dtx.pushObject('triangle');
+        dtx.beginPath();
+        dtx.moveTo(100, 100);
+        dtx.lineTo(400, 100);
+        dtx.lineTo(400, 200);
+        dtx.closePath();
+        dtx.fill();
+        dtx.popObject();
+      }
+
+      // This point is in the top right (and hence in the triangle)
+      expect(getObjectsAt(draw, 300, 110)).to.deep.equal([['triangle']]);
+      // This poitn is in the bottom left (and hence not in the triangle)
+      expect(getObjectsAt(draw, 200, 180)).to.deep.equal([]);
+    });
+
+    it('should track clicks on stacked shapes', function() {
+      function draw(dtx: DataCanvasRenderingContext2D) {
+        dtx.pushObject('bottom');
+        dtx.fillStyle = 'red';
+        dtx.fillRect(100, 50, 400, 100);
+        dtx.pushObject('top');
+        dtx.fillStyle = 'blue';
+        dtx.fillRect(200, 75, 100, 50);
+        dtx.popObject();
+        dtx.popObject();
+        dtx.pushObject('side');
+        dtx.fillStyle = 'green';
+        dtx.fillRect(450, 75, 100, 50);
+        dtx.popObject();
+      }
+
+      draw(dataCanvas.getDataContext(ctx));
+      expect(getObjectsAt(draw, 110, 60)).to.deep.equal([['bottom']]);
+      expect(getObjectsAt(draw, 250, 100)).to.deep.equal([['top', 'bottom'], ['bottom']]);
+      expect(getObjectsAt(draw, 475, 100)).to.deep.equal([['side'], ['bottom']]);
+    });
+
+    // TODO: tests with drawText()
+  });
+
+  describe('RecordingContext', function() {
+    var ctx;
+    before(function() {
+      if (!canvas) throw 'bad';  // for flow
+      ctx = canvas.getContext('2d');
+      ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    });
+
+    it('should record calls', function() {
+      var dtx = new dataCanvas.RecordingContext(ctx);
+      dtx.fillStyle = 'red';
+      dtx.pushObject('a');
+      dtx.fillRect(100, 50, 200, 25);
+      dtx.popObject();
+
+      expect(dtx.calls).to.have.length(3); // push, fill, pop
+      expect(dtx.drawnObjectsWith(x => x == 'a')).to.have.length(1);
+      expect(dtx.drawnObjectsWith(x => x == 'b')).to.have.length(0);
+
+      // TODO: check drawing styles
+    });
+  });
+});

--- a/src/test/pileuputils-test.js
+++ b/src/test/pileuputils-test.js
@@ -155,8 +155,8 @@ describe('pileuputils', function() {
 
       expect(getOpInfo(deleteRead, fakeReferenceSource)).to.deep.equal({
         ops: [
-          { op: 'M', length: 37, pos: 7513328 + 0 },
-          { op: 'D', length:  4, pos: 7513328 + 37 },
+          { op: 'M', length: 37, pos: 7513328 + 0,  arrow: null },
+          { op: 'D', length:  4, pos: 7513328 + 37, arrow: null },
           { op: 'M', length: 64, pos: 7513328 + 41, arrow: 'R' }
         ],
         mismatches: []
@@ -164,16 +164,16 @@ describe('pileuputils', function() {
 
       expect(getOpInfo(insertRead, fakeReferenceSource)).to.deep.equal({
         ops: [
-          { op: 'M', length: 73, pos: 7513204 + 0, arrow: 'L' },
-          { op: 'I', length: 20, pos: 7513204 + 73 },
-          { op: 'M', length:  8, pos: 7513204 + 73 }
+          { op: 'M', length: 73, pos: 7513204 + 0,  arrow: 'L' },
+          { op: 'I', length: 20, pos: 7513204 + 73, arrow: null },
+          { op: 'M', length:  8, pos: 7513204 + 73, arrow: null }
         ],
         mismatches: []
       });
 
       expect(getOpInfo(softClipRead, fakeReferenceSource)).to.deep.equal({
           ops: [
-            { op: 'S', length: 66, pos: 7513108 + 0 },
+            { op: 'S', length: 66, pos: 7513108 + 0, arrow: null },
             { op: 'M', length: 35, pos: 7513108 + 0, arrow: 'L' }
           ],
           mismatches: [

--- a/types/types.js
+++ b/types/types.js
@@ -3,3 +3,23 @@ declare class GenomeRange {
   start: number;  // inclusive
   stop: number;  // inclusive
 }
+
+declare class DataCanvasRenderingContext2D extends CanvasRenderingContext2D {
+  pushObject(o: any): void;
+  popObject(): void;
+}
+
+declare class DataContext extends DataCanvasRenderingContext2D {
+  constructor(ctx: CanvasRenderingContext2D): void;
+}
+
+declare class RecordingContext extends DataCanvasRenderingContext2D {
+  constructor(ctx: CanvasRenderingContext2D): void;
+  calls: Object[];
+  drawnObjectsWith(predicate: (o: Object)=>boolean): Object[];
+}
+
+declare class ClickTrackingContext extends DataCanvasRenderingContext2D {
+  constructor(ctx: CanvasRenderingContext2D, x: number, y: number): void;
+  hits: any[][];
+}


### PR DESCRIPTION
See #255 

When I remove all tracks but a single `PileupTrack`, I see panning performance at ~700bp scale go from ~20fps→60fps. It's better than that, though. The SVG version sometimes goes down to around 6fps while panning, whereas the canvas version never drops below 30fps.

Remaining bits to implement:
- [x] Make mismatched base pairs the correct font/size
- [x] Make mismatches turn into blocks of color
- [x] Add back click handler support
- [x] Update the tests to understand canvas

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/257)
<!-- Reviewable:end -->
