### PR TITLE
Set minimum size for track viewing

### DIFF
--- a/style/pileup.css
+++ b/style/pileup.css
@@ -183,6 +183,8 @@
 /* pileup track */
 .pileup-root > .pileup {
   flex: 1;  /* stretch to fill remaining space */
+  flex-basis: auto;
+  min-height: 300px; /* prevent tracks from becoming too small */
 }
 .pileup .alignment .match {
   fill: #c8c8c8;  /* matches IGV */


### PR DESCRIPTION
Follow up of #463

This change will set minimum height values for tracks to help prevent the use case where the window is too small to view anything, shown below
<img width="1271" alt="screen shot 2017-07-14 at 11 24 31 am" src="https://user-images.githubusercontent.com/3150228/28218595-0a8ba096-6887-11e7-80fd-d55d9e65cf5e.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/465)
<!-- Reviewable:end -->
