### PR TITLE
Force pileup tracks to stay aligned

### DIFF
--- a/src/main/PileupTrack.js
+++ b/src/main/PileupTrack.js
@@ -393,6 +393,10 @@ class PileupTrack extends React.Component {
 
     // TODO: the center line should go above alignments, but below mismatches
     this.renderCenterLine(ctx, range, scale);
+
+    // This is a hack to mitigate #350
+    var el = d3utils.findParent(this.refs.canvas, 'track-content');
+    if (el) el.scrollLeft = 0;
   }
 
   // Draw the center line(s), which orient the user

--- a/src/main/d3utils.js
+++ b/src/main/d3utils.js
@@ -69,8 +69,21 @@ function sizeCanvas(el: HTMLCanvasElement, width: number, height: number) {
   }
 }
 
+/**
+ * Find the closest parent with a given class name.
+ */
+function findParent(inEl: Element, className: string): ?Element {
+  var el = inEl;  // this is for Flow.
+  do {
+    if (el.classList.contains(className)) return el;
+    el = el.parentElement;
+  } while (el);
+  return null;
+}
+
 module.exports = {
   formatRange,
   getTrackScale,
-  sizeCanvas
+  sizeCanvas,
+  findParent
 };


### PR DESCRIPTION
The issue is that one of the pileups winds up with `scrollLeft=15`. I'm not sure why. It only happens in Chrome.

You can still see the issue after this change while you're panning, but it goes away once you let go of the mouse.

Mitigates #350

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/383)
<!-- Reviewable:end -->
