### PR TITLE
Better handle BAI chunk sizes (fixes #405 and #406)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
 
 script: >
     npm run build &&
-    ./scripts/post-code-size.sh &&
     npm run test &&
     npm run flow-check &&
     npm run lint &&

--- a/src/main/data/bai.js
+++ b/src/main/data/bai.js
@@ -22,6 +22,7 @@ import VirtualOffset from './VirtualOffset';
 // winds up saving time to do a fast pass over the data to compute them. This
 // allows us to parse a single contig at a time using jBinary.
 function computeIndexChunks(buffer) {
+  var BLOCK_SIZE = 65536;
   var view = new jDataView(buffer, 0, buffer.byteLength, true /* little endian */);
 
   var minBlockIndex = Infinity;
@@ -39,15 +40,14 @@ function computeIndexChunks(buffer) {
     var n_intv = view.getInt32();
     if (n_intv) {
       var offset = VirtualOffset.fromBlob(view.getBytes(8), 0),
-          coffset = offset.coffset + (offset.uoffset ? 65536 : 0);
-      if (coffset) {
-        minBlockIndex = Math.min(coffset, minBlockIndex);
-      }
+          coffset = offset.coffset + (offset.uoffset ? BLOCK_SIZE : 0);
+      minBlockIndex = coffset ? Math.min(coffset, minBlockIndex) : BLOCK_SIZE;
       view.skip((n_intv - 1) * 8);
     }
   }
   contigStartOffsets.push(view.tell());
 
+  // At this point, `minBlockIndex` should be non-Infinity (see #405 & #406)
   return {
     chunks: _.zip(_.initial(contigStartOffsets), _.rest(contigStartOffsets)),
     minBlockIndex
@@ -206,7 +206,7 @@ class BaiFile {
     this.remoteFile = remoteFile;
     if (indexChunks) {
       this.immediate = Q.when(new ImmediateBaiFile(null, remoteFile, indexChunks));
-    } else { 
+    } else {
       this.immediate = remoteFile.getAll().then(buf => {
         return new ImmediateBaiFile(buf, remoteFile, indexChunks);
       });


### PR DESCRIPTION
For reasons unknown to me, some BAI files seem to have contigs of size 0. This was forcing pileup.js to try to fetch `Infinity` bytes and eventually fail. This change captures the edge case and caps the chunk size as a fix to issue #405 and #406.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/407)
<!-- Reviewable:end -->
