### PR TITLE
Attempt to display deltas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 
 script: >
     npm run build &&
+    ./scripts/post_code_size.py dist/pileup.min.js &&
     npm run test &&
     npm run flow-check &&
     npm run lint &&

--- a/scripts/post-coverage.sh
+++ b/scripts/post-coverage.sh
@@ -5,6 +5,4 @@ cat coverage/lcov.info | ./node_modules/.bin/coveralls
 # echo "Code size: $size"
 # curl --header "Authorization: token $GITHUB_TOKEN" --data '{"state": "success", "description": "'$size' bytes", "context": "Minified Code Size" }' https://api.github.com/repos/$TRAVIS_REPO_SLUG/statuses/$TRAVIS_COMMIT
 
-./scripts/post_code_size.py dist/pileup.min.js
-
 echo ''  # reset exit code -- failure to post coverage shouldn't be an error.

--- a/scripts/post_code_size.py
+++ b/scripts/post_code_size.py
@@ -20,6 +20,7 @@ import urllib2
 
 TRAVIS_COMMIT = os.environ['TRAVIS_COMMIT']
 TRAVIS_PULL_REQUEST = os.environ.get('TRAVIS_PULL_REQUEST')
+TRAVIS_COMMIT_RANGE = os.environ.get('TRAVIS_COMMIT_RANGE')
 TRAVIS_REPO_SLUG = os.environ['TRAVIS_REPO_SLUG']
 GITHUB_TOKEN = os.environ.get('GITHUB_TOKEN')
 
@@ -143,6 +144,8 @@ if __name__ == '__main__':
     if not os.environ.get('TRAVIS'):
         print 'Not Travis; exiting'
         sys.exit(0)
+
+    print 'commit range: %s' % TRAVIS_COMMIT_RANGE
 
     current_size = os.stat(filename).st_size
     previous_size = get_base_size(filename)


### PR DESCRIPTION
This builds on #327 

This is a bit roundabout because of how Travis-CI handles pull requests. As near as I can tell:

- When you push anything to GitHub, Travis-CI starts a "push" build. This has the `TRAVIS_COMMIT` environment variable set, but not `TRAVIS_PULL_REQUEST`. This makes sense, since the push might not be part of a PR.
- When you create a pull request for a branch, Travis-CI starts a "pr" build. This checks out something like `refs/pull/328/merge`, which is the PR branch as merged onto whatever its base is. This has, e.g. `TRAVIS_PULL_REQUEST=328`, and `TRAVIS_COMMIT` set to whatever the merge commit's SHA is.
- GitHub only shows statuses for the "push" commit in the PR view.

It's difficult to determine PR information in the "push" build (see [this question][1]), so instead I figure out the "push" SHA in the "pr" build. Both builds post file size information as a status on the "push" SHA, but only the "pr" build will post a file size delta. Since it typically starts after the "push" build, the better message will typically be the one that's displayed. But it is a race.

I'm not sure if there's a better way to do this. I do need to calculate sizes in "push" builds (e.g. for when you push to master, to get baselines). But unless that SO question gets a satisfactory answer, I don't see any way to reliably get the deltas to show up.

[1]: http://stackoverflow.com/questions/33307413/how-can-i-determine-which-pull-request-a-commit-belongs-to-using-the-github-api

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/328)
<!-- Reviewable:end -->