### PR TITLE
Devel genome track bug

### DIFF
--- a/src/main/sources/TwoBitDataSource.js
+++ b/src/main/sources/TwoBitDataSource.js
@@ -68,8 +68,14 @@ var createFromTwoBitFile = function(remoteSource: TwoBit): TwoBitSource {
   function fetch(range: ContigInterval) {
     var span = range.length();
     if (span > MAX_BASE_PAIRS_TO_FETCH) {
+			//informa that we won't fetch the data
+      o.trigger('newdatarefused', range);
       return Q.when();  // empty promise
     }
+		//now we cam add region to covered regions 
+		//doing it earlier will provide inconsistency
+    coveredRanges.push(range);
+    coveredRanges = ContigInterval.coalesce(coveredRanges);
 
     remoteSource.getFeaturesInRange(range.contig, range.start(), range.stop())
       .then(letters => {
@@ -138,8 +144,6 @@ var createFromTwoBitFile = function(remoteSource: TwoBit): TwoBitSource {
 
         range = expandRange(range);
         var newRanges = range.complementIntervals(coveredRanges);
-        coveredRanges.push(range);
-        coveredRanges = ContigInterval.coalesce(coveredRanges);
 
         for (var newRange of newRanges) {
           fetch(newRange);

--- a/src/main/sources/TwoBitDataSource.js
+++ b/src/main/sources/TwoBitDataSource.js
@@ -68,12 +68,12 @@ var createFromTwoBitFile = function(remoteSource: TwoBit): TwoBitSource {
   function fetch(range: ContigInterval) {
     var span = range.length();
     if (span > MAX_BASE_PAIRS_TO_FETCH) {
-			//inform that we won't fetch the data
+      //inform that we won't fetch the data
       o.trigger('newdatarefused', range);
       return Q.when();  // empty promise
     }
-		//now we can add region to covered regions 
-		//doing it earlier would provide inconsistency
+    //now we can add region to covered regions 
+    //doing it earlier would provide inconsistency
     coveredRanges.push(range);
     coveredRanges = ContigInterval.coalesce(coveredRanges);
 

--- a/src/main/sources/TwoBitDataSource.js
+++ b/src/main/sources/TwoBitDataSource.js
@@ -68,12 +68,12 @@ var createFromTwoBitFile = function(remoteSource: TwoBit): TwoBitSource {
   function fetch(range: ContigInterval) {
     var span = range.length();
     if (span > MAX_BASE_PAIRS_TO_FETCH) {
-			//informa that we won't fetch the data
+			//inform that we won't fetch the data
       o.trigger('newdatarefused', range);
       return Q.when();  // empty promise
     }
-		//now we cam add region to covered regions 
-		//doing it earlier will provide inconsistency
+		//now we can add region to covered regions 
+		//doing it earlier would provide inconsistency
     coveredRanges.push(range);
     coveredRanges = ContigInterval.coalesce(coveredRanges);
 

--- a/src/test/sources/TwoBitDataSource-test.js
+++ b/src/test/sources/TwoBitDataSource-test.js
@@ -31,11 +31,18 @@ describe('TwoBitDataSource', function() {
     });
   });
 
+	/**
+	 * Test case that visualize situation when we set range very big
+	 * (in millions) and afterwards we set the range to small subrange
+	 * of the huge range. The huge range shouldn't be fetched from
+	 * 2bit file. But due to //github.com/hammerlab/pileup.js/issues/416
+	 * every small request from the big range wasn't handled properly 
+	 * afterwardfs.
+	 * 
+	 */
   it('should fetch base pairs (bug 416)', function(done) {
     var source = getTestSource();
-		//this range shouldn't be fetched because is huge (but due to bug: 
-		// https://github.com/hammerlab/pileup.js/issues/416
-		// everyt small request from the big range wasn't handled properly afterwardfs
+		//this range shouldn't be fetched because is huge 
 		var hugeRange= {contig: 'chr22', start: 0, stop: 114529884};
 
 		//small range that due to bug wasn't properly handled
@@ -55,7 +62,7 @@ describe('TwoBitDataSource', function() {
 		//try to fetch huge chunk of data (should be skipped)
     source.rangeChanged(hugeRange);
 
-		//and now try to fetch small chunk (should be fetched and proper newdata event should be dispatched
+		//and now try to fetch small chunk (should be fetched and proper newdata event should be dispatched)
     source.rangeChanged(smallSubRange);
   });
 

--- a/src/test/sources/TwoBitDataSource-test.js
+++ b/src/test/sources/TwoBitDataSource-test.js
@@ -31,24 +31,24 @@ describe('TwoBitDataSource', function() {
     });
   });
 
-	/**
-	 * Test case that visualize situation when we set range very big
-	 * (in millions) and afterwards we set the range to small subrange
-	 * of the huge range. The huge range shouldn't be fetched from
-	 * 2bit file. But due to //github.com/hammerlab/pileup.js/issues/416
-	 * every small request from the big range wasn't handled properly 
-	 * afterwardfs.
-	 * 
-	 */
+  /**
+   * Test case that visualize situation when we set range very big
+   * (in millions) and afterwards we set the range to small subrange
+   * of the huge range. The huge range shouldn't be fetched from
+   * 2bit file. But due to //github.com/hammerlab/pileup.js/issues/416
+   * every small request from the big range wasn't handled properly 
+   * afterwardfs.
+   * 
+   */
   it('should fetch base pairs (bug 416)', function(done) {
     var source = getTestSource();
-		//this range shouldn't be fetched because is huge 
-		var hugeRange= {contig: 'chr22', start: 0, stop: 114529884};
+    //this range shouldn't be fetched because is huge 
+    var hugeRange= {contig: 'chr22', start: 0, stop: 114529884};
 
-		//small range that due to bug wasn't properly handled
+    //small range that due to bug wasn't properly handled
     var smallSubRange = {contig: 'chr22', start: 0, stop: 3};
     source.on('newdata', () => {
-			//should be called only once when short chunk is requested
+      //should be called only once when short chunk is requested
       expect(source.getRange(smallSubRange)).to.deep.equal({
         'chr22:0': 'N',
         'chr22:1': 'T',
@@ -59,10 +59,10 @@ describe('TwoBitDataSource', function() {
       done();
     });
 
-		//try to fetch huge chunk of data (should be skipped)
+    //try to fetch huge chunk of data (should be skipped)
     source.rangeChanged(hugeRange);
 
-		//and now try to fetch small chunk (should be fetched and proper newdata event should be dispatched)
+    //and now try to fetch small chunk (should be fetched and proper newdata event should be dispatched)
     source.rangeChanged(smallSubRange);
   });
 

--- a/src/test/viz/GenomeTrack-test.js
+++ b/src/test/viz/GenomeTrack-test.js
@@ -47,6 +47,11 @@ describe('GenomeTrack', function() {
           drawnObjects(testDiv, '.reference').length > 0;
     };
 
+	var referenceTrackLoaded = () => {
+		//this can be done in a preatier way
+		return testDiv.querySelector('canvas') !== null ;
+	}
+
   it('should tolerate non-chr ranges', function() {
     var p = pileup.create(testDiv, {
       range: {contig: '17', start: 7500730, stop: 7500790},
@@ -81,6 +86,44 @@ describe('GenomeTrack', function() {
     // note: this isn't really true, but it makes flow happy
     return ((els: any): HTMLInputElement[]);
   };
+
+	/**
+	 * Test case show situation when we zoom in from very global view
+	 * (range span is milions of nucleotides) into very narrow view
+	 * (tens of nucleotides).
+	 */
+  it('should zoom from huge zoom out', function() {
+		
+    var p = pileup.create(testDiv, {
+      range: { contig: '17', start: 0, stop: 114529884 },
+      tracks: [{
+        data: referenceSource,
+	      viz: pileup.viz.genome(),
+	      isReference: true
+	     }
+	  ]
+	  });
+
+	  expect(testDiv.querySelectorAll('.zoom-controls')).to.have.length(1);
+
+	  var buttons = testDiv.querySelectorAll('.controls button');
+	  var [goBtn, minusBtn, plusBtn] = buttons;
+	  var [locationTxt] = getInputs('.controls input[type="text"]');
+	  expect(goBtn.textContent).to.equal('Go');
+    expect(minusBtn.className).to.equal('btn-zoom-out');
+    expect(plusBtn.className).to.equal('btn-zoom-in');
+
+    return waitFor(referenceTrackLoaded, 2000).then(() => {
+			//in global view we shouldn't see reference track
+      expect(hasReference()).to.be.false;
+      p.setRange({contig: '17', start: 7500725, stop: 7500775});
+    }).delay(300).then(() => {
+			//after zoom in we should see reference track
+      expect(hasReference()).to.be.true;
+      expect(locationTxt.value).to.equal('7,500,725-7,500,775');
+      p.destroy();
+    });
+	});
 
   it('should zoom in and out', function() {
     var p = pileup.create(testDiv, {

--- a/src/test/viz/GenomeTrack-test.js
+++ b/src/test/viz/GenomeTrack-test.js
@@ -50,7 +50,7 @@ describe('GenomeTrack', function() {
 	var referenceTrackLoaded = () => {
 		//this can be done in a preatier way
 		return testDiv.querySelector('canvas') !== null ;
-	}
+	};
 
   it('should tolerate non-chr ranges', function() {
     var p = pileup.create(testDiv, {

--- a/src/test/viz/GenomeTrack-test.js
+++ b/src/test/viz/GenomeTrack-test.js
@@ -47,10 +47,10 @@ describe('GenomeTrack', function() {
           drawnObjects(testDiv, '.reference').length > 0;
     };
 
-	var referenceTrackLoaded = () => {
-		//this can be done in a preatier way
-		return testDiv.querySelector('canvas') !== null ;
-	};
+  var referenceTrackLoaded = () => {
+    //this can be done in a preatier way
+    return testDiv.querySelector('canvas') !== null ;
+  };
 
   it('should tolerate non-chr ranges', function() {
     var p = pileup.create(testDiv, {
@@ -87,43 +87,43 @@ describe('GenomeTrack', function() {
     return ((els: any): HTMLInputElement[]);
   };
 
-	/**
-	 * Test case show situation when we zoom in from very global view
-	 * (range span is milions of nucleotides) into very narrow view
-	 * (tens of nucleotides).
-	 */
+  /**
+   * Test case show situation when we zoom in from very global view
+   * (range span is milions of nucleotides) into very narrow view
+   * (tens of nucleotides).
+   */
   it('should zoom from huge zoom out', function() {
-		
+    
     var p = pileup.create(testDiv, {
       range: { contig: '17', start: 0, stop: 114529884 },
       tracks: [{
         data: referenceSource,
-	      viz: pileup.viz.genome(),
-	      isReference: true
-	     }
-	  ]
-	  });
+        viz: pileup.viz.genome(),
+        isReference: true
+       }
+    ]
+    });
 
-	  expect(testDiv.querySelectorAll('.zoom-controls')).to.have.length(1);
+    expect(testDiv.querySelectorAll('.zoom-controls')).to.have.length(1);
 
-	  var buttons = testDiv.querySelectorAll('.controls button');
-	  var [goBtn, minusBtn, plusBtn] = buttons;
-	  var [locationTxt] = getInputs('.controls input[type="text"]');
-	  expect(goBtn.textContent).to.equal('Go');
+    var buttons = testDiv.querySelectorAll('.controls button');
+    var [goBtn, minusBtn, plusBtn] = buttons;
+    var [locationTxt] = getInputs('.controls input[type="text"]');
+    expect(goBtn.textContent).to.equal('Go');
     expect(minusBtn.className).to.equal('btn-zoom-out');
     expect(plusBtn.className).to.equal('btn-zoom-in');
 
     return waitFor(referenceTrackLoaded, 2000).then(() => {
-			//in global view we shouldn't see reference track
+      //in global view we shouldn't see reference track
       expect(hasReference()).to.be.false;
       p.setRange({contig: '17', start: 7500725, stop: 7500775});
     }).delay(300).then(() => {
-			//after zoom in we should see reference track
+      //after zoom in we should see reference track
       expect(hasReference()).to.be.true;
       expect(locationTxt.value).to.equal('7,500,725-7,500,775');
       p.destroy();
     });
-	});
+  });
 
   it('should zoom in and out', function() {
     var p = pileup.create(testDiv, {


### PR DESCRIPTION
This pull request is a patch that fixes bug reported here: https://github.com/hammerlab/pileup.js/issues/416

Here is brief description of the bug source:
When TwoBitDataSource object was requested to obtain data from huge range it checked if the region was already fetched ('covered') from remote file. If the chunk wasn't fetched from remote file it marked the region as fetched and then tried to fetch it. However, in the fetch method there was additional check that compared the requested range size with maximum allowed fetch range size. When request was too big it silently skipped fetching.
I moved "marking regions as covered" after range size checks.

I provided two test cases for the bug:
* low level unit test for TwoBitDataSource which shows the flow in patched file
* test case that shows how the bug affected the whole pileup vizualization component (with some gui checks as well)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/419)
<!-- Reviewable:end -->
