### PR TITLE
Add an automated speed test

### DIFF
--- a/examples/playground-complete.html
+++ b/examples/playground-complete.html
@@ -14,10 +14,16 @@
   right: 0;
   top: 0;
 }
+#jiggle {
+  position: absolute;
+  left: 0;
+  top: 0;
+}
 </style>
 </head>
 
 <body>
+<button id="jiggle">FPS test</button>
 <div id="yourDiv"></div>
 </body>
 

--- a/examples/playground.js
+++ b/examples/playground.js
@@ -67,3 +67,36 @@ var p = pileup.create(yourDiv, {
   range: {contig: 'chr17', start: 7512284, stop: 7512644},
   tracks: sources
 });
+
+function jiggle() {
+  var r = p.getRange();
+  if (r.start % 10 == 0) {
+    r.start -= 9;
+    r.stop -= 9;
+  } else {
+    r.start += 1;
+    r.stop += 1;
+  }
+
+  p.setRange(r);
+}
+
+var isJiggling = false;
+document.getElementById('jiggle').onclick = function() {
+  if (isJiggling) {
+    isJiggling = false;
+    this.innerHTML = 'FPS test';
+    return;
+  }
+
+  var repeatedlyJiggle = function() {
+    jiggle();
+    if (isJiggling) {
+      window.requestAnimationFrame(repeatedlyJiggle);
+    }
+  };
+
+  isJiggling = true;
+  this.innerHTML = 'Stop!';
+  repeatedlyJiggle();
+};

--- a/src/main/pileup.js
+++ b/src/main/pileup.js
@@ -81,7 +81,7 @@ function create(elOrId: string|Element, params: PileupParams): Pileup {
       reactElement.handleRangeChange(range);
     },
     getRange(): GenomeRange {
-      return reactElement.state.range;
+      return _.clone(reactElement.state.range);
     }
   };
 }


### PR DESCRIPTION
Or at least semi-automated, you still have to click a button:

![screen recording 2015-09-25 at 12 11 pm](https://cloud.githubusercontent.com/assets/98301/10105771/8efeb332-637e-11e5-8a8e-0e8466b51b6d.gif)

This should be slightly more reliable than the approach we've used so far (wildly dragging around with the mouse and watching the FPS meter).

Also adds a defensive copy to `pileup.getRange`, so that users can't accidentally muck with its internal React `state`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/267)
<!-- Reviewable:end -->
