### PR TITLE
Visual improvements to CoverageTrack

### DIFF
--- a/src/main/style.js
+++ b/src/main/style.js
@@ -40,7 +40,6 @@ module.exports = {
   COVERAGE_TEXT_PADDING: 3,  // space between axis ticks and text
   COVERAGE_TEXT_Y_OFFSET: 3,  // so that ticks and texts align better
   COVERAGE_BIN_COLOR: '#a0a0a0',
-  COVERAGE_BIN_PADDING_CONSTANT: 0.01,  // 1% of bar width
 
   // Scale Track
   SCALE_LINE_PADDING: 40,  // space between mid point and left/right lines

--- a/src/main/style.js
+++ b/src/main/style.js
@@ -40,6 +40,7 @@ module.exports = {
   COVERAGE_TEXT_PADDING: 3,  // space between axis ticks and text
   COVERAGE_TEXT_Y_OFFSET: 3,  // so that ticks and texts align better
   COVERAGE_BIN_COLOR: '#a0a0a0',
+  COVERAGE_MIN_BAR_WIDTH_FOR_GAP: 8,  // show a 1px gap between bars at this resolution
 
   // Scale Track
   SCALE_LINE_PADDING: 40,  // space between mid point and left/right lines


### PR DESCRIPTION
This includes a bunch of changes:

1. eliminates the Moiré pattern (fixes #334). This required splitting out the mismatch rendering code into a separate loop.
1. rounds the y-axis coordinates to get crisper rendering. IGV.js does this and it looks much nicer.
1. fixes a bug where the bars were all ~10px too high, thus giving incorrect counts. Funny that we never noticed this!
1. restored the white border on the coverage track scale. I believe this was lost in the SVG→canvas transition (we used to do it with CSS).

Here's a before/after:

![screen shot 2015-10-27 at 1 20 59 pm](https://cloud.githubusercontent.com/assets/98301/10766375/9e3f98c8-7cad-11e5-967a-eaa61fe172f3.png)

![screen shot 2015-10-27 at 1 20 14 pm](https://cloud.githubusercontent.com/assets/98301/10766372/9be15508-7cad-11e5-9469-13e350e61361.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/338)
<!-- Reviewable:end -->
