### PR TITLE
Only fetch new ranges in {TwoBit,Bam}DataSource

### DIFF
--- a/src/main/Alignment.js
+++ b/src/main/Alignment.js
@@ -43,5 +43,6 @@ export type AlignmentDataSource = {
   rangeChanged: (newRange: GenomeRange) => void;
   getAlignmentsInRange: (range: ContigInterval<string>) => Alignment[];
   on: (event: string, handler: Function) => void;  // really => AlignmentDataSource
+  once: (event: string, handler: Function) => void;
   off: (event: string) => void;
 };

--- a/src/main/GA4GHDataSource.js
+++ b/src/main/GA4GHDataSource.js
@@ -140,6 +140,7 @@ function create(spec: GA4GHSpec): AlignmentDataSource {
 
     // These are here to make Flow happy.
     on: () => {},
+    once: () => {},
     off: () => {},
     trigger: () => {}
   };

--- a/src/test/BamDataSource-test.js
+++ b/src/test/BamDataSource-test.js
@@ -99,4 +99,18 @@ describe('BamDataSource', function() {
       stop: range.stop()
     });
   });
+
+  it('should only fetch new features', function(done) {
+    var source = getTestSource();
+    source.once('newdata', range => {
+      expect(range.toString()).to.equal('20:31512100-31512400');  // expanded range
+      source.once('newdata', range => {
+        expect(range.toString()).to.equal('20:31512000-31512099');  // only 100bp
+        done();
+      });
+      // This range is 100bp to the left of the previous one.
+      source.rangeChanged({contig: '20', start: 31512050, stop: 31512250});
+    });
+    source.rangeChanged({contig: '20', start: 31512150, stop: 31512350});
+  });
 });

--- a/src/test/ContigInterval-test.js
+++ b/src/test/ContigInterval-test.js
@@ -72,6 +72,17 @@ describe('ContigInterval', function() {
     ])).to.deep.equal([
       '0:0-18', '0:20-30'
     ]);
+
+    // ContigInterval.coalesce() shouldn't mutate the input ContigIntervals.
+    var ci1 = ci(0, 20, 30),
+        ci2 = ci(0, 5, 18),
+        ci3 = ci(0, 0, 10);
+    expect(coalesceToString([ci1, ci2, ci3])).to.deep.equal([
+      '0:0-18', '0:20-30'
+    ]);
+    expect(ci1.toString()).to.equal('0:20-30');
+    expect(ci2.toString()).to.equal('0:5-18');
+    expect(ci3.toString()).to.equal('0:0-10');
   });
 
   it('should determine coverage', function() {


### PR DESCRIPTION
Fixes #379 

This is a _really_ nice performance win. See explanation in issue #379. After this, panning at 16,000bp resolution is pretty reasonable.

There were no screenshot diffs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/381)
<!-- Reviewable:end -->
