### PR TITLE
Fixed collapsed zoom button bug in Electron.

### DIFF
--- a/src/main/Controls.js
+++ b/src/main/Controls.js
@@ -112,8 +112,8 @@ class Controls extends React.Component {
         <input ref='position' type='text' />{' '}
         <button className='btn-submit' onClick={this.handleFormSubmit.bind(this)}>Go</button>{' '}
         <div className='zoom-controls'>
-          <button className='btn-zoom-out' onClick={this.zoomOut.bind(this)}></button>{' '}
-          <button className='btn-zoom-in' onClick={this.zoomIn.bind(this)}></button>
+          <button className='btn-zoom-out' onClick={this.zoomOut.bind(this)}>-</button>{' '}
+          <button className='btn-zoom-in' onClick={this.zoomIn.bind(this)}>+</button>
         </div>
       </form>
     );


### PR DESCRIPTION
Under Electron "+" and "-" do not render on the zoom in and out buttons. This addresses this. Not tested for breakage in browser.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/442)
<!-- Reviewable:end -->
