### PR TITLE
Don't stretch tiles vertically

### DIFF
--- a/src/main/TiledCanvas.js
+++ b/src/main/TiledCanvas.js
@@ -95,7 +95,9 @@ class TiledCanvas {
       // rounding issues, which can result in 1px gaps or overdrawing.
       // We always have:
       //   width - tile.buffer.width \in {-1, 0, +1}
-      ctx.drawImage(tile.buffer, 0, 0, tile.buffer.width, tile.buffer.height, left, 0, width, height);
+      ctx.drawImage(tile.buffer, 
+                    0, 0, tile.buffer.width, tile.buffer.height,
+                    left, 0, width, tile.buffer.height);
 
       if (DEBUG_RENDER_TILE_EDGES) {
         ctx.save();


### PR DESCRIPTION
Fixes #384 

The issue was that the track height would increase (because the pileup got taller due to added reads) and the existing tiles would be stretched vertically to match it. This was goofy. Tiles should be rendered at their natural height.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/392)
<!-- Reviewable:end -->
