### PR TITLE
fixed label overflow issue

### DIFF
--- a/style/pileup.css
+++ b/style/pileup.css
@@ -25,15 +25,25 @@
 }
 .track-label > span {
   padding-right: 5px;
+  width: 100px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  right: 0;
 }
+
 /* bottom-justify these track labels */
 .track.reference .track-label > span,
 .track.variants .track-label > span
 {
-  position: absolute;
   bottom: 0;
-  right: 0;
 }
+
+.track-label > span:hover {
+  overflow: visible !important;
+}
+
 .track-content {
   flex: 1;  /* stretch to fill remaining space */
   overflow-y: auto;


### PR DESCRIPTION
There has been an issue with long label names, shown here:
<img width="458" alt="screen shot 2017-06-03 at 1 24 29 pm" src="https://cloud.githubusercontent.com/assets/6503416/26756812/03aa8ff4-4860-11e7-8969-0d8202f2e94f.png">


The fix shows ellipsis for long labels but allows you to hover to get the full name.
Without hover (Variants label):
<img width="645" alt="screen shot 2017-06-03 at 1 17 17 pm" src="https://cloud.githubusercontent.com/assets/6503416/26756786/8b6861e2-485f-11e7-91a2-d6ea9b1bb7bd.png">


With hover (Variants label):
<img width="683" alt="screen shot 2017-06-03 at 1 17 24 pm" src="https://cloud.githubusercontent.com/assets/6503416/26756788/9285044e-485f-11e7-82d6-e2a859cba403.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/458)
<!-- Reviewable:end -->
