### PR TITLE
Props states types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -22,6 +22,7 @@
 .*node_modules/source-map.*
 .*node_modules/exorcist.*
 .*react/node_modules/fbjs.*
+.*/node_modules/react/.*
 .*coverage.*
 
 [include]

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "q": "^1.1.2",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
-    "react-addons-pure-render-mixin": "^0.14.0",
     "shallow-equals": "0.0.0",
     "underscore": "^1.7.0"
   },

--- a/src/main/Alignment.js
+++ b/src/main/Alignment.js
@@ -41,6 +41,6 @@ export type Alignment = {
 export type AlignmentDataSource = {
   rangeChanged: (newRange: GenomeRange) => void;
   getAlignmentsInRange: (range: ContigInterval<string>) => Alignment[];
-  on: (event: string, handler: Function) => void;
+  on: (event: string, handler: Function) => void;  // really => AlignmentDataSource
   off: (event: string) => void;
 };

--- a/src/main/BigBedDataSource.js
+++ b/src/main/BigBedDataSource.js
@@ -24,7 +24,7 @@ export type Gene = {
 }
 
 // Flow type for export.
-type BigBedSource = {
+export type BigBedSource = {
   rangeChanged: (newRange: GenomeRange) => void;
   getGenesInRange: (range: ContigInterval<string>) => Gene[];
   on: (event: string, handler: Function) => void;

--- a/src/main/Controls.js
+++ b/src/main/Controls.js
@@ -18,7 +18,7 @@ type Props = {
   onChange: (newRange: GenomeRange)=>void;
 };
 
-class Controls extends (React.Component : typeof ReactComponent) {
+class Controls extends React.Component {
   props: Props;
   state: void;  // no state
 

--- a/src/main/Controls.js
+++ b/src/main/Controls.js
@@ -9,8 +9,7 @@ import type {PartialGenomeRange} from './types';
 var React = require('react'),
     _ = require('underscore');
 
-var types = require('./react-types'),
-    utils = require('./utils'),
+var utils = require('./utils'),
     Interval = require('./Interval');
 
 type Props = {
@@ -22,6 +21,10 @@ type Props = {
 class Controls extends (React.Component : typeof ReactComponent) {
   props: Props;
   state: void;  // no state
+
+  constructor(props: Object) {
+    super(props);
+  }
 
   makeRange(): GenomeRange {
     return {
@@ -102,15 +105,15 @@ class Controls extends (React.Component : typeof ReactComponent) {
 
     // Note: input values are set in componentDidUpdate.
     return (
-      <form className='controls' onSubmit={this.handleFormSubmit}>
-        <select ref='contig' onChange={this.handleContigChange}>
+      <form className='controls' onSubmit={this.handleFormSubmit.bind(this)}>
+        <select ref='contig' onChange={this.handleContigChange.bind(this)}>
           {contigOptions}
         </select>{' '}
         <input ref='position' type='text' />{' '}
-        <button className='btn-submit' onClick={this.handleFormSubmit}>Go</button>{' '}
+        <button className='btn-submit' onClick={this.handleFormSubmit.bind(this)}>Go</button>{' '}
         <div className='zoom-controls'>
-          <button className='btn-zoom-out' onClick={this.zoomOut}></button>{' '}
-          <button className='btn-zoom-in' onClick={this.zoomIn}></button>
+          <button className='btn-zoom-out' onClick={this.zoomOut.bind(this)}></button>{' '}
+          <button className='btn-zoom-in' onClick={this.zoomIn.bind(this)}></button>
         </div>
       </form>
     );

--- a/src/main/Controls.js
+++ b/src/main/Controls.js
@@ -13,21 +13,25 @@ var types = require('./react-types'),
     utils = require('./utils'),
     Interval = require('./Interval');
 
-var Controls = React.createClass({
-  propTypes: {
-    range: types.GenomeRange,
-    contigList: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
-    // XXX: can we be more specific than this with Flow?
-    onChange: React.PropTypes.func.isRequired
-  },
-  makeRange: function(): GenomeRange {
+type Props = {
+  range: GenomeRange;
+  contigList: string[];
+  onChange: (newRange: GenomeRange)=>void;
+};
+
+class Controls extends (React.Component : typeof ReactComponent) {
+  props: Props;
+  state: void;  // no state
+
+  makeRange(): GenomeRange {
     return {
       contig: this.refs.contig.value,
       start: Number(this.refs.start.value),
       stop: Number(this.refs.stop.value)
     };
-  },
-  completeRange: function(range: ?PartialGenomeRange): GenomeRange {
+  }
+
+  completeRange(range: ?PartialGenomeRange): GenomeRange {
     range = range || {};
     if (range.start && range.stop === undefined) {
       // Construct a range centered around a value. This matches IGV.
@@ -44,17 +48,20 @@ var Controls = React.createClass({
     }
 
     return (_.extend({}, this.props.range, range) : any);
-  },
-  handleContigChange: function(e: SyntheticEvent) {
+  }
+
+  handleContigChange(e: SyntheticEvent) {
     this.props.onChange(this.completeRange({contig: this.refs.contig.value}));
-  },
-  handleFormSubmit: function(e: SyntheticEvent) {
+  }
+
+  handleFormSubmit(e: SyntheticEvent) {
     e.preventDefault();
     var range = this.completeRange(utils.parseRange(this.refs.position.value));
     this.props.onChange(range);
-  },
+  }
+
   // Sets the values of the input elements to match `props.range`.
-  updateRangeUI: function() {
+  updateRangeUI() {
     const r = this.props.range;
     if (!r) return;
 
@@ -64,16 +71,19 @@ var Controls = React.createClass({
       var contigIdx = this.props.contigList.indexOf(r.contig);
       this.refs.contig.selectedIndex = contigIdx;
     }
-  },
-  zoomIn: function(e: any) {
+  }
+
+  zoomIn(e: any) {
     e.preventDefault();
     this.zoomByFactor(0.5);
-  },
-  zoomOut: function(e: any) {
+  }
+
+  zoomOut(e: any) {
     e.preventDefault();
     this.zoomByFactor(2.0);
-  },
-  zoomByFactor: function(factor: number) {
+  }
+
+  zoomByFactor(factor: number) {
     var r = this.props.range;
     if (!r) return;
 
@@ -83,8 +93,9 @@ var Controls = React.createClass({
       start: iv.start,
       stop: iv.stop
     });
-  },
-  render: function(): any {
+  }
+
+  render(): any {
     var contigOptions = this.props.contigList
         ? this.props.contigList.map((contig, i) => <option key={i}>{contig}</option>)
         : null;
@@ -103,15 +114,17 @@ var Controls = React.createClass({
         </div>
       </form>
     );
-  },
-  componentDidUpdate: function(prevProps: Object) {
+  }
+
+  componentDidUpdate(prevProps: Object) {
     if (!_.isEqual(prevProps.range, this.props.range)) {
       this.updateRangeUI();
     }
-  },
-  componentDidMount: function() {
+  }
+
+  componentDidMount() {
     this.updateRangeUI();
   }
-});
+}
 
 module.exports = Controls;

--- a/src/main/GeneTrack.js
+++ b/src/main/GeneTrack.js
@@ -69,7 +69,7 @@ function drawGeneName(ctx: CanvasRenderingContext2D,
   }
 }
 
-class GeneTrack extends React.Component {
+class GeneTrack extends (React.Component : typeof ReactComponent) {
   props: VizProps & { source: BigBedSource };
   state: {genes: Gene[]};
 

--- a/src/main/GeneTrack.js
+++ b/src/main/GeneTrack.js
@@ -13,8 +13,7 @@ var React = require('react'),
     _ = require('underscore'),
     shallowEquals = require('shallow-equals');
 
-var types = require('./react-types'),
-    bedtools = require('./bedtools'),
+var bedtools = require('./bedtools'),
     Interval = require('./Interval'),
     d3utils = require('./d3utils'),
     scale = require('./scale'),

--- a/src/main/GeneTrack.js
+++ b/src/main/GeneTrack.js
@@ -68,7 +68,7 @@ function drawGeneName(ctx: CanvasRenderingContext2D,
   }
 }
 
-class GeneTrack extends (React.Component : typeof ReactComponent) {
+class GeneTrack extends React.Component {
   props: VizProps & { source: BigBedSource };
   state: {genes: Gene[]};
 

--- a/src/main/GeneTrack.js
+++ b/src/main/GeneTrack.js
@@ -5,7 +5,8 @@
 'use strict';
 
 import type {Strand} from './Alignment';
-import type {Gene} from './BigBedDataSource';
+import type {Gene, BigBedSource} from './BigBedDataSource';
+import type {VizProps} from './VisualizationWrapper';
 
 var React = require('react'),
     ReactDOM = require('react-dom'),
@@ -68,21 +69,22 @@ function drawGeneName(ctx: CanvasRenderingContext2D,
   }
 }
 
-var GeneTrack = React.createClass({
-  displayName: 'genes',
-  propTypes: {
-    range: types.GenomeRange.isRequired,
-    source: React.PropTypes.object.isRequired,
-  },
-  getInitialState: function() {
-    return {
-      genes: ([]: Object[])  // TODO: import Gene type from BigBedDataSource
+class GeneTrack extends React.Component {
+  props: VizProps & { source: BigBedSource };
+  state: {genes: Gene[]};
+
+  constructor(props: VizProps) {
+    super(props);
+    this.state = {
+      genes: []
     };
-  },
-  render: function(): any {
+  }
+
+  render(): any {
     return <canvas />;
-  },
-  componentDidMount: function() {
+  }
+
+  componentDidMount() {
     // Visualize new reference data as it comes in from the network.
     this.props.source.on('newdata', () => {
       var range = this.props.range,
@@ -93,23 +95,25 @@ var GeneTrack = React.createClass({
     });
 
     this.updateVisualization();
-  },
+  }
 
-  getScale: function() {
+  getScale() {
     return d3utils.getTrackScale(this.props.range, this.props.width);
-  },
-  componentDidUpdate: function(prevProps: any, prevState: any) {
+  }
+
+  componentDidUpdate(prevProps: any, prevState: any) {
     if (!shallowEquals(prevProps, this.props) ||
         !shallowEquals(prevState, this.state)) {
       this.updateVisualization();
     }
-  },
-  updateVisualization: function() {
+  }
+
+  updateVisualization() {
     var canvas = ReactDOM.findDOMNode(this),
         {width, height} = this.props,
         genomeRange = this.props.range;
 
-    var range = genomeRange ? new ContigInterval(genomeRange.contig, genomeRange.start, genomeRange.stop) : null;
+    var range = new ContigInterval(genomeRange.contig, genomeRange.start, genomeRange.stop);
 
     // Hold off until height & width are known.
     if (width === 0) return;
@@ -166,6 +170,8 @@ var GeneTrack = React.createClass({
       ctx.popObject();
     });
   }
-});
+}
+
+GeneTrack.displayName = 'genes';
 
 module.exports = GeneTrack;

--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -4,6 +4,9 @@
  */
 'use strict';
 
+import type {VizProps} from './VisualizationWrapper';
+import type {BigBedSource} from './BigBedDataSource';
+
 var React = require('react'),
     ReactDOM = require('react-dom'),
     PureRenderMixin = require('react-addons-pure-render-mixin');
@@ -16,37 +19,34 @@ var shallowEquals = require('shallow-equals'),
     DisplayMode = require('./DisplayMode'),
     style = require('./style');
 
+// props: VizProps & {source: BigBedSource};
 
-var GenomeTrack = React.createClass({
-  // This prevents updates if state & props have not changed.
-  mixins: [PureRenderMixin],
-  displayName: 'reference',
-
-  propTypes: {
-    range: types.GenomeRange.isRequired,
-    source: React.PropTypes.object.isRequired,
-  },
-  render: function(): any {
+class GenomeTrack extends React.Component {
+  render(): any {
     return <canvas />;
-  },
-  componentDidMount: function() {
+  }
+
+  componentDidMount() {
     // Visualize new reference data as it comes in from the network.
     this.props.source.on('newdata', () => {
       this.updateVisualization();
     });
 
     this.updateVisualization();
-  },
-  getScale: function() {
+  }
+
+  getScale() {
     return d3utils.getTrackScale(this.props.range, this.props.width);
-  },
-  componentDidUpdate: function(prevProps: any, prevState: any) {
+  }
+
+  componentDidUpdate(prevProps: any, prevState: any) {
     if (!shallowEquals(prevProps, this.props) ||
         !shallowEquals(prevState, this.state)) {
       this.updateVisualization();
     }
-  },
-  updateVisualization: function() {
+  }
+
+  updateVisualization() {
     var canvas = ReactDOM.findDOMNode(this),
         {width, height, range} = this.props;
 
@@ -111,6 +111,15 @@ var GenomeTrack = React.createClass({
       }
     }
   }
-});
+}
+
+// This prevents updates if state & props have not changed.
+GenomeTrack.mixins = [PureRenderMixin];
+GenomeTrack.displayName = 'reference';
+
+GenomeTrack.propTypes = {
+  range: types.GenomeRange.isRequired,
+  source: React.PropTypes.object.isRequired,
+};
 
 module.exports = GenomeTrack;

--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -19,7 +19,7 @@ var shallowEquals = require('shallow-equals'),
     style = require('./style');
 
 
-class GenomeTrack extends React.Component {
+class GenomeTrack extends (React.Component : typeof ReactComponent) {
   props: VizProps & {source: TwoBitSource};
   state: void;  // no state
 

--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -5,11 +5,10 @@
 'use strict';
 
 import type {VizProps} from './VisualizationWrapper';
-import type {BigBedSource} from './BigBedDataSource';
+import type {TwoBitSource} from './TwoBitDataSource';
 
 var React = require('react'),
-    ReactDOM = require('react-dom'),
-    PureRenderMixin = require('react-addons-pure-render-mixin');
+    ReactDOM = require('react-dom');
 
 var shallowEquals = require('shallow-equals'),
     types = require('./react-types'),
@@ -19,9 +18,11 @@ var shallowEquals = require('shallow-equals'),
     DisplayMode = require('./DisplayMode'),
     style = require('./style');
 
-// props: VizProps & {source: BigBedSource};
 
 class GenomeTrack extends React.Component {
+  props: VizProps & {source: TwoBitSource};
+  state: void;  // no state
+
   render(): any {
     return <canvas />;
   }
@@ -113,13 +114,6 @@ class GenomeTrack extends React.Component {
   }
 }
 
-// This prevents updates if state & props have not changed.
-GenomeTrack.mixins = [PureRenderMixin];
 GenomeTrack.displayName = 'reference';
-
-GenomeTrack.propTypes = {
-  range: types.GenomeRange.isRequired,
-  source: React.PropTypes.object.isRequired,
-};
 
 module.exports = GenomeTrack;

--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -11,7 +11,6 @@ var React = require('react'),
     ReactDOM = require('react-dom');
 
 var shallowEquals = require('shallow-equals'),
-    types = require('./react-types'),
     canvasUtils = require('./canvas-utils'),
     dataCanvas = require('data-canvas'),
     d3utils = require('./d3utils'),

--- a/src/main/GenomeTrack.js
+++ b/src/main/GenomeTrack.js
@@ -18,7 +18,7 @@ var shallowEquals = require('shallow-equals'),
     style = require('./style');
 
 
-class GenomeTrack extends (React.Component : typeof ReactComponent) {
+class GenomeTrack extends React.Component {
   props: VizProps & {source: TwoBitSource};
   state: void;  // no state
 

--- a/src/main/LocationTrack.js
+++ b/src/main/LocationTrack.js
@@ -9,7 +9,6 @@ import type {VizProps} from './VisualizationWrapper';
 var React = require('react'),
     ReactDOM = require('react-dom'),
     EmptySource = require('./EmptySource'),
-    types = require('./react-types'),
     canvasUtils = require('./canvas-utils'),
     dataCanvas = require('data-canvas'),
     style = require('./style'),

--- a/src/main/LocationTrack.js
+++ b/src/main/LocationTrack.js
@@ -14,7 +14,7 @@ var React = require('react'),
     style = require('./style'),
     d3utils = require('./d3utils');
 
-class LocationTrack extends (React.Component : typeof ReactComponent) {
+class LocationTrack extends React.Component {
   props: VizProps;
   state: void;  // no state
   static defaultSource: Object;

--- a/src/main/LocationTrack.js
+++ b/src/main/LocationTrack.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+import type {VizProps} from './VisualizationWrapper';
+
 var React = require('react'),
     ReactDOM = require('react-dom'),
     EmptySource = require('./EmptySource'),
@@ -13,7 +15,11 @@ var React = require('react'),
     style = require('./style'),
     d3utils = require('./d3utils');
 
-class LocationTrack extends React.Component {
+class LocationTrack extends (React.Component : typeof ReactComponent) {
+  props: VizProps;
+  state: void;  // no state
+  static defaultSource: Object;
+
   constructor(props: Object) {
     super(props);
   }
@@ -73,9 +79,6 @@ class LocationTrack extends React.Component {
   }
 }
 
-LocationTrack.propTypes = {
-  range: types.GenomeRange.isRequired,
-};
 LocationTrack.displayName = 'location';
 LocationTrack.defaultSource = EmptySource.create();
 

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -10,6 +10,7 @@ import type {BasePair} from './pileuputils';
 import type {VisualAlignment, VisualGroup} from './PileupCache';
 import type {DataCanvasRenderingContext2D} from 'data-canvas';
 import type * as Interval from './Interval';
+import type {VizProps} from './VisualizationWrapper';
 
 var React = require('react'),
     shallowEquals = require('shallow-equals'),
@@ -202,10 +203,11 @@ function opacityForQuality(quality: number): number {
 
 
 class PileupTrack extends React.Component {
+  props: VizProps & { source: AlignmentDataSource };
   cache: PileupCache;
   tiles: TiledCanvas;
 
-  constructor(props: Object) {
+  constructor(props: VizProps) {
     super(props);
     this.state = {
     };
@@ -271,7 +273,8 @@ class PileupTrack extends React.Component {
     });
     this.props.source.on('networkprogress', e => {
       this.setState({networkStatus: e});
-    }).on('networkdone', e => {
+    });
+    this.props.source.on('networkdone', e => {
       this.setState({networkStatus: null});
     });
 

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -17,7 +17,6 @@ var React = require('react'),
     _ = require('underscore');
 
 var scale = require('./scale'),
-    types = require('./react-types'),
     d3utils = require('./d3utils'),
     {CigarOp} = require('./pileuputils'),
     ContigInterval = require('./ContigInterval'),

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -207,11 +207,12 @@ type State = {
 };
 
 
-class PileupTrack extends React.Component {
+class PileupTrack extends (React.Component : typeof ReactComponent) {
   props: VizProps & { source: AlignmentDataSource };
   state: State;
   cache: PileupCache;
   tiles: TiledCanvas;
+  static defaultOptions: { viewAsPairs: boolean };
 
   constructor(props: VizProps) {
     super(props);
@@ -385,17 +386,10 @@ class PileupTrack extends React.Component {
   }
 }
 
-PileupTrack.propTypes = {
-  range: types.GenomeRange.isRequired,
-  source: React.PropTypes.object.isRequired,
-  referenceSource: React.PropTypes.object.isRequired,
-  options: React.PropTypes.object
-};
 PileupTrack.displayName = 'pileup';
 PileupTrack.defaultOptions = {
   viewAsPairs: false
 };
-PileupTrack.renderPileup = renderPileup;  // exposed for testing
 
 
 module.exports = PileupTrack;

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -201,15 +201,22 @@ function opacityForQuality(quality: number): number {
   return Math.min(1.0, alpha);
 }
 
+type NetworkStatus = {numRequests?: number, status?: string};
+type State = {
+  networkStatus: ?NetworkStatus;
+};
+
 
 class PileupTrack extends React.Component {
   props: VizProps & { source: AlignmentDataSource };
+  state: State;
   cache: PileupCache;
   tiles: TiledCanvas;
 
   constructor(props: VizProps) {
     super(props);
     this.state = {
+      networkStatus: null
     };
   }
 
@@ -245,12 +252,12 @@ class PileupTrack extends React.Component {
     );
   }
 
-  formatStatus(state: Object): string {
-    if (state.numRequests) {
-      var pluralS = state.numRequests > 1 ? 's' : '';
-      return `issued ${state.numRequests} request${pluralS}`;
-    } else if (state.status) {
-      return state.status;
+  formatStatus(status: NetworkStatus): string {
+    if (status.numRequests) {
+      var pluralS = status.numRequests > 1 ? 's' : '';
+      return `issued ${status.numRequests} request${pluralS}`;
+    } else if (status.status) {
+      return status.status;
     }
     throw 'invalid';
   }

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -206,7 +206,7 @@ type State = {
 };
 
 
-class PileupTrack extends (React.Component : typeof ReactComponent) {
+class PileupTrack extends React.Component {
   props: VizProps & { source: AlignmentDataSource };
   state: State;
   cache: PileupCache;

--- a/src/main/Root.js
+++ b/src/main/Root.js
@@ -4,32 +4,38 @@
  */
 'use strict';
 
+import type {TwoBitSource} from './TwoBitDataSource';
 import type {VisualizedTrack} from './types';
 
 var React = require('react'),
     Controls = require('./Controls'),
     VisualizationWrapper = require('./VisualizationWrapper');
 
+type Props = {
+  referenceSource: TwoBitSource;
+  tracks: VisualizedTrack[];
+  initialRange: GenomeRange;
+};
 
-var Root = React.createClass({
-  propTypes: {
-    referenceSource: React.PropTypes.object.isRequired,
-    tracks: React.PropTypes.array.isRequired,
-    initialRange: React.PropTypes.object.isRequired
-  },
-  getInitialState: function() {
-    return {
+class Root extends (React.Component : typeof ReactComponent) {
+  props: Props;
+  state: {
+    contigList: string[];
+    range: ?GenomeRange;
+  };
+
+  constructor(props: Object) {
+    super(props);
+    this.state = {
       contigList: this.props.referenceSource.contigList(),
-      range: (null: ?GenomeRange)
+      range: null
     };
-  },
-  componentDidMount: function() {
-    // Note: flow is unable to infer this type through `this.propTypes`.
-    var referenceSource = this.props.referenceSource;
+  }
 
-    referenceSource.on('contigs', () => {
+  componentDidMount() {
+    this.props.referenceSource.on('contigs', () => {
       this.setState({
-        contigList: referenceSource.contigList(),
+        contigList: this.props.referenceSource.contigList(),
       });
     });
 
@@ -38,8 +44,9 @@ var Root = React.createClass({
     }
     // in case the contigs came in between getInitialState() and here.
     this.setState({contigList: this.props.referenceSource.contigList()});
-  },
-  handleRangeChange: function(newRange: GenomeRange) {
+  }
+
+  handleRangeChange(newRange: GenomeRange) {
     this.props.referenceSource.normalizeRange(newRange).then(range => {
       this.setState({range: range});
 
@@ -48,12 +55,13 @@ var Root = React.createClass({
         track.source.rangeChanged(range);
       });
     }).done();
-  },
+  }
+
   makeDivForTrack(key: string, track: VisualizedTrack): React.Element {
     var trackEl = (
         <VisualizationWrapper visualization={track.visualization}
             range={this.state.range}
-            onRangeChange={this.handleRangeChange}
+            onRangeChange={this.handleRangeChange.bind(this)}
             source={track.source}
             referenceSource={this.props.referenceSource}
           />);
@@ -70,8 +78,9 @@ var Root = React.createClass({
         </div>
       </div>
     );
-  },
-  render: function(): any {
+  }
+
+  render(): any {
     // TODO: use a better key than index.
     var trackEls = this.props.tracks.map((t, i) => this.makeDivForTrack(''+i, t));
     return (
@@ -83,13 +92,14 @@ var Root = React.createClass({
           <div className='track-content'>
             <Controls contigList={this.state.contigList}
                       range={this.state.range}
-                      onChange={this.handleRangeChange} />
+                      onChange={this.handleRangeChange.bind(this)} />
           </div>
         </div>
         {trackEls}
       </div>
     );
   }
-});
+}
+Root.displayName = 'Root';
 
 module.exports = Root;

--- a/src/main/Root.js
+++ b/src/main/Root.js
@@ -5,7 +5,7 @@
 'use strict';
 
 import type {TwoBitSource} from './TwoBitDataSource';
-import type {VisualizedTrack} from './types';
+import type {VisualizedTrack, VizWithOptions} from './types';
 
 var React = require('react'),
     Controls = require('./Controls'),
@@ -17,7 +17,7 @@ type Props = {
   initialRange: GenomeRange;
 };
 
-class Root extends (React.Component : typeof ReactComponent) {
+class Root extends React.Component {
   props: Props;
   state: {
     contigList: string[];

--- a/src/main/ScaleTrack.js
+++ b/src/main/ScaleTrack.js
@@ -15,7 +15,6 @@ import type {VizProps} from './VisualizationWrapper';
 var React = require('react'),
     ReactDOM = require('react-dom'),
     EmptySource = require('./EmptySource'),
-    types = require('./react-types'),
     canvasUtils = require('./canvas-utils'),
     dataCanvas = require('data-canvas'),
     style = require('./style'),

--- a/src/main/ScaleTrack.js
+++ b/src/main/ScaleTrack.js
@@ -10,6 +10,8 @@
  */
 'use strict';
 
+import type {VizProps} from './VisualizationWrapper';
+
 var React = require('react'),
     ReactDOM = require('react-dom'),
     EmptySource = require('./EmptySource'),
@@ -20,11 +22,12 @@ var React = require('react'),
     d3utils = require('./d3utils');
 
 class ScaleTrack extends React.Component {
+  props: VizProps;
+  state: void;  // no state
+  static defaultSource: Object;
+
   constructor(props: Object) {
     super(props);
-    this.state = {
-      labelSize: {height: 0, width: 0}
-    };
   }
 
   getScale() {
@@ -99,9 +102,6 @@ class ScaleTrack extends React.Component {
   }
 }
 
-ScaleTrack.propTypes = {
-  range: types.GenomeRange.isRequired,
-};
 ScaleTrack.displayName = 'scale';
 ScaleTrack.defaultSource = EmptySource.create();
 

--- a/src/main/TwoBitDataSource.js
+++ b/src/main/TwoBitDataSource.js
@@ -36,7 +36,7 @@ var MAX_BASE_PAIRS_TO_FETCH = 2000;
 // Flow type for export.
 export type TwoBitSource = {
   rangeChanged: (newRange: GenomeRange) => void;
-  getRange: (range: GenomeRange) => ?{[key:string]: string};
+  getRange: (range: GenomeRange) => {[key:string]: string};
   getRangeAsString: (range: GenomeRange) => string;
   contigList: () => string[];
   normalizeRange: (range: GenomeRange) => Q.Promise<GenomeRange>;
@@ -117,7 +117,6 @@ var createFromTwoBitFile = function(remoteSource: TwoBit): TwoBitSource {
 
   // Returns a {"chr12:123" -> "[ATCG]"} mapping for the range.
   function getRange(inputRange: GenomeRange) {
-    if (!inputRange) return null;
     var range = normalizeRangeSync(inputRange);
     var span = range.stop - range.start;
     if (span > MAX_BASE_PAIRS_TO_FETCH) {

--- a/src/main/VariantTrack.js
+++ b/src/main/VariantTrack.js
@@ -14,7 +14,6 @@ var React = require('react'),
 
 var d3utils = require('./d3utils'),
     shallowEquals = require('shallow-equals'),
-    types = require('./react-types'),
     ContigInterval = require('./ContigInterval'),
     canvasUtils = require('./canvas-utils'),
     dataCanvas = require('data-canvas'),

--- a/src/main/VariantTrack.js
+++ b/src/main/VariantTrack.js
@@ -20,7 +20,7 @@ var d3utils = require('./d3utils'),
     style = require('./style');
 
 
-class VariantTrack extends (React.Component : typeof ReactComponent) {
+class VariantTrack extends React.Component {
   props: VizProps & {source: VcfDataSource};
   state: void;  // no state
 

--- a/src/main/VariantTrack.js
+++ b/src/main/VariantTrack.js
@@ -7,6 +7,7 @@
 import type {VcfDataSource} from './VcfDataSource';
 import type {Variant} from './vcf';
 import type {DataCanvasRenderingContext2D} from 'data-canvas';
+import type {VizProps} from './VisualizationWrapper';
 
 var React = require('react'),
     ReactDOM = require('react-dom');
@@ -20,36 +21,38 @@ var d3utils = require('./d3utils'),
     style = require('./style');
 
 
-var VariantTrack = React.createClass({
-  displayName: 'variants',
-  propTypes: {
-    range: types.GenomeRange.isRequired,
-    source: React.PropTypes.object.isRequired,
-  },
-  render: function(): any {
+class VariantTrack extends (React.Component : typeof ReactComponent) {
+  props: VizProps & {source: VcfDataSource};
+  state: void;  // no state
+
+  constructor(props: Object) {
+    super(props);
+  }
+
+  render(): any {
     return <canvas onClick={this.handleClick} />;
-  },
-  getVariantSource(): VcfDataSource {
-    return this.props.source;
-  },
-  componentDidMount: function() {
+  }
+
+  componentDidMount() {
     this.updateVisualization();
 
-    this.getVariantSource().on('newdata', () => {
+    this.props.source.on('newdata', () => {
       this.updateVisualization();
     });
-  },
-  getScale: function() {
+  }
+
+  getScale() {
     return d3utils.getTrackScale(this.props.range, this.props.width);
-  },
-  componentDidUpdate: function(prevProps: any, prevState: any) {
+  }
+
+  componentDidUpdate(prevProps: any, prevState: any) {
     if (!shallowEquals(prevProps, this.props) ||
         !shallowEquals(prevState, this.state)) {
       this.updateVisualization();
     }
-  },
+  }
 
-  updateVisualization: function() {
+  updateVisualization() {
     var canvas = ReactDOM.findDOMNode(this),
         {width, height} = this.props;
 
@@ -60,12 +63,12 @@ var VariantTrack = React.createClass({
     var ctx = canvasUtils.getContext(canvas);
     var dtx = dataCanvas.getDataContext(ctx);
     this.renderScene(dtx);
-  },
+  }
 
   renderScene(ctx: DataCanvasRenderingContext2D) {
     var range = this.props.range,
         interval = new ContigInterval(range.contig, range.start, range.stop),
-        variants = this.getVariantSource().getFeaturesInRange(interval),
+        variants = this.props.source.getFeaturesInRange(interval),
         scale = this.getScale(),
         height = this.props.height,
         y = height - style.VARIANT_HEIGHT - 1;
@@ -86,7 +89,7 @@ var VariantTrack = React.createClass({
     });
 
     ctx.restore();
-  },
+  }
 
   handleClick(reactEvent: any) {
     var ev = reactEvent.nativeEvent,
@@ -102,6 +105,8 @@ var VariantTrack = React.createClass({
       alert(JSON.stringify(variant));
     }
   }
-});
+}
+
+VariantTrack.displayName = 'variants';
 
 module.exports = VariantTrack;

--- a/src/main/VisualizationWrapper.js
+++ b/src/main/VisualizationWrapper.js
@@ -5,6 +5,7 @@
 
 
 import type {TwoBitSource} from './TwoBitDataSource';
+import type {VizWithOptions} from './types';
 
 var React = require('react'),
     ReactDOM = require('react-dom'),
@@ -21,7 +22,17 @@ export type VizProps = {
   options: any;
 };
 
-class VisualizationWrapper extends React.Component {
+type Props = {
+  range: ?GenomeRange;
+  visualization: VizWithOptions;
+  onRangeChange: (newRange: GenomeRange) => void;
+  referenceSource: TwoBitSource;
+  source: any;
+};
+
+class VisualizationWrapper extends (React.Component : typeof ReactComponent) {
+  props: Props;
+  state: {width: number; height: number};
   hasDragBeenInitialized: boolean;
 
   constructor(props: Object) {
@@ -104,14 +115,14 @@ class VisualizationWrapper extends React.Component {
   }
 
   render(): any {
-    var range = this.props.range;
-    var component = this.props.visualization.component;
+    const range = this.props.range;
+    const component = this.props.visualization.component;
     if (!range) {
       return <EmptyTrack className={component.displayName} />;
     }
 
     var el = React.createElement(component, ({
-      range: this.props.range,
+      range: range,
       source: this.props.source,
       referenceSource: this.props.referenceSource,
       width: this.state.width,

--- a/src/main/VisualizationWrapper.js
+++ b/src/main/VisualizationWrapper.js
@@ -144,11 +144,12 @@ VisualizationWrapper.propTypes = {
 };
 
 
-var EmptyTrack = React.createClass({
-  render: function() {
+class EmptyTrack extends (React.Component : typeof ReactComponent) {
+  props: {className: string};
+  render() {
     var className = this.props.className + ' empty';
     return <div className={className}></div>;
   }
-});
+}
 
 module.exports = VisualizationWrapper;

--- a/src/main/VisualizationWrapper.js
+++ b/src/main/VisualizationWrapper.js
@@ -3,12 +3,23 @@
  */
 'use strict';
 
+
+import type {TwoBitSource} from './TwoBitDataSource';
+
 var React = require('react'),
     ReactDOM = require('react-dom'),
     types = require('./react-types'),
     d3utils = require('./d3utils'),
     _ = require('underscore'),
     d3 = require('../lib/minid3');
+
+export type VizProps = {
+  width: number;
+  height: number;
+  range: GenomeRange;
+  referenceSource: TwoBitSource;
+  options: any;
+};
 
 class VisualizationWrapper extends React.Component {
   hasDragBeenInitialized: boolean;
@@ -99,14 +110,14 @@ class VisualizationWrapper extends React.Component {
       return <EmptyTrack className={component.displayName} />;
     }
 
-    var el = React.createElement(component, {
+    var el = React.createElement(component, ({
       range: this.props.range,
       source: this.props.source,
       referenceSource: this.props.referenceSource,
       width: this.state.width,
       height: this.state.height,
       options: this.props.visualization.options
-    });
+    } : VizProps));
 
     return <div className='drag-wrapper'>{el}</div>;
   }

--- a/src/main/VisualizationWrapper.js
+++ b/src/main/VisualizationWrapper.js
@@ -9,7 +9,6 @@ import type {VizWithOptions} from './types';
 
 var React = require('react'),
     ReactDOM = require('react-dom'),
-    types = require('./react-types'),
     d3utils = require('./d3utils'),
     _ = require('underscore'),
     d3 = require('../lib/minid3');
@@ -30,7 +29,7 @@ type Props = {
   source: any;
 };
 
-class VisualizationWrapper extends (React.Component : typeof ReactComponent) {
+class VisualizationWrapper extends React.Component {
   props: Props;
   state: {width: number; height: number};
   hasDragBeenInitialized: boolean;
@@ -63,7 +62,8 @@ class VisualizationWrapper extends (React.Component : typeof ReactComponent) {
     if (this.props.range && !this.hasDragBeenInitialized) this.addDragInterface();
   }
 
-  getScale(): any {
+  getScale(): (num: number)=>number {
+    if (!this.props.range) return x => x;
     return d3utils.getTrackScale(this.props.range, this.state.width);
   }
 
@@ -135,16 +135,8 @@ class VisualizationWrapper extends (React.Component : typeof ReactComponent) {
 }
 VisualizationWrapper.displayName = 'VisualizationWrapper';
 
-VisualizationWrapper.propTypes = {
-  range: types.GenomeRange,
-  onRangeChange: React.PropTypes.func.isRequired,
-  source: React.PropTypes.object.isRequired,
-  referenceSource: React.PropTypes.object.isRequired,
-  visualization: React.PropTypes.object.isRequired,
-};
 
-
-class EmptyTrack extends (React.Component : typeof ReactComponent) {
+class EmptyTrack extends React.Component {
   props: {className: string};
   render() {
     var className = this.props.className + ' empty';

--- a/src/main/d3utils.js
+++ b/src/main/d3utils.js
@@ -4,14 +4,18 @@
  */
 'use strict';
 
-import type {GenomeRange} from './react-types';
-
 var scale = require('./scale');
+
+// Subtype of GenomeRange
+type Range = {
+  start: number;
+  stop: number;
+};
 
 /**
  * Shared x-axis scaling logic for tracks
  */
-function getTrackScale(range: GenomeRange, width: number): any {
+function getTrackScale(range: Range, width: number): any {
   if (!range) return scale.linear();
   var offsetPx = range.offsetPx || 0;
   return scale.linear()

--- a/src/main/pileup.js
+++ b/src/main/pileup.js
@@ -108,7 +108,7 @@ function create(elOrId: string|Element, params: PileupParams): Pileup {
 
 type VizObject = ((options: ?Object) => VizWithOptions);
 
-function makeVizObject(component: React.Component): VizObject {
+function makeVizObject(component: ReactClass): VizObject {
   return options => {
     options = _.extend({}, component.defaultOptions, options);
     return {component, options};

--- a/src/main/pileup.js
+++ b/src/main/pileup.js
@@ -24,7 +24,7 @@ var _ = require('underscore'),
     VariantTrack = require('./VariantTrack'),
     Root = require('./Root');
 
-import type {Track, VisualizedTrack} from './types';
+import type {Track, VisualizedTrack, VizWithOptions} from './types';
 
 type GenomeRange = {
   contig: string;
@@ -106,7 +106,7 @@ function create(elOrId: string|Element, params: PileupParams): Pileup {
   };
 }
 
-type VizObject = ((options: ?Object) => {component: React.Component, options:?Object});
+type VizObject = ((options: ?Object) => VizWithOptions);
 
 function makeVizObject(component: React.Component): VizObject {
   return options => {

--- a/src/main/types.js
+++ b/src/main/types.js
@@ -14,7 +14,7 @@
 import type * as React from 'react';
 
 export type VizWithOptions = {
-  component: React.Component;
+  component: ReactClass;
   options: ?Object;
 }
 
@@ -27,7 +27,7 @@ export type Track = {
 }
 
 export type VisualizedTrack = {
-  visualization: React.Component;
+  visualization: VizWithOptions;
   source: Object;  // data source
   track: Track;  // for css class and options
 }


### PR DESCRIPTION
Fixes #235 

This migrates all React components to use ES6 classes and declares types for `state` and `props` in all of them. This should make Flow much more effective.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/354)
<!-- Reviewable:end -->
