### PR TITLE
Added GA4GHAlignments to be accessible through raw json

### DIFF
--- a/src/main/json/GA4GHJson.js
+++ b/src/main/json/GA4GHJson.js
@@ -1,0 +1,50 @@
+/**
+ * A data source which implements generic JSON protocol.
+ * Currently only used to load alignments.
+ * @flow
+ */
+'use strict';
+
+import type {Alignment, AlignmentDataSource} from '../Alignment';
+
+import _ from 'underscore';
+import {Events} from 'backbone';
+
+import ContigInterval from '../ContigInterval';
+import GA4GHAlignment from '../GA4GHAlignment';
+
+function create(json: string): AlignmentDataSource {
+
+  // fill reads with json
+  var reads: Alignment[] = JSON.parse(json).alignments.map(alignment => new GA4GHAlignment(alignment));
+
+  function rangeChanged(newRange: GenomeRange) {
+    // Data is already parsed, so immediately return
+    var range = new ContigInterval(newRange.contig, newRange.start, newRange.stop);
+    o.trigger('newdata', range);
+    o.trigger('networkdone');
+    return;
+  }
+
+  function getAlignmentsInRange(range: ContigInterval<string>): Alignment[] {
+    if (!range) return [];
+    var r = _.filter(reads, read => read.intersects(range));
+    return r;
+  }
+
+  var o = {
+    rangeChanged,
+    getAlignmentsInRange,
+
+    on: () => {},
+    once: () => {},
+    off: () => {},
+    trigger: () => {}
+  };
+  _.extend(o, Events);
+  return o;
+}
+
+module.exports = {
+  create
+};

--- a/src/main/json/GA4GHJson.js
+++ b/src/main/json/GA4GHJson.js
@@ -15,8 +15,14 @@ import GA4GHAlignment from '../GA4GHAlignment';
 
 function create(json: string): AlignmentDataSource {
 
+  // parse json
+  var parsedJson = JSON.parse(json);
+  var reads: Alignment[] = [];
+
   // fill reads with json
-  var reads: Alignment[] = JSON.parse(json).alignments.map(alignment => new GA4GHAlignment(alignment));
+  if (!_.isEmpty(parsedJson)) {
+      reads = _.values(parsedJson.alignments).map(alignment => new GA4GHAlignment(alignment));
+  }
 
   function rangeChanged(newRange: GenomeRange) {
     // Data is already parsed, so immediately return

--- a/src/main/pileup.js
+++ b/src/main/pileup.js
@@ -19,6 +19,9 @@ import BamDataSource from './sources/BamDataSource';
 import GA4GHDataSource from './sources/GA4GHDataSource';
 import EmptySource from './sources/EmptySource';
 
+// Data sources from json
+import GA4GHJson from './json/GA4GHJson';
+
 // Visualizations
 import CoverageTrack from './viz/CoverageTrack';
 import GenomeTrack from './viz/GenomeTrack';
@@ -163,6 +166,7 @@ var pileup = {
   formats: {
     bam: BamDataSource.create,
     ga4gh: GA4GHDataSource.create,
+    json: GA4GHJson.create,
     vcf: VcfDataSource.create,
     twoBit: TwoBitDataSource.create,
     bigBed: BigBedDataSource.create,

--- a/src/test/json/GA4GHJson-test.js
+++ b/src/test/json/GA4GHJson-test.js
@@ -28,4 +28,16 @@ describe('GA4GHJson', function() {
 
   });
 
+  it('should not fail on empty json string', function(done) {
+
+    var source = GA4GHJson.create("{}");
+
+    var requestInterval = new ContigInterval('chr17', 10, 20);
+
+    var reads = source.getAlignmentsInRange(requestInterval);
+    expect(reads).to.have.length(0);
+    done();
+
+  });
+
 });

--- a/src/test/json/GA4GHJson-test.js
+++ b/src/test/json/GA4GHJson-test.js
@@ -1,0 +1,31 @@
+/** @flow */
+'use strict';
+
+import {expect} from 'chai';
+
+import ContigInterval from '../../main/ContigInterval';
+import GA4GHJson from '../../main/json/GA4GHJson';
+import RemoteFile from '../../main/RemoteFile';
+
+describe('GA4GHJson', function() {
+  var json;
+
+  before(function () {
+    return new RemoteFile('/test-data/chr17.1-250.json').getAllString().then(data => {
+      json = data;
+    });
+  });
+
+  it('should filter alignments from json', function(done) {
+
+    var source = GA4GHJson.create(json);
+
+    var requestInterval = new ContigInterval('chr17', 10, 20);
+
+    var reads = source.getAlignmentsInRange(requestInterval);
+    expect(reads).to.have.length(2);
+    done();
+
+  });
+
+});


### PR DESCRIPTION
This is primarily to allow pileup.js to be used in platforms other than the browser. For example, a user can load data into a pandas data frame in python, and pipe the dataframe using the  to_json() function into pileup. Since python notebook supports html and JS, one can immediately view their in the same environment. 

I think I will eventually add similar functionality for variants, features, etc. but thought this is a good starting point for discussion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/460)
<!-- Reviewable:end -->
