### PR TITLE
Tiled Canvas

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -19,6 +19,8 @@
 .*node_modules/babel.*
 .*node_modules/d3.*
 .*node_modules/smash.*
+.*node_modules/source-map.*
+.*node_modules/exorcist.*
 .*react/node_modules/fbjs.*
 .*coverage.*
 

--- a/README.md
+++ b/README.md
@@ -74,18 +74,6 @@ To play with the demo, start an [http-server][hs]:
 
 Then open [http://localhost:8080/examples/index.html](http://localhost:8080/examples/index.html) in your browser of choice.
 
-### BioJS
-
-Alternatively you can use [BioJS sniper][sniper] for the demo:
-
-    npm install -g sniper # installs sniper globally
-
-Once installed, start sniper in the `pileup.js` folder:
-
-    sniper # and keep it running
-
-And browse to [http://localhost:9090/examples/playground](http://localhost:9090/examples/playground).
-
 ## Testing
 
 Run the tests from the command line:
@@ -97,15 +85,33 @@ Run the tests in a real browser:
     npm run http-server
     open http://localhost:8080/src/test/runner.html
 
-To continuously regenerate the combined JS, run:
+To continuously regenerate the combined pileup and test JS, run:
 
     npm run watch
+
+To run a single test from the command line, use:
+
+    npm run test -- --grep=pileuputils
+
+To do the same in the web UI, pass in a `?grep=` URL parameter.
 
 To typecheck the code, run
 
     npm run flow
 
 For best results, use one of the flowtype editor integrations.
+
+### BioJS
+
+Alternatively you can use [BioJS sniper][sniper] for the demo:
+
+    npm install -g sniper # installs sniper globally
+
+Once installed, start sniper in the `pileup.js` folder:
+
+    sniper # and keep it running
+
+And browse to [http://localhost:9090/examples/playground](http://localhost:9090/examples/playground).
 
 ## License
 

--- a/lib/underscore.js
+++ b/lib/underscore.js
@@ -45,4 +45,7 @@ declare module "underscore" {
 
   declare function reduce<T, R>(a: T[], fn: (memo: R, val: T, idx: number, list: T[])=>R, memo?: R): R;
   declare function reduce<K, T, R>(a: {[key:K]: T}, fn: (memo: R, val: T, key: K, o: {[key:K]: T})=>R, memo?: R): R;
+
+  declare function uniq<T>(array: T[], isSorted?: boolean, iteratee?: (v: T)=>any): T[];
+  declare function unique<T>(array: T[], isSorted?: boolean, iteratee?: (v: T)=>any): T[];
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "backbone": "1.1.2",
     "d3": "^3.5.5",
-    "data-canvas": "0.0.0",
+    "data-canvas": "^0.1.0",
     "jbinary": "^2.1.3",
     "jdataview": "^2.5.0",
     "pako": "^0.2.5",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -18,4 +18,4 @@ trap finish EXIT
 sleep 1
 
 # Start the tests
-mocha-phantomjs http://localhost:8081/src/test/runner.html
+mocha-phantomjs http://localhost:8081/src/test/runner.html "$@"

--- a/src/main/ContigInterval.js
+++ b/src/main/ContigInterval.js
@@ -87,18 +87,21 @@ class ContigInterval<T: (number|string)> {
     return `${this.contig}:${this.start()}-${this.stop()}`;
   }
 
+  // Comparator for use with Array.prototype.sort
+  static compare(a: ContigInterval, b: ContigInterval): number {
+    if (a.contig > b.contig) {
+      return -1;
+    } else if (a.contig < b.contig) {
+      return +1;
+    } else {
+      return a.start() - b.start();
+    }
+  }
+
   // Sort an array of intervals & coalesce adjacent/overlapping ranges.
   // NB: this may re-order the intervals parameter
   static coalesce(intervals: ContigInterval[]): ContigInterval[] {
-    intervals.sort((a, b) => {
-      if (a.contig > b.contig) {
-        return -1;
-      } else if (a.contig < b.contig) {
-        return +1;
-      } else {
-        return a.start() - b.start();
-      }
-    });
+    intervals.sort(ContigInterval.compare);
 
     var rs = [];
     intervals.forEach(r => {

--- a/src/main/Interval.js
+++ b/src/main/Interval.js
@@ -91,6 +91,8 @@ class Interval {
    * If comp = interval.complementIntervals(ranges), then this guarantees that:
    * - comp union ranges = interval
    * - a int b = 0 forall a \in comp, b in ranges
+   *
+   * (The input ranges need not be disjoint.)
    */
   complementIntervals(ranges: Interval[]): Interval[] {
     var comps = [this];

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -48,8 +48,7 @@ function isRendered(op) {
 
 // The renderer pulls out the canvas context and scale into shared variables in a closure.
 function getRenderer(ctx: DataCanvasRenderingContext2D,
-                     scale: (num: number) => number,
-                     visibleYRange: Interval) {
+                     scale: (num: number) => number) {
   // Should mismatched base pairs be shown as blocks of color or as letters?
   var pxPerLetter = scale(1) - scale(0),
       mode = DisplayMode.getDisplayMode(pxPerLetter),
@@ -123,10 +122,6 @@ function getRenderer(ctx: DataCanvasRenderingContext2D,
 
   function drawGroup(vGroup: VisualGroup) {
     var y = yForRow(vGroup.row);
-    if (y < visibleYRange.start - READ_HEIGHT || y > visibleYRange.stop) {
-      // Optimization: don't render off-screen alignments.
-      return;
-    }
     ctx.pushObject(vGroup);
     vGroup.alignments.forEach(vRead => drawAlignment(vRead, y));
     if (vGroup.insert) {
@@ -184,7 +179,6 @@ class PileupTrack extends React.Component {
   constructor(props: Object) {
     super(props);
     this.state = {
-      visibleYRange: new Interval(0, Number.MAX_VALUE)
     };
   }
 
@@ -245,29 +239,12 @@ class PileupTrack extends React.Component {
     }).on('networkdone', e => {
       this.setState({networkStatus: null});
     });
-    this.getScrollParent().addEventListener('scroll', e => {
-      this.updateVisibleYRange();
-    });
 
     this.updateVisualization();
   }
 
   getScale() {
     return d3utils.getTrackScale(this.props.range, this.props.width);
-  }
-
-  getScrollParent(): HTMLElement {
-    var node = this.refs.container;
-    while (node && !node.classList.contains(SCROLLING_CLASS_NAME)) {
-      node = node.parentElement;
-    }
-    return node;
-  }
-
-  updateVisibleYRange() {
-    var node = this.getScrollParent();
-    var top = node.scrollTop;
-    this.setState({visibleYRange: new Interval(top, top + node.offsetHeight)});
   }
 
   componentDidUpdate(prevProps: any, prevState: any) {

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -157,6 +157,9 @@ function renderPileup(ctx: DataCanvasRenderingContext2D,
   }
 
   function renderMismatch(bp: BasePair, y: number) {
+    // This can happen if the mismatch is in a different tile, for example.
+    if (!range.interval.contains(bp.pos)) return;
+
     ctx.pushObject(bp);
     ctx.save();
     ctx.fillStyle = style.BASE_COLORS[bp.basePair];

--- a/src/main/RemoteFile.js
+++ b/src/main/RemoteFile.js
@@ -150,13 +150,13 @@ class RemoteFile {
     var deferred = Q.defer();
     xhr.addEventListener('load', function(e) {
       if (this.status >= 400) {
-        deferred.reject(this.status + ' ' + this.statusText);
+        deferred.reject(`Request for ${url} failed with status: ${this.status} ${this.statusText}`);
       } else {
         deferred.resolve([this.response, e]);
       }
     });
     xhr.addEventListener('error', function(e) {
-      deferred.reject(`Request for ${url} failed with status: ${this.status}`);
+      deferred.reject(`Request for ${url} failed with status: ${this.status} ${this.statusText}`);
     });
     this.numNetworkRequests++;
     xhr.send();

--- a/src/main/TiledCanvas.js
+++ b/src/main/TiledCanvas.js
@@ -35,6 +35,7 @@ class TiledCanvas {
     var range = tile.range;
     var height = this.heightForRef(range.contig),
         width = Math.round(tile.pixelsPerBase * range.length());
+    // TODO: does it make sense to re-use canvases?
     tile.buffer = document.createElement('canvas');
     tile.buffer.width = width;
     tile.buffer.height = height;
@@ -82,12 +83,15 @@ class TiledCanvas {
     tiles.forEach(tile => {
       var left = Math.round(scale(tile.range.start())),
           nextLeft = Math.round(scale(tile.range.stop() + 1)),
-          width = nextLeft - left;
+          width = nextLeft - left,
+          height = tile.buffer.height;
+      // Drawing a 0px tall canvas throws in Firefox and PhantomJS.
+      if (height === 0) return;
       // We can't just throw the images on the screen without scaling due to
       // rounding issues, which can result in 1px gaps or overdrawing.
       // We always have:
       //   width - tile.buffer.width \in {-1, 0, +1}
-      ctx.drawImage(tile.buffer, left, 0, width, tile.buffer.height);
+      ctx.drawImage(tile.buffer, left, 0, width, height);
     });
   }
 

--- a/src/main/TiledCanvas.js
+++ b/src/main/TiledCanvas.js
@@ -1,0 +1,124 @@
+/**
+ * A canvas which maintains a cache of previously-rendered tiles.
+ * @flow
+ */
+'use strict';
+
+import type {DataCanvasRenderingContext2D} from 'data-canvas';
+
+var _ = require('underscore');
+
+var scale = require('./scale'),
+    ContigInterval = require('./ContigInterval'),
+    Interval = require('./Interval'),
+    canvasUtils = require('./canvas-utils'),
+    dataCanvas = require('data-canvas'),
+    utils = require('./utils');
+
+type Tile = {
+  pixelsPerBase: number;
+  range: ContigInterval<string>;
+  buffer: HTMLCanvasElement;
+};
+
+const EPSILON = 1e-6;
+const MIN_PX_PER_BUFFER = 500;
+
+class TiledCanvas {
+  tileCache: Tile[];
+
+  constructor() {
+    this.tileCache = [];
+  }
+
+  renderTile(tile: Tile) {
+    var range = tile.range;
+    var height = this.heightForRef(range.contig),
+        width = Math.round(tile.pixelsPerBase * range.length());
+    tile.buffer = document.createElement('canvas');
+    tile.buffer.width = width;
+    tile.buffer.height = height;
+
+    var sc = scale.linear().domain([range.start(), range.stop()]).range([0, width]);
+    var ctx = canvasUtils.getContext(tile.buffer);
+    var dtx = dataCanvas.getDataContext(ctx);
+    this.render(dtx, sc, range);
+  }
+
+  // Create (and render) new tiles to fill the gaps.
+  makeNewTiles(existingTiles: Interval[],
+               pixelsPerBase: number,
+               range: ContigInterval<string>): Tile[] {
+    var newIntervals = TiledCanvas.getNewTileRanges(
+          existingTiles, range.interval, pixelsPerBase);
+
+    var newTiles = newIntervals.map(iv => ({
+      pixelsPerBase,
+      range: new ContigInterval(range.contig, iv.start, iv.stop),
+      buffer: document.createElement('canvas')
+    }));
+
+    // TODO: it would be better to wrap these calls in requestAnimationFrame,
+    // so that rendering is done off the main event loop.
+    newTiles.forEach(tile => this.renderTile(tile));
+    this.tileCache = this.tileCache.concat(newTiles);
+    this.tileCache.sort((a, b) => ContigInterval.compare(a.range, b.range));
+    return newTiles;
+  }
+
+  renderToScreen(ctx: CanvasRenderingContext2D,
+                 range: ContigInterval<string>,
+                 scale: (num: number) => number) {
+    var pixelsPerBase = scale(1) - scale(0);
+    var tilesAtRes = this.tileCache.filter(tile => Math.abs(tile.pixelsPerBase - pixelsPerBase) < EPSILON && range.chrOnContig(tile.range.contig));
+
+    var existingIntervals = tilesAtRes.map(tile => tile.range.interval);
+    if (!range.interval.isCoveredBy(existingIntervals)) {
+      tilesAtRes = tilesAtRes.concat(this.makeNewTiles(existingIntervals, pixelsPerBase, range));
+    }
+
+    var tiles = tilesAtRes.filter(tile => range.chrIntersects(tile.range));
+
+    tiles.forEach(tile => {
+      var left = Math.round(scale(tile.range.start())),
+          nextLeft = Math.round(scale(tile.range.stop() + 1)),
+          width = nextLeft - left;
+      // We can't just throw the images on the screen without scaling due to
+      // rounding issues, which can result in 1px gaps or overdrawing.
+      // We always have:
+      //   width - tile.buffer.width \in {-1, 0, +1}
+      ctx.drawImage(tile.buffer, left, 0, width, tile.buffer.height);
+    });
+  }
+
+  invalidateAll() {
+    this.tileCache = [];
+  }
+
+  heightForRef(ref: string): number {
+    throw 'Not implemented';
+  }
+
+  render(dtx: DataCanvasRenderingContext2D,
+         scale: (x: number)=>number,
+         range: ContigInterval<string>): void {
+    throw 'Not implemented';
+  }
+
+  // requires that existingIntervals be sorted.
+  static getNewTileRanges(existingIntervals: Interval[],
+                          range: Interval,
+                          pixelsPerBase: number): Interval[] {
+    var ivWidth = Math.ceil(MIN_PX_PER_BUFFER / pixelsPerBase);
+    var firstStart = Math.floor(range.start / ivWidth) * ivWidth;
+    var ivs = _.range(firstStart, range.stop, ivWidth)
+               .map(start => new Interval(start, start + ivWidth - 1))
+               .filter(iv => !iv.isCoveredBy(existingIntervals));
+
+    return utils.flatMap(ivs, iv => iv.complementIntervals(existingIntervals))
+                .filter(iv => iv.intersects(range));
+  }
+
+}
+
+module.exports = TiledCanvas;

--- a/src/main/TiledCanvas.js
+++ b/src/main/TiledCanvas.js
@@ -24,7 +24,7 @@ type Tile = {
 const EPSILON = 1e-6;
 const MIN_PX_PER_BUFFER = 500;
 
-const DEBUG_RENDER_TILE_EDGES = true;
+const DEBUG_RENDER_TILE_EDGES = false;
 
 class TiledCanvas {
   tileCache: Tile[];
@@ -42,7 +42,9 @@ class TiledCanvas {
     tile.buffer.width = width;
     tile.buffer.height = height;
 
-    var sc = scale.linear().domain([range.start(), range.stop()]).range([0, width]);
+    // The far right edge of the tile is the start of the _next_ range's base
+    // pair, not the start of the last one in this tile.
+    var sc = scale.linear().domain([range.start(), range.stop() + 1]).range([0, width]);
     var ctx = canvasUtils.getContext(tile.buffer);
     var dtx = dataCanvas.getDataContext(ctx);
     this.render(dtx, sc, range);
@@ -93,7 +95,7 @@ class TiledCanvas {
       // rounding issues, which can result in 1px gaps or overdrawing.
       // We always have:
       //   width - tile.buffer.width \in {-1, 0, +1}
-      ctx.drawImage(tile.buffer, left, 0, width, height);
+      ctx.drawImage(tile.buffer, left, 0 , width, height);
 
       if (DEBUG_RENDER_TILE_EDGES) {
         ctx.save();

--- a/src/main/TiledCanvas.js
+++ b/src/main/TiledCanvas.js
@@ -24,6 +24,8 @@ type Tile = {
 const EPSILON = 1e-6;
 const MIN_PX_PER_BUFFER = 500;
 
+const DEBUG_RENDER_TILE_EDGES = true;
+
 class TiledCanvas {
   tileCache: Tile[];
 
@@ -92,6 +94,14 @@ class TiledCanvas {
       // We always have:
       //   width - tile.buffer.width \in {-1, 0, +1}
       ctx.drawImage(tile.buffer, left, 0, width, height);
+
+      if (DEBUG_RENDER_TILE_EDGES) {
+        ctx.save();
+        ctx.strokeStyle = 'black';
+        canvasUtils.drawLine(ctx, left - 0.5, 0, left - 0.5, height);
+        canvasUtils.drawLine(ctx, nextLeft - 0.5, 0, nextLeft - 0.5, height);
+        ctx.restore();
+      }
     });
   }
 

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -7,7 +7,8 @@
 import type {InflatedBlock, PartialGenomeRange} from './types';
 import type * as Q from 'q';
 
-var pako = require('pako/lib/inflate');
+var pako = require('pako/lib/inflate'),
+    _ = require('underscore');
 
 var Interval = require('./Interval');
 
@@ -248,6 +249,10 @@ function parseNumberWithCommas(x: string): number {
   return parseInt(x.replace(/,/g, ''), 10);
 }
 
+function flatMap<T, R>(array: T[], fn: (t: T)=>R[]): R[] {
+  return _.flatten(array.map(fn), true /* shallow */);
+}
+
 module.exports = {
   tupleLessOrEqual,
   tupleRangeOverlaps,
@@ -259,5 +264,6 @@ module.exports = {
   scaleRange,
   parseRange,
   formatInterval,
-  isChrMatch
+  isChrMatch,
+  flatMap
 };

--- a/src/test/TiledCanvas-test.js
+++ b/src/test/TiledCanvas-test.js
@@ -1,0 +1,89 @@
+/** @flow */
+'use strict';
+
+var expect = require('chai').expect;
+
+var _ = require('underscore');
+
+var Interval = require('../main/Interval'),
+    TiledCanvas = require('../main/TiledCanvas');
+
+describe('TiledCanvas', function() {
+  describe('getNewTileRanges', function() {
+    var getNewTileRanges = TiledCanvas.getNewTileRanges;
+    var iv = (a, b) => new Interval(a, b);
+
+    it('should tile new ranges', function() {
+      // The 0-100bp range gets enlarged & covered by a 0-500bp buffer.
+      expect(getNewTileRanges([], iv(0, 100), 1))
+          .to.deep.equal([iv(0, 499)]);
+
+      // A large range requires multiple buffers.
+      expect(getNewTileRanges([], iv(0, 800), 1))
+          .to.deep.equal([iv(  0, 499),
+                          iv(500, 999)]);
+
+      // A gap gets filled.
+      expect(getNewTileRanges([iv(0, 200), iv(400, 800)], iv(0, 800), 1))
+          .to.deep.equal([iv(201, 399)]);
+
+      // There's an existing tile in the middle of the new range.
+      expect(getNewTileRanges([iv(0, 200), iv(400, 700)], iv(350, 750), 1))
+          .to.deep.equal([iv(201, 399), iv(701, 999)]);
+    });
+
+    function intervalsAfterPanning(seq: Interval[], pxPerBase: number): Interval[] {
+      var tiles = [];
+      seq.forEach(range => {
+        tiles = tiles.concat(getNewTileRanges(tiles, range, pxPerBase));
+        tiles = _.sortBy(tiles, iv => iv.start);
+      });
+      return tiles;
+    }
+
+    it('should generate a small number of tiles while panning', function() {
+      // This simulates a sequence of views that might result from panning.
+      // Start at [100, 500], pan to the left, then over to the right.
+      expect(intervalsAfterPanning(
+            [iv(100, 500),
+             iv( 95, 495),
+             iv( 85, 485),
+             iv( 75, 475),
+             iv( 15, 415),
+             iv( 70, 470),
+             iv(101, 501),
+             iv(110, 510),
+             iv(120, 520),
+             iv(600, 1000),
+             iv(610, 1010)], 1))
+          .to.deep.equal([iv(0, 499), iv(500, 999), iv(1000, 1499)]);
+    });
+
+    it('should not leave gaps with non-integer pixels per base', function() {
+      var pxPerBase = 1100 / 181;  // ~6.077 px/bp -- very awkward!
+      expect(intervalsAfterPanning(
+            [iv(100, 300),
+             iv( 95, 295),
+             iv( 85, 285),
+             iv( 75, 275),
+             iv( 15, 215),
+             iv( 70, 270),
+             iv(101, 301),
+             iv(110, 310),
+             iv(120, 320),
+             iv(600, 800),
+             iv(610, 810)], pxPerBase))
+          .to.deep.equal([
+              // These tiles are somewhat arbitrary.
+              // What's important is that they're integers with no gaps.
+              iv(  0, 82),
+              iv( 83, 165),
+              iv(166, 248),
+              iv(249, 331),
+              iv(581, 663),
+              iv(664, 746),
+              iv(747, 829)
+            ]);
+    });
+  });
+});

--- a/src/test/utils-test.js
+++ b/src/test/utils-test.js
@@ -212,4 +212,11 @@ describe('utils', function() {
     });
   });
 
+  it('should flatMap', function() {
+    expect(utils.flatMap([1, 2, 3], x => [x])).to.deep.equal([1, 2, 3]);
+    expect(utils.flatMap([1, 2, 3], x => x % 2 === 0 ? [x, x] : [])).to.deep.equal([2, 2]);
+
+    expect(utils.flatMap([[1,2], [2,3]], a => a)).to.deep.equal([1, 2, 2, 3]);
+    expect(utils.flatMap([[1,2], [2,3]], a => [a])).to.deep.equal([[1, 2], [2, 3]]);
+  });
 });


### PR DESCRIPTION
Fixes #86 

This introduces `TiledCanvas`, which maintains a cache of previously rendered buffers. This greatly improves performance during panning, since each frame just involves drawing pre-rendered buffers on the on-screen canvas. Panning at any zoom level improves to ~60fps after this change.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/346)
<!-- Reviewable:end -->
