### PR TITLE
Tile the CoverageTrack

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "backbone": "1.1.2",
     "d3": "^3.5.5",
-    "data-canvas": "^0.1.0",
+    "data-canvas": ">=0.1.1",
     "jbinary": "^2.1.3",
     "jdataview": "^2.5.0",
     "pako": "^0.2.5",

--- a/src/main/ContigInterval.js
+++ b/src/main/ContigInterval.js
@@ -87,6 +87,17 @@ class ContigInterval<T: (number|string)> {
     return `${this.contig}:${this.start()}-${this.stop()}`;
   }
 
+  toGenomeRange(): GenomeRange {
+    if (!(this.contig instanceof String)) {
+      throw 'Cannot convert numeric ContigInterval to GenomeRange';
+    }
+    return {
+      contig: this.contig,
+      start: this.start(),
+      stop: this.stop()
+    };
+  }
+
   // Comparator for use with Array.prototype.sort
   static compare(a: ContigInterval, b: ContigInterval): number {
     if (a.contig > b.contig) {
@@ -119,6 +130,10 @@ class ContigInterval<T: (number|string)> {
     });
 
     return rs;
+  }
+
+  static fromGenomeRange(range: GenomeRange): ContigInterval<string> {
+    return new ContigInterval(range.contig, range.start, range.stop);
   }
 }
 

--- a/src/main/CoverageTrack.js
+++ b/src/main/CoverageTrack.js
@@ -120,10 +120,10 @@ class CoverageTiledCanvas extends TiledCanvas {
   }
 
   update(height: number, yScale: (count: number) => number, binCounts: BinSummaryWithLocation[]) {
-    this.height = height;
+    // workaround for an issue in PhantomJS where height always comes out to zero.
+    this.height = Math.max(1, height);
     this.yScale = yScale;
     this.binCounts = binCounts;
-    // this.invalidateAll();
   }
 
   render(ctx: DataCanvasRenderingContext2D,

--- a/src/test/CoverageTrack-test.js
+++ b/src/test/CoverageTrack-test.js
@@ -69,7 +69,6 @@ describe('CoverageTrack', function() {
     return drawnObjectsWith(testDiv, '.coverage', b => b.base);
   };
 
-
   var findCoverageLabels = () => {
     return drawnObjectsWith(testDiv, '.coverage', l => l.type == 'label');
   };
@@ -91,7 +90,9 @@ describe('CoverageTrack', function() {
 
   it('should show mismatch information', function() {
     return waitFor(hasCoverage, 2000).then(() => {
-      expect(findMismatchBins()).to.deep.equal(
+      var visibleMismatches = findMismatchBins()
+          .filter(bin => bin.position >= range.start && bin.position <= range.stop);
+      expect(visibleMismatches).to.deep.equal(
         [{position: 7500765, count: 22, base: 'T'},
          {position: 7500765, count: 22, base: 'C'}]);
       // TODO: IGV shows counts of 20 and 20 at this locus. Whither the two bases?


### PR DESCRIPTION
See #351

Adding explicit types for props/state works really nicely. It makes Flow much more useful for these components.

The hack for PhantomJS is kinda gross, but I don't see an alternative.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/353)
<!-- Reviewable:end -->
