### PR TITLE
after changing pythonjs to mocha-headless-chrome grep on unit tests stopped working

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,5 +17,19 @@ trap finish EXIT
 # possible racing conditions
 sleep 1
 
+# extract parameters passed to "npm test" method
+grep_param=''
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --grep=*)
+      grep_param="${1#*=}"
+      ;;
+    *)
+      printf "Error: Invalid argument: $1\n"
+      exit 1
+  esac
+  shift
+done
+
 # Start the tests
-mocha-headless-chrome -f http://localhost:8081/src/test/runner.html
+mocha-headless-chrome -f http://localhost:8081/src/test/runner.html?grep=$grep_param


### PR DESCRIPTION
After changing pythonjs to mocha-headless-chrome there was no way to run single test from the console. 

For instance this call executed all unit tests, but shouldn't.
```
npm run test -- --grep=pileuputils
```
This PR restores grep functionality when running unit tests.