### PR TITLE
removed 'killChr' requirement for demos

### DIFF
--- a/examples/data-ga4gh.js
+++ b/examples/data-ga4gh.js
@@ -41,8 +41,7 @@ var sources = [
     data: pileup.formats.GAVariant({
         endpoint: ga4ghReferenceServer,
         variantSetId: "WyIxa2dlbm9tZXMiLCJ2cyIsInBoYXNlMy1yZWxlYXNlIl0",
-        callSetIds: ["WyIxa2dlbm9tZXMiLCJ2cyIsInBoYXNlMy1yZWxlYXNlIiwiSEcwMDA5NiJd"],
-        killChr: true
+        callSetIds: ["WyIxa2dlbm9tZXMiLCJ2cyIsInBoYXNlMy1yZWxlYXNlIiwiSEcwMDA5NiJd"]
     }),
     options: {
       onVariantClicked: function(data) {
@@ -63,7 +62,7 @@ var sources = [
     viz: pileup.viz.features(),
     data: pileup.formats.GAFeature({
       endpoint: ga4ghReferenceServer,
-      featureSetId: "WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyJd",
+      featureSetId: "WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyJd"
     }),
     name: 'gencode_v24lift37'
   },
@@ -72,7 +71,6 @@ var sources = [
     data: pileup.formats.GAReadAlignment({
       endpoint: ga4ghReferenceServer,
       readGroupId: "WyIxa2dlbm9tZXMiLCJyZ3MiLCJOQTEyODc4IiwiU1JSNjIyNDYxIl0",
-      killChr: true,
       forcedReferenceId: "WyJOQ0JJMzciLCIxIl0"
     }),
     cssClass: 'normal',
@@ -83,7 +81,6 @@ var sources = [
     data: pileup.formats.GAReadAlignment({
       endpoint: ga4ghReferenceServer,
       readGroupId: "WyIxa2dlbm9tZXMiLCJyZ3MiLCJOQTEyODc4IiwiU1JSNjIyNDYxIl0",
-      killChr: true,
       forcedReferenceId: "WyJOQ0JJMzciLCIxIl0"
     }),
     cssClass: 'normal',

--- a/src/main/ContigInterval.js
+++ b/src/main/ContigInterval.js
@@ -30,41 +30,30 @@ class ContigInterval<T: (number|string)> {
     return this.interval.length();
   }
 
+  // Intersects function, allowing for 'chr17' vs. '17'-style mismatches.
   intersects(other: ContigInterval<T>): boolean {
-    return (this.contig === other.contig &&
-            this.interval.intersects(other.interval));
-  }
-
-  // Like intersects(), but allows 'chr17' vs. '17'-style mismatches.
-  chrIntersects(other: ContigInterval<T>): boolean {
     return (this.chrOnContig(other.contig) &&
             this.interval.intersects(other.interval));
   }
 
   containsInterval(other: ContigInterval<T>): boolean {
-    return (this.contig === other.contig &&
+    return (this.chrOnContig(other.contig) &&
             this.interval.containsInterval(other.interval));
   }
 
   isAdjacentTo(other: ContigInterval<T>): boolean {
-    return (this.contig === other.contig &&
+    return (this.chrOnContig(other.contig) &&
             (this.start() == 1 + other.stop() ||
              this.stop() + 1 == other.start()));
   }
 
   isCoveredBy(intervals: ContigInterval<T>[]): boolean {
-    var ivs = intervals.filter(iv => iv.contig === this.contig)
+    var ivs = intervals.filter(iv => this.chrOnContig(iv.contig))
                        .map(iv => iv.interval);
     return this.interval.isCoveredBy(ivs);
   }
 
   containsLocus(contig: T, position: number): boolean {
-    return this.contig === contig &&
-           this.interval.contains(position);
-  }
-
-  // Like containsLocus, but allows 'chr17' vs '17'-style mismatches
-  chrContainsLocus(contig: T, position: number): boolean {
     return this.chrOnContig(contig) &&
            this.interval.contains(position);
   }
@@ -86,7 +75,7 @@ class ContigInterval<T: (number|string)> {
    */
   complementIntervals(intervals: ContigInterval<T>[]): ContigInterval<T>[] {
     return this.interval.complementIntervals(
-        flatMap(intervals, ci => ci.contig === this.contig ? [ci.interval] : []))
+        flatMap(intervals, ci => this.chrOnContig(ci.contig) ? [ci.interval] : []))
         .map(iv => new ContigInterval(this.contig, iv.start, iv.stop));
   }
 

--- a/src/main/sources/GA4GHAlignmentSource.js
+++ b/src/main/sources/GA4GHAlignmentSource.js
@@ -27,9 +27,6 @@ var BASE_PAIRS_PER_FETCH = 100;
 type GA4GHSpec = {
   endpoint: string;
   readGroupId: string;
-  // HACK if set, strips "chr" from reference names.
-  // See https://github.com/ga4gh/schemas/issues/362
-  killChr: boolean;
   // HACK for demo. If set, will always use this reference id.
   // This is for fetching referenceIds specified in GA4GH reference
   // server
@@ -63,12 +60,7 @@ function create(spec: GA4GHSpec): AlignmentDataSource {
   }
 
   function rangeChanged(newRange: GenomeRange) {
-    // HACK FOR DEMO
-    var contig = newRange.contig.replace(/^chr/, '');
-    if (!spec.killChr) {
-      contig = `chr${contig}`;
-    }
-    var interval = new ContigInterval(contig, newRange.start, newRange.stop);
+    var interval = new ContigInterval(newRange.contig, newRange.start, newRange.stop);
     if (interval.isCoveredBy(coveredRanges)) return;
 
     interval = interval.round(BASE_PAIRS_PER_FETCH, ZERO_BASED);
@@ -142,12 +134,7 @@ function create(spec: GA4GHSpec): AlignmentDataSource {
   function getAlignmentsInRange(range: ContigInterval<string>): Alignment[] {
     if (!range) return [];
 
-    // HACK FOR DEMO
-    var contig = range.contig.replace(/^chr/, '');
-    if (!spec.killChr) {
-      contig = `chr${contig}`;
-    }
-    range = new ContigInterval(contig, range.start(), range.stop());
+    range = new ContigInterval(range.contig, range.start(), range.stop());
 
     return _.filter(reads, read => read.intersects(range));
   }

--- a/src/main/sources/GA4GHVariantSource.js
+++ b/src/main/sources/GA4GHVariantSource.js
@@ -20,8 +20,6 @@ type GA4GHVariantSpec = {
   endpoint: string;
   variantSetId: string;
   callSetIds: string[];
-  // HACK for demo. If true, strips "chr" from reference names. If false, adds chr.
-  killChr: boolean;
 };
 
 function create(spec: GA4GHVariantSpec): VcfDataSource {
@@ -47,11 +45,7 @@ function create(spec: GA4GHVariantSpec): VcfDataSource {
   }
 
   function rangeChanged(newRange: GenomeRange) {
-    var contig = newRange.contig.replace(/^chr/, '');
-    if (!spec.killChr) {
-      contig = `chr${contig}`;
-    }
-    var interval = new ContigInterval(contig, newRange.start, newRange.stop);
+    var interval = new ContigInterval(newRange.contig, newRange.start, newRange.stop);
 
     if (interval.isCoveredBy(coveredRanges)) return;
 
@@ -121,11 +115,7 @@ function create(spec: GA4GHVariantSpec): VcfDataSource {
   function getFeaturesInRange(range: ContigInterval<string>): Variant[] {
     if (!range) return [];
 
-    var contig = range.contig.replace(/^chr/, '');
-    if (!spec.killChr) {
-      contig = `chr${contig}`;
-    }
-    range = new ContigInterval(contig, range.start(), range.stop());
+    range = new ContigInterval(range.contig, range.start(), range.stop());
 
     return _.filter(variants, variant => intersects(variant, range));
   }

--- a/src/main/sources/VcfDataSource.js
+++ b/src/main/sources/VcfDataSource.js
@@ -69,7 +69,7 @@ function createFromVcfFile(remoteSource: VcfFile): VcfDataSource {
 
   function getFeaturesInRange(range: ContigInterval<string>): Variant[] {
     if (!range) return [];  // XXX why would this happen?
-    return _.filter(variants, v => range.chrContainsLocus(v.contig, v.position));
+    return _.filter(variants, v => range.containsLocus(v.contig, v.position));
   }
 
   var o = {

--- a/src/main/viz/FeatureTrack.js
+++ b/src/main/viz/FeatureTrack.js
@@ -68,7 +68,7 @@ function renderFeatures(ctx: DataCanvasRenderingContext2D,
 
     features.forEach(feature => {
       var position = new ContigInterval(feature.contig, feature.start, feature.stop);
-      if (!position.chrIntersects(range)) return;
+      if (!position.intersects(range)) return;
       ctx.pushObject(feature);
       ctx.lineWidth = 1;
 

--- a/src/main/viz/GeneTrack.js
+++ b/src/main/viz/GeneTrack.js
@@ -134,7 +134,7 @@ class GeneTrack extends React.Component {
     ctx.font = `${style.GENE_FONT_SIZE}px ${style.GENE_FONT}`;
     ctx.textAlign = 'center';
     this.state.genes.forEach(gene => {
-      if (!gene.position.chrIntersects(range)) return;
+      if (!gene.position.intersects(range)) return;
       ctx.pushObject(gene);
       ctx.lineWidth = 1;
       ctx.strokeStyle = style.GENE_COLOR;

--- a/src/main/viz/PileupCache.js
+++ b/src/main/viz/PileupCache.js
@@ -147,7 +147,7 @@ class PileupCache {
       var reads = this.groups[k].alignments;
       for (var vRead of reads) {
         var read = vRead.read;
-        if (read.getInterval().chrIntersects(range)) {
+        if (read.getInterval().intersects(range)) {
           var opInfo = getOpInfo(read, this.referenceSource);
           vRead.mismatches = opInfo.mismatches;
         }
@@ -178,7 +178,7 @@ class PileupCache {
   // Find groups overlapping the range. This is 'chr'-agnostic.
   getGroupsOverlapping(range: ContigInterval<string>): VisualGroup[] {
     // TODO: speed this up using an interval tree
-    return _.filter(this.groups, group => group.span.chrIntersects(range));
+    return _.filter(this.groups, group => group.span.intersects(range));
   }
 
   // Determine the number of groups at a locus.
@@ -186,7 +186,7 @@ class PileupCache {
   anyGroupsOverlapping(range: ContigInterval<string>): boolean {
     for (var k in this.groups) {
       var group = this.groups[k];
-      if (group.span.chrIntersects(range)) {
+      if (group.span.intersects(range)) {
         return true;
       }
     }
@@ -205,7 +205,7 @@ class PileupCache {
     // Find the groups for which an alignment overlaps the locus.
     var groups = _.filter(this.groups,
           group => _.any(group.alignments,
-              a => a.read.getInterval().chrContainsLocus(contig, position)));
+              a => a.read.getInterval().containsLocus(contig, position)));
 
     // For each row, find the left-most point (for sorting).
     var rowsOverlapping =

--- a/src/main/viz/TiledCanvas.js
+++ b/src/main/viz/TiledCanvas.js
@@ -83,7 +83,7 @@ class TiledCanvas {
       tilesAtRes = tilesAtRes.concat(this.makeNewTiles(existingIntervals, pixelsPerBase, range));
     }
 
-    var tiles = tilesAtRes.filter(tile => range.chrIntersects(tile.range));
+    var tiles = tilesAtRes.filter(tile => range.intersects(tile.range));
 
     tiles.forEach(tile => {
       var left = Math.round(scale(tile.range.start())),
@@ -114,7 +114,7 @@ class TiledCanvas {
   }
 
   invalidateRange(range: ContigInterval) {
-    this.tileCache = this.tileCache.filter(tile => !tile.range.chrIntersects(range));
+    this.tileCache = this.tileCache.filter(tile => !tile.range.intersects(range));
   }
 
   heightForRef(ref: string): number {

--- a/src/test/sources/GA4GHAlignmentSource-test.js
+++ b/src/test/sources/GA4GHAlignmentSource-test.js
@@ -30,7 +30,6 @@ describe('GA4GHAlignmentSource', function() {
     var source = GA4GHAlignmentSource.create({
       endpoint: '/v0.5.1',
       readGroupId: 'some-group-set:some-read-group',
-      killChr: false,
       forcedReferenceId: null
     });
 

--- a/src/test/sources/GA4GHVariantSource-test.js
+++ b/src/test/sources/GA4GHVariantSource-test.js
@@ -16,8 +16,7 @@ describe('GA4GHVariantSource', function() {
     source = GA4GHVariantSource.create({
       endpoint: '/v0.6.0',
       variantSetId: "WyIxa2dlbm9tZXMiLCJ2cyIsInBoYXNlMy1yZWxlYXNlIl0",
-      callSetIds: ["WyIxa2dlbm9tZXMiLCJ2cyIsInBoYXNlMy1yZWxlYXNlIiwiSEcwMDA5NiJd"],
-      killChr: true
+      callSetIds: ["WyIxa2dlbm9tZXMiLCJ2cyIsInBoYXNlMy1yZWxlYXNlIiwiSEcwMDA5NiJd"]
     });
 
     return new RemoteFile('/test-data/variants.ga4gh.chr1.10000-11000.json').getAllString().then(data => {


### PR DESCRIPTION
This removes the requirement for specifying 'killChr' in the demos. Now, there are no issues with 'chr1' vs '1' in the reference vs data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/471)
<!-- Reviewable:end -->
