### PR TITLE
Make all tracks draggable!

### DIFF
--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -37,42 +37,6 @@ var GenomeTrack = React.createClass({
       this.updateVisualization();
     });
 
-    var originalRange, originalScale, dx=0;
-    var dragstarted = () => {
-      d3.event.sourceEvent.stopPropagation();
-      dx = 0;
-      originalRange = _.clone(this.props.range);
-      originalScale = this.getScale();
-    };
-    var updateRange = () => {
-      if (!originalScale) return;  // can never happen, but Flow don't know.
-      if (!originalRange) return;  // can never happen, but Flow don't know.
-      var newStart = originalScale.invert(-dx),
-          intStart = Math.round(newStart),
-          offsetPx = originalScale(newStart) - originalScale(intStart);
-
-      var newRange = {
-        contig: originalRange.contig,
-        start: intStart,
-        stop: intStart + (originalRange.stop - originalRange.start),
-        offsetPx: offsetPx
-      };
-      this.props.onRangeChange(newRange);
-    };
-    var dragmove = () => {
-      dx += d3.event.dx;  // these are integers, so no roundoff issues.
-      updateRange();
-    };
-    function dragended() {
-      updateRange();
-    }
-
-    var drag = d3.behavior.drag()
-        .on('dragstart', dragstarted)
-        .on('drag', dragmove)
-        .on('dragend', dragended);
-
-    d3.select(div).call(drag);
 
     this.updateVisualization();
   },

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -40,7 +40,7 @@
   overflow-x: hidden;
   position: relative;
 }
-.track-content > div > div {
+.track-content > div {
   position: absolute; /* Gets the child of the flex-item to fill height 100% */
 }
 


### PR DESCRIPTION
I moved the drag-to-pan functionality into `VisualizationWrapper`, so that it's automatic for all tracks. Clicks still fall through for the track itself to handle.

Fixes #61 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/264)
<!-- Reviewable:end -->
