### PR TITLE
Fix two small bugs

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -16,6 +16,9 @@
 .*node_modules/jstransformify.*
 .*node_modules/uglify.*
 .*node_modules/data-canvas.*
+.*node_modules/babel.*
+.*node_modules/d3.*
+.*node_modules/smash.*
 .*react/node_modules/fbjs.*
 .*coverage.*
 

--- a/src/main/Controls.js
+++ b/src/main/Controls.js
@@ -5,8 +5,11 @@
 'use strict';
 
 var React = require('react'),
-    types = require('./react-types'),
     _ = require('underscore');
+
+var types = require('./react-types'),
+    utils = require('./utils'),
+    Interval = require('./Interval');
 
 var Controls = React.createClass({
   propTypes: {
@@ -52,13 +55,11 @@ var Controls = React.createClass({
     var r = this.props.range;
     if (!r) return;
 
-    var span = r.stop - r.start,
-        center = r.start + span / 2,
-        newSpan = factor * span;
+    var iv = utils.scaleRange(new Interval(r.start, r.stop), factor);
     this.props.onChange({
       contig: r.contig,
-      start: Math.floor(Math.max(0, center - newSpan / 2)),
-      stop: Math.floor(center + newSpan / 2)  // TODO: clamp
+      start: iv.start,
+      stop: iv.stop
     });
   },
   render: function(): any {

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -132,6 +132,7 @@ function getRenderer(ctx: DataCanvasRenderingContext2D, scale: (num: number) => 
     ctx.save();
     ctx.fillStyle = style.BASE_COLORS[bp.basePair];
     ctx.globalAlpha = opacityForQuality(bp.quality);
+    ctx.textAlign = 'center';
     if (showText) {
       // 0.5 = centered
       ctx.fillText(bp.basePair, scale(1 + 0.5 + bp.pos), y + READ_HEIGHT - 2);

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -9,6 +9,8 @@ import type * as Q from 'q';
 
 var pako = require('pako/lib/inflate');
 
+var Interval = require('./Interval');
+
 // Compare two tuples of equal length. Is t1 <= t2?
 // TODO: make this tupleLessOrEqual<T> -- it works with strings or booleans, too.
 function tupleLessOrEqual(t1: Array<number>, t2: Array<number>): boolean {
@@ -153,6 +155,20 @@ function pipePromise<T>(deferred: Q.Deferred<T>, promise: Q.Promise<T>) {
   promise.then(deferred.resolve, deferred.reject, deferred.notify);
 }
 
+/**
+ * Scale the range by `factor` about its center.
+ * factor 2.0 will produce a range with twice the span, 0.5 with half.
+ * An invariant is that the center value will be identical before and after.
+ */
+function scaleRange(range: Interval, factor: number): Interval {
+  var span = range.stop - range.start,
+      center = Math.floor((range.start + range.stop) / 2),
+      newSpan = Math.round(factor * span / 2) * 2,
+      start = Math.max(0, center - newSpan / 2),
+      stop = center + newSpan / 2;  // TODO: clamp
+  return new Interval(start, stop);
+}
+
 module.exports = {
   tupleLessOrEqual,
   tupleRangeOverlaps,
@@ -160,5 +176,6 @@ module.exports = {
   inflateConcatenatedGzip,
   inflateGzip,
   altContigName,
-  pipePromise
+  pipePromise,
+  scaleRange
 };

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -164,8 +164,14 @@ function scaleRange(range: Interval, factor: number): Interval {
   var span = range.stop - range.start,
       center = Math.floor((range.start + range.stop) / 2),
       newSpan = Math.round(factor * span / 2) * 2,
-      start = Math.max(0, center - newSpan / 2),
+      start = center - newSpan / 2,
       stop = center + newSpan / 2;  // TODO: clamp
+
+  if (start < 0) {
+    // Shift to the right so that the range starts at zero.
+    stop -= start;
+    start = 0;
+  }
   return new Interval(start, stop);
 }
 

--- a/src/test/utils-test.js
+++ b/src/test/utils-test.js
@@ -6,7 +6,8 @@ var expect = require('chai').expect;
 var pako = require('pako'),
     jBinary = require('jbinary');
 
-var utils = require('../main/utils');
+var utils = require('../main/utils'),
+    Interval = require('../main/Interval');
 
 describe('utils', function() {
   describe('tupleLessOrEqual', function() {
@@ -118,6 +119,54 @@ describe('utils', function() {
     expect(utils.altContigName('chr21')).to.equal('21');
     expect(utils.altContigName('M')).to.equal('chrM');
     expect(utils.altContigName('chrM')).to.equal('M');
+  });
+
+  describe('scaleRanges', function() {
+    // This matches how LocationTrack and PileupTrack define "center".
+    function center(iv: Interval) {
+      return Math.floor((iv.stop + iv.start) / 2);
+    }
+
+    it('should scaleRanges', function() {
+      // Zooming in and out should not change the center.
+      // See https://github.com/hammerlab/pileup.js/issues/321
+      var iv = new Interval(7, 17);
+      expect(center(iv)).to.equal(12);
+      var iv2 = utils.scaleRange(iv, 0.5);
+      expect(center(iv2)).to.equal(12);
+      var iv3 = utils.scaleRange(iv2, 2.0);
+      expect(center(iv3)).to.equal(12);
+
+      // Zooming in & out once can shift the frame, but doing so repeatedly will
+      // not produce any drift or growth/shrinkage.
+      var iv4 = iv3.clone();
+      for (var i = 0; i < 10; i++) {
+        iv4 = utils.scaleRange(iv4, 0.5);
+        iv4 = utils.scaleRange(iv4, 2.0);
+      }
+      expect(iv4.toString()).to.equal(iv3.toString());
+    });
+
+    it('should preserve centers', function() {
+      function checkCenterThroughZoom(origIv: Interval) {
+        var c = center(origIv);
+        // Zoom in then out
+        var iv = utils.scaleRange(origIv, 0.5);
+        expect(center(iv)).to.equal(c);
+        iv = utils.scaleRange(iv, 2.0);
+        expect(center(iv)).to.equal(c);
+        // Zoom out then in
+        iv = utils.scaleRange(origIv, 2.0);
+        expect(center(iv)).to.equal(c);
+        iv = utils.scaleRange(iv, 0.5);
+        expect(center(iv)).to.equal(c);
+      }
+
+      checkCenterThroughZoom(new Interval(7, 17));
+      checkCenterThroughZoom(new Interval(8, 18));
+      checkCenterThroughZoom(new Interval(8, 19));
+      checkCenterThroughZoom(new Interval(7, 18));
+    });
   });
 
 });

--- a/src/test/utils-test.js
+++ b/src/test/utils-test.js
@@ -167,6 +167,12 @@ describe('utils', function() {
       checkCenterThroughZoom(new Interval(8, 19));
       checkCenterThroughZoom(new Interval(7, 18));
     });
+
+    it('should stay positive', function() {
+      var iv = new Interval(5, 25),
+          iv2 = utils.scaleRange(iv, 2.0);
+      expect(iv2.toString()).to.equal('[0, 40]');
+    });
   });
 
 });


### PR DESCRIPTION
These popped up when I tried updating pileup in Cycledash.

With the `scaleRange` change, we lose the invariant that the range is precisely half or double what it was before, but we gain an invariant that the center base stays fixed, which is what you notice most easily.
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/322)
<!-- Reviewable:end -->
