### PR TITLE
Implement PileupCache.sortReadsAt

### DIFF
--- a/lib/underscore.js
+++ b/lib/underscore.js
@@ -16,13 +16,16 @@ declare module "underscore" {
   declare function chain<S>(obj: S): any;
   declare function any<T>(list: Array<T>, pred: (el: T)=>boolean): boolean;
 
-  declare function each<T>(o: {[key:string]: T}, iteratee: (val: T, key: string)=>void): void;
-  declare function each<T>(a: T[], iteratee: (val: T, key: string)=>void): void;
+  declare function each<T>(a: T[], iteratee: (val: T, index: number)=>void): void;
+  declare function each<K, T>(o: {[key:K]: T}, iteratee: (val: T, key: K)=>void): void;
 
   declare function map<T, U>(a: T[], iteratee: (val: T, n?: number)=>U): U[];
   declare function map<K, T, U>(a: {[key:K]: T}, iteratee: (val: T, k?: K)=>U): U[];
 
-  declare function object<T>(a: Array<[string, T]>): {[key:string]: T};
+  declare function object<K, T>(a: Array<[K, T]>): {[key:K]: T};
+  declare function object<K, T>(...a: [K, T][]): {[key:K]: T};
+
+  declare function mapObject<K, S, T>(o: {[key:K]:S}, iteratee:(v: S, k?: K)=>T): {[key:K]: T};
 
   declare function every<T>(a: Array<T>, pred: (val: T)=>boolean): boolean;
 
@@ -35,7 +38,7 @@ declare module "underscore" {
 
   declare function isEmpty(o: any): boolean;
 
-  declare function groupBy<T>(a: Array<T>, iteratee: (val: T, index: number)=>any): {[key:string]: T[]};
+  declare function groupBy<K, T>(a: Array<T>, iteratee: (val: T, index: number)=>K): {[key:K]: T[]};
 
   declare function min<T>(a: Array<T>|{[key:any]: T}): T;
   declare function max<T>(a: Array<T>|{[key:any]: T}): T;

--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -352,6 +352,14 @@ class PileupTrack extends React.Component {
     ctx.restore();
   }
 
+  handleSort() {
+    var {start, stop} = this.props.range,
+        middle = (start + stop) / 2;
+    this.cache.sortReadsAt(this.props.range.contig, middle);
+    this.tiles.invalidateAll();
+    this.updateVisualization();
+  }
+
   handleClick(reactEvent: any) {
     var ev = reactEvent.nativeEvent,
         x = ev.offsetX,

--- a/src/test/PileupCache-test.js
+++ b/src/test/PileupCache-test.js
@@ -55,6 +55,12 @@ function makeReadPair(range1: ContigInterval<string>, range2: ContigInterval<str
   ];
 }
 
+function makeRead(range: ContigInterval<string>, strand: Strand): Alignment {
+  var name = 'read:' + (nameCounter++);
+  return new TestAlignment(range, name, strand);
+}
+
+
 function dieFn() { throw 'Should not have called this.'; }
 var fakeSource = {
   rangeChanged: dieFn,
@@ -177,6 +183,105 @@ describe('PileupCache', function() {
     // 'chr'-tolerance
     expect(cache.getGroupsOverlapping(ci('1', 50, 150))).to.have.length(1);
     expect(cache.getGroupsOverlapping(ci('1', 50, 350))).to.have.length(2);
+  });
+
+  it('should sort reads at a locus', function() {
+    var read = (start, stop) => makeRead(ci('chr1', start, stop), '+');
+    var cache = makeCache([
+      read(100, 200),
+      read(150, 250),
+      read(200, 300),
+      read(250, 350)
+    ], false /* viewAsPairs */);
+    expect(cache.pileupHeightForRef('chr1')).to.equal(3);
+
+    var formatReads = g => [g.row, g.span.toString()];
+
+    expect(cache.getGroupsOverlapping(ci('chr1', 0, 500))
+                .map(formatReads)).to.deep.equal([
+      [0, 'chr1:100-200'],
+      [1, 'chr1:150-250'],
+      [2, 'chr1:200-300'],
+      [0, 'chr1:250-350']
+    ]);
+
+    cache.sortReadsAt('1', 275);  // note 'chr'-tolerance
+    expect(cache.getGroupsOverlapping(ci('chr1', 0, 500))
+                .map(formatReads)).to.deep.equal([
+      [1, 'chr1:100-200'],
+      [2, 'chr1:150-250'],
+      [0, 'chr1:200-300'],  // these last two reads are now on top
+      [1, 'chr1:250-350']
+    ]);
+
+    // reads on another contig should not be affected by sorting.
+    cache.addAlignment(makeRead(ci('chr2', 0, 100), '+'));
+    cache.addAlignment(makeRead(ci('chr2', 50, 150), '+'));
+    cache.addAlignment(makeRead(ci('chr2', 100, 200), '+'));
+    expect(cache.getGroupsOverlapping(ci('chr2', 0, 500))
+                .map(formatReads)).to.deep.equal([
+      [0, 'chr2:0-100'],
+      [1, 'chr2:50-150'],
+      [2, 'chr2:100-200']
+    ]);
+
+    cache.sortReadsAt('chr1', 150);
+    expect(cache.getGroupsOverlapping(ci('chr1', 0, 500))
+                .map(formatReads)).to.deep.equal([
+      [0, 'chr1:100-200'],
+      [1, 'chr1:150-250'],
+      [2, 'chr1:200-300'],
+      [0, 'chr1:250-350']
+    ]);
+    expect(cache.getGroupsOverlapping(ci('chr2', 0, 500))
+                .map(formatReads)).to.deep.equal([
+      [0, 'chr2:0-100'],
+      [1, 'chr2:50-150'],
+      [2, 'chr2:100-200']
+    ]);
+  });
+
+  it('should sort paired reads at a locus', function() {
+    var cache = makeCache([
+      makeReadPair(ci('chr1', 100, 200), ci('chr1', 800, 900)),
+      makeReadPair(ci('chr1', 300, 400), ci('chr1', 500, 600))
+    ], true /* viewAsPairs */);
+
+
+    var groups = _.values(cache.groups);
+    expect(groups).to.have.length(2);
+
+    var rows = () => groups.map(g => g.row);
+    expect(rows()).to.deep.equal([0, 1]);
+    expect(cache.pileupHeightForRef('chr1')).to.equal(2);
+
+    // While both groups overlap this locus when you include the insert, only
+    // the second group has a read which overlaps it.
+    cache.sortReadsAt('chr1', 350);
+    expect(rows()).to.deep.equal([1, 0]);
+
+    cache.sortReadsAt('chr1', 850);
+    expect(rows()).to.deep.equal([0, 1]);
+  });
+
+  it('should sort a larger pileup of pairs', function() {
+    // A:   <---        --->
+    // B:        <---  --->
+    // C:      <---   --->
+    // x          |
+    // (x intersects reads on B&C but only the insert on A)
+    var cache = makeCache([
+      makeReadPair(ci('chr1', 100, 200), ci('chr1', 600, 700)),  // A
+      makeReadPair(ci('chr1', 300, 400), ci('chr1', 550, 650)),  // B
+      makeReadPair(ci('chr1', 250, 350), ci('chr1', 500, 600))   // C
+    ], true /* viewAsPairs */);
+
+    var groups = _.values(cache.groups);
+    var rows = () => groups.map(g => g.row);
+    expect(rows()).to.deep.equal([0, 1, 2]);
+
+    cache.sortReadsAt('chr1', 325);  // x
+    expect(rows()).to.deep.equal([2, 1, 0]);
   });
 
   // TODO:


### PR DESCRIPTION
See #181 

There's no UI for this yet. I'm thinking of two ideas there:

1. When you go to a new location (either on the initial load or by jumping to a previously unloaded region), then the alignments should get sorted around the center position.
1. There could be an option to sort the reads via the UI, maybe under a gear icon below the pileup track label.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/355)
<!-- Reviewable:end -->
