### PR TITLE
Added the ability to pass a function into pileup click handler

### DIFF
--- a/src/main/viz/PileupTrack.js
+++ b/src/main/viz/PileupTrack.js
@@ -475,8 +475,14 @@ class PileupTrack extends React.Component {
     renderPileup(trackingCtx, scale, range, null, false, vGroups);
     var vRead = _.find(trackingCtx.hits[0], hit => hit.read);
     var alert = window.alert || console.log;
+
     if (vRead) {
-      alert(vRead.read.debugString());
+      //user provided function for displaying popup
+      if (typeof this.props.options.onReadClicked  === "function") {
+        this.props.options.onReadClicked(vRead);
+      } else {
+        alert(vRead.read.debugString());
+      }
     }
   }
 }

--- a/src/test/viz/PileupTrack-test.js
+++ b/src/test/viz/PileupTrack-test.js
@@ -23,6 +23,8 @@ import ContigInterval from '../../main/ContigInterval';
 import {waitFor} from '../async';
 import dataCanvas from 'data-canvas';
 
+// Uncomment this for testing click
+//import ReactTestUtils from 'react-addons-test-utils';
 
 // This is like TwoBit, but allows a controlled release of sequence data.
 class FakeTwoBit extends TwoBit {
@@ -202,7 +204,7 @@ describe('PileupTrack', function() {
       p.destroy();
     });
   });
-
+  
   it('should hide alignments', function() {
     var p = pileup.create(testDiv, {
       range: {contig: 'chr17', start: 7500734, stop: 7500796},
@@ -229,6 +231,58 @@ describe('PileupTrack', function() {
     return waitFor(hasPileupSelector, 2000).then(() => {
       var alignments = drawnObjectsWith(testDiv, '.pileup', x => x.span);
       expect(alignments.length).to.equal(0);
+      p.destroy();
+    });
+  });
+
+  it('should use provided click function', function() {
+    var readClickedData = null;
+    var readClicked = function (data) {
+      // TODO: remove after testing is done
+      var alert = window.alert || console.log;
+      alert(data.read.debugString());
+      readClickedData = data;
+    };
+
+    var p = pileup.create(testDiv, {
+      range: {contig: 'chr17', start: 7500734, stop: 7500796},
+      tracks: [
+        {
+          data: pileup.formats.twoBit({
+            url: '/test-data/test.2bit'
+          }),
+          viz: pileup.viz.genome(),
+          isReference: true
+        },
+        {
+          data: pileup.formats.bam({
+            url: '/test-data/synth3.normal.17.7500000-7515000.bam',
+            indexUrl: '/test-data/synth3.normal.17.7500000-7515000.bam.bai'
+          }),
+          viz: pileup.viz.pileup({
+            onReadClicked: readClicked
+          }),
+        }
+      ]
+    });
+
+    return waitFor(hasPileupSelector, 2000).then(() => {
+      /*
+      // TODO: Fix - canvasList is empty but testDiv is fine?
+      var alignments = drawnObjectsWith(testDiv, '.pileup')
+      console.log("alignments", alignments)
+      var canvasList = testDiv.getElementsByTagName('canvas');
+    
+      console.log("canvasList", canvasList)
+      console.log("canaslist len", canvasList.length)
+      var canvas = canvasList[1];
+      console.log("canvas", canvas);
+      expect(readClickedData).to.be.null;
+    
+      //check clicking on variant
+      // TODO: how can I tell what offsets to provide??
+      ReactTestUtils.Simulate.click(canvas,{nativeEvent: {offsetX: -0.5, offsetY: -15.5}});
+      */
       p.destroy();
     });
   });


### PR DESCRIPTION
@akmorrow13 I can't tell how to get the click test to work.

`drawnObjectsWith(testDiv, '.pileup')` throws a failure even though if I comment out the other tests and remove the resets on testDiv and p, it displays fine in the browser.

There seems to be a timing issue because sometimes `var canvasList = testDiv.getElementsByTagName('canvas');` has two elements and sometimes it doesn't.  Maybe `hasPileupSelector` is not an appropriate wait for this test?

I don't know how to get what offset I should provide to the `ReactTestUtils.Simulate.click`.

Thanks for your help.