### PR TITLE
fixed check for forced referenceId in GA4GH examples

### DIFF
--- a/src/main/sources/GA4GHAlignmentSource.js
+++ b/src/main/sources/GA4GHAlignmentSource.js
@@ -117,7 +117,7 @@ function create(spec: GA4GHSpec): AlignmentDataSource {
     o.trigger('networkprogress', {numRequests});
     // hack for DEMO. force GA4GH reference ID
     var contig = range.contig;
-    if (spec.forcedReferenceId !== null)
+    if (spec.forcedReferenceId !== undefined)
     {
       contig = spec.forcedReferenceId;
     }


### PR DESCRIPTION
This is an issue if spec.forceReferenceId is not set

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/pileup.js/473)
<!-- Reviewable:end -->
