### PR TITLE
Fix of the gene-track zoom issue

### DIFF
--- a/src/main/sources/BigBedDataSource.js
+++ b/src/main/sources/BigBedDataSource.js
@@ -96,7 +96,8 @@ function createFromBigBedFile(remoteSource: BigBed): BigBedSource {
         coveredRanges = ContigInterval.coalesce(coveredRanges);
         var genes = fb.rows.map(parseBedFeature);
         genes.forEach(gene => addGene(gene));
-        o.trigger('newdata', interval);
+        //we have new data from our internal block range
+        o.trigger('newdata', fb.range);
       });
     });
   }

--- a/src/main/viz/GeneTrack.js
+++ b/src/main/viz/GeneTrack.js
@@ -85,11 +85,9 @@ class GeneTrack extends React.Component {
 
   componentDidMount() {
     // Visualize new reference data as it comes in from the network.
-    this.props.source.on('newdata', () => {
-      var range = this.props.range,
-          ci = new ContigInterval(range.contig, range.start, range.stop);
+    this.props.source.on('newdata', (range) => {
       this.setState({
-        genes: this.props.source.getGenesInRange(ci)
+        genes: this.props.source.getGenesInRange(range)
       });
     });
 


### PR DESCRIPTION
Here is a patch that fixes https://github.com/hammerlab/pileup.js/issues/417 issue.

Short desription of the problem:
When passing information between GeneTrack and BigBedDataSource at some point intervals were mixed up (interval that was requested, and interval for which data was obtained). This resulted in skipping data that didn't match to both of the intervals.

@armish I mentioned more pull requests. This is the last for now. I plan to do at least one more (add onclick events on variants), but I don't have time now. Hopefully I will get back to it in late July.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/422)
<!-- Reviewable:end -->
