### PR TITLE
Mention the URL in Request failed errors

### DIFF
--- a/src/main/RemoteFile.js
+++ b/src/main/RemoteFile.js
@@ -146,6 +146,7 @@ class RemoteFile {
   // Wrapper to convert XHRs to Promises.
   // The promised values are the response (e.g. an ArrayBuffer) and the Event.
   promiseXHR(xhr: XMLHttpRequest): Q.Promise<[any, Event]> {
+    var url = this.url;
     var deferred = Q.defer();
     xhr.addEventListener('load', function(e) {
       if (this.status >= 400) {
@@ -155,7 +156,7 @@ class RemoteFile {
       }
     });
     xhr.addEventListener('error', function(e) {
-      deferred.reject("Request failed with status: " + this.status);
+      deferred.reject(`Request for ${url} failed with status: ${this.status}`);
     });
     this.numNetworkRequests++;
     xhr.send();

--- a/src/test/RemoteFile-test.js
+++ b/src/test/RemoteFile-test.js
@@ -113,7 +113,8 @@ describe('RemoteFile', () => {
       // The majority of the browsers will return 404
       // and a minority (like PhantomJS) will fail fast
       // (more information: https://github.com/ariya/phantomjs/issues/11195)
-      expect(err).to.match(/404|^Request failed/);
+      expect(err).to.match(/404|^Request.*failed/);
+      expect(err).to.match(/nonexistent/);
     });
   });
 


### PR DESCRIPTION
I was seeing a lot of this in Cycledash:

![screen shot 2015-10-21 at 5 51 12 pm](https://cloud.githubusercontent.com/assets/98301/10651233/579cee2e-781c-11e5-845e-4a9606235194.png)

This should help clarify what's going on.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/323)
<!-- Reviewable:end -->
