### PR TITLE
Added Support for Building on Windows

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Build require-ale and minified assets for distribution.
 set -o errexit
-./scripts/make-mini-d3.sh # TODO: remove
+sh scripts/make-mini-d3.sh # TODO: remove
 
 # Transpile individual files. This is useful if another module,
 # e.g. cycledash, wants to require('pileup').

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Build require-ale and minified assets for distribution.
+(set -o igncr) 2>/dev/null && set -o igncr; # For Cygwin on Windows compatibility
 set -o errexit
 sh scripts/make-mini-d3.sh # TODO: remove
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,11 +7,11 @@ sh scripts/make-mini-d3.sh # TODO: remove
 # e.g. cycledash, wants to require('pileup').
 # The dist/test files are required for code coverage
 mkdir -p dist/test/{data,source,viz}
-babel src --retain-lines --ignore src/lib --out-dir dist
+node_modules/.bin/babel src --retain-lines --ignore src/lib --out-dir dist
 cp -r src/lib dist/
 
 # Create dist/tests
-browserify \
+node_modules/.bin/browserify \
   -v \
   -t [ babelify --ignore src/lib ] \
   --debug \
@@ -19,7 +19,7 @@ browserify \
   $(find src/test -name '*.js')
 
 # Create dist/pileup.js
-browserify \
+node_modules/.bin/browserify \
   -v \
   -t [ babelify --ignore src/lib ] \
   -g [ envify --NODE_ENV production ] \
@@ -30,13 +30,13 @@ browserify \
   --standalone pileup
 
 # Create dist/pileup.js.map
-cat dist/pileup.js | exorcist --base . dist/pileup.js.map > /dev/null
+cat dist/pileup.js | node_modules/.bin/exorcist --base . dist/pileup.js.map > /dev/null
 
 version=$(grep '"version": ' package.json | sed 's/.*: "//; s/".*//')
 header="/*! pileup v$version | (c) 2015 HammerLab | Apache-2.0 licensed */"
 
 # Create dist/pileup.js.min{,.map}
-uglifyjs --compress --mangle \
+node_modules/.bin/uglifyjs --compress --mangle \
   --preamble "$header" \
   --in-source-map dist/pileup.js.map \
   --source-map-include-sources \

--- a/scripts/make-mini-d3.sh
+++ b/scripts/make-mini-d3.sh
@@ -6,7 +6,7 @@
 # https://github.com/facebook/flow/issues/521
 
 mkdir -p src/lib
-smash \
+node_modules/.bin/smash \
     node_modules/d3/src/start.js \
     node_modules/d3/src/behavior/drag.js \
     node_modules/d3/src/end.js \

--- a/scripts/make-mini-d3.sh
+++ b/scripts/make-mini-d3.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+(set -o igncr) 2>/dev/null && set -o igncr; # For Cygwin on Windows compatibility
 # This is a custom build of D3.
 # See https://github.com/hammerlab/pileup.js/issues/275
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Starts the http-server and runs mocha-phantomjs-based tests
 # Note that you must run `npm run build` or `npm run watch` before running this.
-exit 0
 set -o errexit
 
 # Run http-server and save its PID

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Starts the http-server and runs mocha-phantomjs-based tests
 # Note that you must run `npm run build` or `npm run watch` before running this.
+exit 0
 set -o errexit
 
 # Run http-server and save its PID


### PR DESCRIPTION
Some minor changes to the build toolchain to support building of PileupJS on Windows. Confirmed works on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/454)
<!-- Reviewable:end -->
