### PR TITLE
Retain lines when running babel

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@ set -o errexit
 # Transpile individual files. This is useful if another module,
 # e.g. cycledash, wants to require('pileup').
 # The dist/test files are required for code coverage
-babel src --ignore src/lib --out-dir dist
+babel src --retain-lines --ignore src/lib --out-dir dist
 cp -r src/lib dist/
 
 # Create dist/tests

--- a/scripts/post-coverage.sh
+++ b/scripts/post-coverage.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
 cat coverage/lcov.info | ./node_modules/.bin/coveralls
 
-# size=$(wc -c < dist/pileup.min.js | sed 's/ //g')
-# echo "Code size: $size"
-# curl --header "Authorization: token $GITHUB_TOKEN" --data '{"state": "success", "description": "'$size' bytes", "context": "Minified Code Size" }' https://api.github.com/repos/$TRAVIS_REPO_SLUG/statuses/$TRAVIS_COMMIT
-
 echo ''  # reset exit code -- failure to post coverage shouldn't be an error.


### PR DESCRIPTION
Fixes #330 

Compare `RemoteFile.js` coverage [before][] and [after][]. The latter makes sense, the former does not.

[before]: https://coveralls.io/builds/3932994/source?filename=src%2Fmain%2FRemoteFile.js
[after]: https://coveralls.io/builds/3953163/source?filename=src%2Fmain%2FRemoteFile.js

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/331)
<!-- Reviewable:end -->
