### PR TITLE
Migrate Coverage from SVG→canvas

### DIFF
--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -57,7 +57,7 @@ class CoverageTrack extends React.Component {
   }
 
   render(): any {
-    return <div><canvas ref='canvas' /></div>;
+    return <canvas ref='canvas' />;
   }
 
   getScale() {
@@ -117,27 +117,26 @@ class CoverageTrack extends React.Component {
     // Let's get our domain max back from the nicified scale
     var axisMax = yScale.domain()[0];
 
-    var calcBarHeight = bin => Math.max(0, yScale(axisMax - bin.count)),
-        calcBarPosX = bin => xScale(bin.position),
-        calcBarPosY = bin => yScale(bin.count) - yScale(axisMax),
-        calcBarWidth = bin => xScale(1) - xScale(0);
-
     var ctx = dataCanvas.getDataContext(this.getContext());
+    ctx.save();
     ctx.reset();
     ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+    ctx.fillStyle = style.COVERAGE_BIN_COLOR;
+    var barWidth = xScale(1) - xScale(0),
+        barPadding = barWidth * style.COVERAGE_BIN_PADDING_CONSTANT;
 
     // Draw coverage bins
     this.binsInRange().forEach(bin => {
       ctx.pushObject(bin);
-      ctx.fillStyle = style.COVERAGE_BIN_COLOR;
-      var barWidth = calcBarWidth(bin),
-          barPadding = barWidth * style.COVERAGE_BIN_PADDING_CONSTANT;
-      ctx.fillRect(calcBarPosX(bin) + barPadding,
-                   calcBarPosY(bin),
-                   calcBarWidth(bin) - barPadding,
-                   calcBarHeight(bin));
+      var barPosX = xScale(bin.position),
+          barPosY = yScale(bin.count) - yScale(axisMax),
+          barHeight = Math.max(0, yScale(axisMax - bin.count));
+      ctx.fillRect(barPosX + barPadding,
+                   barPosY,
+                   barWidth - barPadding,
+                   barHeight);
       ctx.popObject();
-      ctx.restore();
     });
 
     // Draw three ticks
@@ -155,7 +154,6 @@ class CoverageTrack extends React.Component {
       ctx.pushObject({value: tick, label: tickLabel, type: 'label'});
       // Now print the coverage information
       ctx.lineWidth = 1;
-      ctx.strokeStyle = style.COVERAGE_FONT_COLOR;
       ctx.fillStyle = style.COVERAGE_FONT_COLOR;
       ctx.font = style.COVERAGE_FONT_STYLE;
       var textPosY = tickPosY + style.COVERAGE_TEXT_Y_OFFSET;
@@ -164,8 +162,9 @@ class CoverageTrack extends React.Component {
                    textPosY);
       ctx.popObject();
       // Clean up with this tick
-      ctx.restore();
     });
+
+    ctx.restore();
   }
 }
 

--- a/src/main/style.js
+++ b/src/main/style.js
@@ -17,8 +17,8 @@ module.exports = {
   },
 
   // Styles for base pairs which are rendered as letters
-  LOOSE_TEXT_STYLE: '24px Helvetica Neue, Helvetica, Arial, sans-serif',
-  TIGHT_TEXT_STYLE: 'bold 12px Helvetica Neue, Helvetica, Arial, sans-serif',
+  LOOSE_TEXT_STYLE: `24px 'Helvetica Neue', Helvetica, Arial, sans-serif`,
+  TIGHT_TEXT_STYLE: `bold 12px 'Helvetica Neue', Helvetica, Arial, sans-serif`,
 
   // Gene track
   GENE_ARROW_SIZE:4,
@@ -34,8 +34,7 @@ module.exports = {
   INSERT_COLOR: 'rgb(97, 0, 216)',
 
   // Coverage track
-  COVERAGE_FONT_SIZE: 9,  // match this number with the one in _STYLE
-  COVERAGE_FONT_STYLE: `bold 9px Helvetica Neue, Helvetica, Arial, sans-serif`,
+  COVERAGE_FONT_STYLE: `bold 9px 'Helvetica Neue', Helvetica, Arial, sans-serif`,
   COVERAGE_FONT_COLOR: 'black',
   COVERAGE_TICK_LENGTH: 5,
   COVERAGE_TEXT_PADDING: 3,  // space between axis ticks and text

--- a/src/main/style.js
+++ b/src/main/style.js
@@ -32,4 +32,15 @@ module.exports = {
   ALIGNMENT_COLOR: '#c8c8c8',
   DELETE_COLOR: 'black',
   INSERT_COLOR: 'rgb(97, 0, 216)',
+
+  // Coverage track
+  COVERAGE_FONT_SIZE: 9,  // match this number with the one in _STYLE
+  COVERAGE_FONT_STYLE: `bold 9px Helvetica Neue, Helvetica, Arial, sans-serif`,
+  COVERAGE_FONT_COLOR: 'black',
+  COVERAGE_TICK_LENGTH: 5,
+  COVERAGE_TEXT_PADDING: 3,  // space between axis ticks and text
+  COVERAGE_TEXT_Y_OFFSET: 3,  // so that ticks and texts align better
+  COVERAGE_BIN_COLOR: '#a0a0a0',
+  COVERAGE_BIN_PADDING_CONSTANT: 0.01,  // 1% of bar width
+
 };

--- a/src/test/CoverageTrack-test.js
+++ b/src/test/CoverageTrack-test.js
@@ -22,6 +22,7 @@ var pileup = require('../main/pileup'),
     RemoteFile = require('../main/RemoteFile'),
     MappedRemoteFile = require('./MappedRemoteFile'),
     ContigInterval = require('../main/ContigInterval'),
+    dataCanvas = require('../main/data-canvas'),
     {waitFor} = require('./async');
 
 describe('CoverageTrack', function() {
@@ -29,6 +30,7 @@ describe('CoverageTrack', function() {
   var range = {contig: '17', start: 7500730, stop: 7500790};
 
   beforeEach(() => {
+    dataCanvas.RecordingContext.recordAll();
     // A fixed width container results in predictable x-positions for mismatches.
     testDiv.style.width = '800px';
     var p = pileup.create(testDiv, {
@@ -53,6 +55,7 @@ describe('CoverageTrack', function() {
   });
 
   afterEach(() => {
+    dataCanvas.RecordingContext.reset();
     // avoid pollution between tests.
     testDiv.innerHTML = '';
     testDiv.style.width = '';
@@ -62,12 +65,14 @@ describe('CoverageTrack', function() {
                             [[0, 16383], [691179834, 691183928], [694008946, 694009197]]),
       referenceSource = TwoBitDataSource.createFromTwoBitFile(new TwoBit(twoBitFile));
 
+  var {drawnObjectsWith} = dataCanvas.RecordingContext;
+
   var findCoverageBins = () => {
-    return testDiv.querySelectorAll('.coverage .bin');
+    return drawnObjectsWith(testDiv, '.coverage', b => b.position);
   };
 
   var findCoverageLabels = () => {
-    return testDiv.querySelectorAll('.coverage .y-axis text');
+    return drawnObjectsWith(testDiv, '.coverage', l => l.type == 'label')
   };
 
   var hasCoverage = () => {
@@ -85,8 +90,8 @@ describe('CoverageTrack', function() {
   it('should create correct labels for coverage', function() {
     return waitFor(hasCoverage, 2000).then(() => {
       var labelTexts = findCoverageLabels();
-      expect(labelTexts[0].textContent).to.equal('0X');
-      expect(labelTexts[labelTexts.length-1].textContent).to.equal('50X');
+      expect(labelTexts[0].label).to.equal('0X');
+      expect(labelTexts[labelTexts.length-1].label).to.equal('50X');
     });
   });
 

--- a/src/test/CoverageTrack-test.js
+++ b/src/test/CoverageTrack-test.js
@@ -65,7 +65,7 @@ describe('CoverageTrack', function() {
                             [[0, 16383], [691179834, 691183928], [694008946, 694009197]]),
       referenceSource = TwoBitDataSource.createFromTwoBitFile(new TwoBit(twoBitFile));
 
-  var {drawnObjectsWith} = dataCanvas.RecordingContext;
+  var {drawnObjectsWith, callsOf} = dataCanvas.RecordingContext;
 
   var findCoverageBins = () => {
     return drawnObjectsWith(testDiv, '.coverage', b => b.position);
@@ -89,9 +89,14 @@ describe('CoverageTrack', function() {
 
   it('should create correct labels for coverage', function() {
     return waitFor(hasCoverage, 2000).then(() => {
+      // These are the objects being used to draw labels
       var labelTexts = findCoverageLabels();
       expect(labelTexts[0].label).to.equal('0X');
       expect(labelTexts[labelTexts.length-1].label).to.equal('50X');
+
+      // Now let's test if they are actually being put on the screen
+      var texts = callsOf(testDiv, '.coverage', 'fillText');
+      expect(texts.map(t => t[1])).to.deep.equal(['0X', '25X', '50X']);
     });
   });
 


### PR DESCRIPTION
Rendering with canvas:
![screen recording 2015-09-24 at 10 47 pm](https://cloud.githubusercontent.com/assets/7809/10091883/9643a14a-630e-11e5-91c0-6da321d0b814.gif)

See #255 

The labels used to be much sharper and they look uglier on the canvas, but hopefully #261 will solve this issue once and for all.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/266)
<!-- Reviewable:end -->
