### PR TITLE
Fix on cleaning during destroy method

### DIFF
--- a/src/main/VisualizationWrapper.js
+++ b/src/main/VisualizationWrapper.js
@@ -33,6 +33,7 @@ class VisualizationWrapper extends React.Component {
   props: Props;
   state: {width: number; height: number};
   hasDragBeenInitialized: boolean;
+	onResizeListener;
 
   constructor(props: Object) {
     super(props);
@@ -52,7 +53,10 @@ class VisualizationWrapper extends React.Component {
   }
 
   componentDidMount(): any {
-    window.addEventListener('resize', () => this.updateSize());
+		//local copy of the listener, so we can remove it
+		//when pileup is destroyed
+		this.onResizeListener = () => this.updateSize();
+    window.addEventListener('resize', this.onResizeListener);
     this.updateSize();
 
     if (this.props.range && !this.hasDragBeenInitialized) this.addDragInterface();
@@ -61,6 +65,10 @@ class VisualizationWrapper extends React.Component {
   componentDidUpdate(): any {
     if (this.props.range && !this.hasDragBeenInitialized) this.addDragInterface();
   }
+
+	componentWillUnmount(): any {
+		window.removeEventListener('resize', this.onResizeListener);
+	}
 
   getScale(): (num: number)=>number {
     if (!this.props.range) return x => x;

--- a/src/main/VisualizationWrapper.js
+++ b/src/main/VisualizationWrapper.js
@@ -33,7 +33,7 @@ class VisualizationWrapper extends React.Component {
   props: Props;
   state: {width: number; height: number};
   hasDragBeenInitialized: boolean;
-	onResizeListener;
+	onResizeListener: Object;	//listener that handles window.onresize event
 
   constructor(props: Object) {
     super(props);

--- a/src/main/VisualizationWrapper.js
+++ b/src/main/VisualizationWrapper.js
@@ -33,7 +33,7 @@ class VisualizationWrapper extends React.Component {
   props: Props;
   state: {width: number; height: number};
   hasDragBeenInitialized: boolean;
-	onResizeListener: Object;	//listener that handles window.onresize event
+  onResizeListener: Object;  //listener that handles window.onresize event
 
   constructor(props: Object) {
     super(props);
@@ -53,9 +53,9 @@ class VisualizationWrapper extends React.Component {
   }
 
   componentDidMount(): any {
-		//local copy of the listener, so we can remove it
-		//when pileup is destroyed
-		this.onResizeListener = () => this.updateSize();
+    //local copy of the listener, so we can remove it
+    //when pileup is destroyed
+    this.onResizeListener = () => this.updateSize();
     window.addEventListener('resize', this.onResizeListener);
     this.updateSize();
 
@@ -66,9 +66,9 @@ class VisualizationWrapper extends React.Component {
     if (this.props.range && !this.hasDragBeenInitialized) this.addDragInterface();
   }
 
-	componentWillUnmount(): any {
-		window.removeEventListener('resize', this.onResizeListener);
-	}
+  componentWillUnmount(): any {
+    window.removeEventListener('resize', this.onResizeListener);
+  }
 
   getScale(): (num: number)=>number {
     if (!this.props.range) return x => x;


### PR DESCRIPTION
This small pull request fixes issue that I reported here: https://github.com/hammerlab/pileup.js/issues/415

During pileup destroy call, listener added by VisualizationWrapper at initialization stage is removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/418)
<!-- Reviewable:end -->
