### PR TITLE
Allow any track to be the reference

### DIFF
--- a/lib/underscore.js
+++ b/lib/underscore.js
@@ -2,7 +2,7 @@
 
 declare module "underscore" {
   declare function find<T>(list: T[], predicate: (val: T)=>boolean): ?T;
-  declare function findWhere<T>(list: Array<T>, properties: {}): ?T;
+  declare function findWhere<T>(list: Array<T>, properties: {[key:string]: any}): ?T;
   declare function clone<T>(obj: T): T;
 
   declare function isEqual<S, T>(a: S, b: T): boolean;

--- a/src/main/pileup.js
+++ b/src/main/pileup.js
@@ -47,7 +47,7 @@ type PileupParams = {
 }
 
 function findReference(tracks: VisualizedTrack[]): ?VisualizedTrack {
-  return _.findWhere(tracks, t => t.track.isReference);
+  return _.find(tracks, t => !!t.track.isReference);
 }
 
 function create(elOrId: string|Element, params: PileupParams): Pileup {

--- a/src/main/types.js
+++ b/src/main/types.js
@@ -18,6 +18,7 @@ export type Track = {
   data: Object;  // This is a DataSource object
   name?: string;
   cssClass?: string;
+  isReference?: boolean
 }
 
 export type VisualizedTrack = {

--- a/src/test/components-test.js
+++ b/src/test/components-test.js
@@ -10,6 +10,16 @@ var pileup = require('../main/pileup'),
 describe('pileup', function() {
   var tracks = [
     {
+      viz: pileup.viz.scale(),
+      data: pileup.formats.empty(),
+      name: 'Scale'
+    },
+    {
+      viz: pileup.viz.location(),
+      data: pileup.formats.empty(),
+      name: 'Location'
+    },
+    {
       viz: pileup.viz.genome(),
       isReference: true,
       data: pileup.formats.twoBit({
@@ -32,16 +42,6 @@ describe('pileup', function() {
         url: '/test-data/tp53.shifted.bb'
       }),
       cssClass: 'c'
-    },
-    {
-      viz: pileup.viz.scale(),
-      data: pileup.formats.empty(),
-      name: 'Scale'
-    },
-    {
-      viz: pileup.viz.location(),
-      data: pileup.formats.empty(),
-      name: 'Location'
     },
     {
       viz: pileup.viz.pileup(),


### PR DESCRIPTION
The issue was that I was calling `_.findWhere`, which expects key-value pairs to look for, rather than `_.find`, which takes a predicate.

Why Flow didn't catch this is beyond me.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/303)
<!-- Reviewable:end -->
