### PR TITLE
Only depend on pako/inflate

### DIFF
--- a/src/main/BigBed.js
+++ b/src/main/BigBed.js
@@ -8,7 +8,7 @@
 var Q = require('q'),
     _ = require('underscore'),
     jBinary = require('jbinary'),
-    pako = require('pako');  // for gzip inflation
+    pako = require('pako/lib/inflate');  // for gzip inflation
     
 
 var RemoteFile = require('./RemoteFile'),

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -7,7 +7,7 @@
 import type {InflatedBlock} from './types';
 import type * as Q from 'q';
 
-var pako = require('pako');
+var pako = require('pako/lib/inflate');
 
 // Compare two tuples of equal length. Is t1 <= t2?
 // TODO: make this tupleLessOrEqual<T> -- it works with strings or booleans, too.


### PR DESCRIPTION
I noticed that pako was split between inflate & deflate in the treemap earlier today. We only use inflate, so there's no need to depend on the deflate code. Fortunately, pako makes this easy.

    475353 pileup.min.js before
    452646 pileup.min.js after

i.e. a 22k = 5% space savings.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/305)
<!-- Reviewable:end -->
