### PR TITLE
Fix mobile display cutting off reference genome letters

### DIFF
--- a/src/main/viz/GenomeTrack.js
+++ b/src/main/viz/GenomeTrack.js
@@ -35,10 +35,11 @@ function renderGenome(ctx: DataCanvasRenderingContext2D,
   if (mode != DisplayMode.HIDDEN) {
     ctx.textAlign = 'center';
     if (mode == DisplayMode.LOOSE) {
-      ctx.font = style.LOOSE_TEXT_STYLE;
+      //ctx.font = style.LOOSE_TEXT_STYLE;
     } else if (mode == DisplayMode.TIGHT) {
-      ctx.font = style.TIGHT_TEXT_STYLE;
+      //ctx.font = style.TIGHT_TEXT_STYLE;
     }
+    ctx.font = String(Math.min(pxPerLetter, 12)) + "px" + ` 'Helvetica Neue', Helvetica, Arial, sans-serif`;
 
     var previousBase = null;
     var start = range.start(),


### PR DESCRIPTION
On devices with retina displays (and simulated mobile displays in browser debug), letters for the reference genome would appear cutoff when zooming in. This fixes it by resizing the font for the letters based on screen size.