### PR TITLE
Cache calls to getDataContext

### DIFF
--- a/src/main/data-canvas.js
+++ b/src/main/data-canvas.js
@@ -40,14 +40,25 @@ function DataContext(ctx: CanvasRenderingContext2D) {
 
 var stubGetDataContext = null;
 
-// This is exposed as a method for easier testing.
+/**
+ * Get a DataContext for the built-in CanvasRenderingContext2D.
+ *
+ * This caches DataContexts and facilitates stubbing in tests.
+ */
 function getDataContext(ctx: CanvasRenderingContext2D) {
   if (stubGetDataContext) {
     return stubGetDataContext(ctx);
   } else {
-    return new DataContext(ctx);
+    for (var i = 0; i < getDataContext.cache.length; i++) {
+      var pair = getDataContext.cache[i];
+      if (pair[0] == ctx) return pair[1];
+    }
+    var dtx = new DataContext(ctx);
+    getDataContext.cache.push([ctx, dtx]);
+    return dtx;
   }
 }
+getDataContext.cache = [];  // (CanvasRenderingContext2D, DataContext) pairs
 
 
 /**

--- a/src/test/data-canvas-test.js
+++ b/src/test/data-canvas-test.js
@@ -46,6 +46,15 @@ describe('data-canvas', function() {
       expect(rgbAtPos(im, 50, 50)).to.deep.equal([0, 0, 0]);
       expect(rgbAtPos(im, 200, 60)).to.deep.equal([255, 0, 0]);
     });
+
+    it('should cache calls', function() {
+      if (!canvas) throw 'bad';  // for flow
+      var ctx = canvas.getContext('2d');
+      var dtx = dataCanvas.getDataContext(ctx);
+      var dtx2 = dataCanvas.getDataContext(ctx);
+
+      expect(dtx2).to.equal(dtx2);
+    });
   });
 
   describe('click tracking context', function() {


### PR DESCRIPTION
See #278 

This seems to be a small performance win.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/279)
<!-- Reviewable:end -->
