### PR TITLE
Record version in pileup.version

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,8 +31,12 @@ browserify \
 # Create dist/pileup.js.map
 cat dist/pileup.js | exorcist --base . dist/pileup.js.map > /dev/null
 
+version=$(grep '"version": ' package.json | sed 's/.*: "//; s/".*//')
+header="/*! pileup v$version | (c) 2015 HammerLab | Apache-2.0 licensed */"
+
 # Create dist/pileup.js.min{,.map}
 uglifyjs --compress --mangle \
+  --preamble "$header" \
   --in-source-map dist/pileup.js.map \
   --source-map-include-sources \
   --source-map dist/pileup.min.js.map \

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+# Check that all .js files have an @flow comment.
 noflow=$(git ls-files | egrep '^(src|test).*\.js$' | grep -v '/data-canvas.js' | xargs grep --files-without-match '@flow')
 if [ -n "$noflow" ]; then
   echo 'These files are missing @flow annotations:'
@@ -6,4 +8,15 @@ if [ -n "$noflow" ]; then
   exit 1
 fi
 
+# Check that the versions in package.json and pileup.js match.
+package_version=$(grep '"version": ' package.json | sed 's/.*: "//; s/".*//')
+code_version=$(grep 'version: ' src/main/pileup.js | sed "s/.*: '//; s/'.*//")
+if [[ $package_version != $code_version ]]; then
+  echo "pileup.js version mismatch!"
+  echo "        package.json: $package_version"
+  echo "  src/main/pileup.js: $code_version"
+  exit 1
+fi
+
+# Run the usual linter
 ./node_modules/.bin/jsxhint --es6module --harmony 'src/main/**/*.js' 'src/test/**/*.js'

--- a/src/main/pileup.js
+++ b/src/main/pileup.js
@@ -133,7 +133,8 @@ var pileup = {
     scale:    makeVizObject(ScaleTrack),
     variants: makeVizObject(VariantTrack),
     pileup:   makeVizObject(PileupTrack)
-  }
+  },
+  version: '0.6.1'
 };
 
 module.exports = pileup;


### PR DESCRIPTION
This will be helpful if we ever want to check what version of pileup someone is using, e.g. ourselves on hammerlab.org or someone else on dnanexus.

Nothing ever stays in sync unless you force it to, so I've added a lint check that the two version numbers are the same.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/388)
<!-- Reviewable:end -->
