### PR TITLE
Remove white space around canvas items

### DIFF
--- a/style/pileup.css
+++ b/style/pileup.css
@@ -43,6 +43,9 @@
 .track-content > div {
   position: absolute; /* Gets the child of the flex-item to fill height 100% */
 }
+.track-content canvas {
+  display: block;
+}
 
 /* controls */
 .pileup-root > .controls {


### PR DESCRIPTION
Looks like [the mysterious-vertical-space bug](https://github.com/hammerlab/cycledash/pull/811) is at it again: http://www.hammerlab.org/pileup/

![screen recording 2015-11-18 at 11 54 am](https://cloud.githubusercontent.com/assets/7809/11247722/4b19bb70-8deb-11e5-82b1-6f6965ecf7af.gif)

This removes the default white space around `canvas` elements and fixes the problem.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/377)
<!-- Reviewable:end -->
