### PR TITLE
Don't let users view past the end of contigs

### DIFF
--- a/lib/underscore.js
+++ b/lib/underscore.js
@@ -2,6 +2,7 @@
 
 declare module "underscore" {
   declare function find<T>(list: T[], predicate: (val: T)=>boolean): ?T;
+  declare function findIndex<T>(list: T[], predicate: (val: T)=>boolean): number;
   declare function findWhere<T>(list: Array<T>, properties: {[key:string]: any}): ?T;
   declare function clone<T>(obj: T): T;
 

--- a/src/main/Controls.js
+++ b/src/main/Controls.js
@@ -15,7 +15,7 @@ import Interval from './Interval';
 
 type Props = {
   range: ?GenomeRange;
-  contigList: ContigInterval[];
+  contigList: ContigInterval<string>[];
   onChange: (newRange: GenomeRange)=>void;
 };
 
@@ -55,8 +55,8 @@ class Controls extends React.Component<Props, State> {
       // There are major performance issues with having a 'chr' mismatch in the
       // global location object.
       const contig = range.contig;
-      var altContig = _.find(this.props.contigList, ref => utils.isChrMatch(contig, ref.contig)).contig;
-      if (altContig) range.contig = altContig;
+      var altContig = _.find(this.props.contigList, ref => utils.isChrMatch(contig, ref.contig));
+      if (altContig) range.contig = altContig.contig;
     }
 
     return (_.extend(_.clone(this.props.range), range) : any);
@@ -165,9 +165,15 @@ class Controls extends React.Component<Props, State> {
     // Update slider if we have collected new information about a contig.
     if (!_.isEqual(prevProps.contigList, this.props.contigList)) {
       if (this.props.range != undefined) {
-        var newInterval = _.find(this.props.contigList, ref => utils.isChrMatch(this.props.range.contig, ref.contig));
-        this.refs.slider.min = -1 * newInterval.stop();
-        this.updateSlider(this.props.range);
+        var range = this.props.range; // flow
+        if (range.contig != undefined) {
+          var newInterval = _.find(this.props.contigList, ref => utils.isChrMatch(range.contig, ref.contig));
+
+          if (newInterval != undefined) {
+            this.refs.slider.min = -1 * newInterval.stop();
+            this.updateSlider(new Interval(range.start, range.stop));
+          }
+        }
       }
     }
   }

--- a/src/main/Controls.js
+++ b/src/main/Controls.js
@@ -133,7 +133,8 @@ class Controls extends React.Component<Props, State> {
   // To be used if the range changes through a control besides the slider
   // Slider value is changed to roughly reflect the new range
   updateSlider(newInterval: Interval) {
-    this.refs.slider.valueAsNumber = -1 * newInterval.stop;
+    var newSpan = (newInterval.stop - newInterval.start);
+    this.refs.slider.valueAsNumber = Math.ceil(-Math.log2(newSpan) + 1);
   }
 
   render(): any {
@@ -170,7 +171,7 @@ class Controls extends React.Component<Props, State> {
           var newInterval = _.find(this.props.contigList, ref => utils.isChrMatch(range.contig, ref.contig));
 
           if (newInterval != undefined) {
-            this.refs.slider.min = -1 * newInterval.stop();
+            this.refs.slider.min = Math.ceil(-Math.log2(newInterval.stop()) + 1);
             this.updateSlider(new Interval(range.start, range.stop));
           }
         }

--- a/src/main/Root.js
+++ b/src/main/Root.js
@@ -7,7 +7,8 @@
 import type {GenomeRange} from './types';
 import type {TwoBitSource} from './sources/TwoBitDataSource';
 import type {VisualizedTrack, VizWithOptions} from './types';
-
+import type ContigInterval from './ContigInterval';
+import utils from './utils';
 import _ from 'underscore';
 
 import React from 'react';
@@ -22,7 +23,7 @@ type Props = {
 };
 
 type State = {
-  contigList: string[];
+  contigList: ContigInterval[];
   range: ?GenomeRange;
   settingsMenuKey: ?string;
   updateSize: boolean;
@@ -50,9 +51,7 @@ class Root extends React.Component<Props, State> {
 
   componentDidMount() {
     this.props.referenceSource.on('contigs', () => {
-      this.setState({
-        contigList: this.props.referenceSource.contigList(),
-      });
+      this.updateOutOfBoundsChromosome();
     });
 
     if (!this.state.range) {
@@ -63,13 +62,33 @@ class Root extends React.Component<Props, State> {
   }
 
   handleRangeChange(newRange: GenomeRange) {
-    // Do not propagate negative ranges
-    if (newRange.start < 0) {
-      newRange.start = 0;
-    }
-    this.props.referenceSource.normalizeRange(newRange).then(range => {
-      this.setState({range: range});
 
+    // copy over range so you don't modify
+    // this.state.range, which is bound to handleRangeChange
+    var modifiedRange =  {
+      contig: newRange.contig,
+      start: newRange.start,
+      stop: newRange.stop,
+    };
+
+    // Do not propagate negative ranges
+    if (modifiedRange.start < 0) {
+      modifiedRange.start = 0;
+    }
+    // Do not propogate ranges exceeding contig limit
+    var contigInfo = _.find(this.state.contigList, ref => utils.isChrMatch(modifiedRange.contig, ref.contig));
+
+    if (contigInfo != undefined) {
+      if (modifiedRange.stop > contigInfo.stop()) {
+        modifiedRange.stop = contigInfo.stop();
+        if (modifiedRange.start > modifiedRange.stop) {
+          modifiedRange.start = 0;
+        }
+      }
+    }
+
+    this.props.referenceSource.normalizeRange(modifiedRange).then(range => {
+      this.setState({range: range});
       // Inform all the sources of the range change (including referenceSource).
       this.props.tracks.forEach(track => {
         track.source.rangeChanged(range);
@@ -160,7 +179,7 @@ class Root extends React.Component<Props, State> {
         </div>
       );
     }
-    
+
     var className = ['track', track.visualization.component.displayName || '', track.track.cssClass || ''].join(' ');
 
     return (
@@ -198,6 +217,46 @@ class Root extends React.Component<Props, State> {
     );
   }
 
+  updateOutOfBoundsChromosome(): any {
+    // We don't want to allow users to go to regions that extend past the end of
+    // a contig. This function truncates queries past the ends of a contig
+    // and updates the required states.
+
+    var current_contig = this.props.initialRange;
+    if (this.state.range) {
+      current_contig = this.state.range.contig;
+    }
+
+    var oldContig = _.find(this.state.contigList, ref =>
+        utils.isChrMatch(current_contig,
+        ref.contig));
+
+    var contigList = this.props.referenceSource.contigList();
+
+    var newContig = _.find(contigList, ref => utils.isChrMatch(current_contig, ref.contig));
+
+    // only update if the current contig has new information regarding
+    // the end of the chromosome AND the current range is out of bounds
+    // with respect to chromosome length
+    if (newContig == undefined) {
+      this.setState({
+        contigList: contigList
+      });
+    }
+
+    if (newContig && oldContig) {
+      if (!_.isEqual(oldContig, newContig)) {
+        // only trigger state if current contig changed
+        this.setState({
+          contigList: contigList
+        });
+        if (this.state.range.stop > newContig.stop()) {
+          this.handleRangeChange(this.state.range);
+        }
+      }
+    }
+  }
+
   componentDidUpdate(prevProps: Props, prevState: Object) {
     if (this.state.updateSize) {
       for (var i=0;i<this.props.tracks.length;i++) {
@@ -205,6 +264,10 @@ class Root extends React.Component<Props, State> {
       }
       this.state.updateSize=false;
     }
+
+    this.props.referenceSource.on('contigs', () => {
+      this.updateOutOfBoundsChromosome();
+    });
   }
 
 }

--- a/src/main/Root.js
+++ b/src/main/Root.js
@@ -23,7 +23,7 @@ type Props = {
 };
 
 type State = {
-  contigList: ContigInterval[];
+  contigList: ContigInterval<string>[];
   range: ?GenomeRange;
   settingsMenuKey: ?string;
   updateSize: boolean;
@@ -222,7 +222,7 @@ class Root extends React.Component<Props, State> {
     // a contig. This function truncates queries past the ends of a contig
     // and updates the required states.
 
-    var current_contig = this.props.initialRange;
+    var current_contig = this.props.initialRange.contig;
     if (this.state.range) {
       current_contig = this.state.range.contig;
     }
@@ -238,7 +238,7 @@ class Root extends React.Component<Props, State> {
     // only update if the current contig has new information regarding
     // the end of the chromosome AND the current range is out of bounds
     // with respect to chromosome length
-    if (newContig == undefined) {
+    if (this.state.contigList.length == 0) {
       this.setState({
         contigList: contigList
       });
@@ -250,8 +250,11 @@ class Root extends React.Component<Props, State> {
         this.setState({
           contigList: contigList
         });
-        if (this.state.range.stop > newContig.stop()) {
-          this.handleRangeChange(this.state.range);
+        if (this.state.range !== null && this.state.range !== undefined) {
+          if (this.state.range.stop > newContig.stop()) {
+            // $FlowIgnore: TODO remove flow suppression
+            this.handleRangeChange(this.state.range);
+          }
         }
       }
     }

--- a/src/main/data/TwoBit.js
+++ b/src/main/data/TwoBit.js
@@ -259,7 +259,7 @@ class TwoBit {
   getContigList(): Q.Promise<ContigInterval<string>[]> {
     return this.header.then(header => {
       return header.sequences.map(seq => {
-        // fill in end if collected
+        // fill in numBases if collected
         var numBases = Number.MAX_VALUE;
         if (this.traversedSequenceRecords[seq.name]) {
           numBases = this.traversedSequenceRecords[seq.name].numBases;

--- a/src/main/data/TwoBit.js
+++ b/src/main/data/TwoBit.js
@@ -256,7 +256,7 @@ class TwoBit {
   }
 
   // Returns a list of contig names.
-  getContigList(): Q.Promise<ContigInterval[]> {
+  getContigList(): Q.Promise<ContigInterval<string>[]> {
     return this.header.then(header => {
       return header.sequences.map(seq => {
         // fill in end if collected

--- a/src/main/sources/TwoBitDataSource.js
+++ b/src/main/sources/TwoBitDataSource.js
@@ -42,7 +42,7 @@ export type TwoBitSource = {
   rangeChanged: (newRange: GenomeRange) => void;
   getRange: (range: GenomeRange) => {[key:string]: ?string};
   getRangeAsString: (range: GenomeRange) => string;
-  contigList: () => ContigInterval[];
+  contigList: () => ContigInterval<string>[];
   normalizeRange: (range: GenomeRange) => Q.Promise<GenomeRange>;
   on: (event: string, handler: Function) => void;
   once: (event: string, handler: Function) => void;
@@ -95,14 +95,15 @@ var createFromTwoBitFile = function(remoteSource: TwoBit): TwoBitSource {
   // This either adds or removes a 'chr' as needed.
   function normalizeRangeSync(range: GenomeRange): GenomeRange {
 
-    var contigIdx = _.findIndex(contigList, ref => utils.isChrMatch(range.contig, ref.contig));
+    // check for direct match
+    var contigIdx = _.findIndex(contigList, ref => range.contig == ref.contig);
 
     if (contigIdx >= 0) {
       return range;
     }
     var altContig = utils.altContigName(range.contig);
 
-    var contigIdx = _.findIndex(contigList, ref => utils.isChrMatch(altContig, ref.contig));
+    contigIdx = _.findIndex(contigList, ref => altContig == ref.contig);
 
     if (contigIdx >= 0) {
       return {

--- a/src/main/sources/TwoBitDataSource.js
+++ b/src/main/sources/TwoBitDataSource.js
@@ -42,7 +42,7 @@ export type TwoBitSource = {
   rangeChanged: (newRange: GenomeRange) => void;
   getRange: (range: GenomeRange) => {[key:string]: ?string};
   getRangeAsString: (range: GenomeRange) => string;
-  contigList: () => string[];
+  contigList: () => ContigInterval[];
   normalizeRange: (range: GenomeRange) => Q.Promise<GenomeRange>;
   on: (event: string, handler: Function) => void;
   once: (event: string, handler: Function) => void;
@@ -62,9 +62,13 @@ var createFromTwoBitFile = function(remoteSource: TwoBit): TwoBitSource {
   function fetch(range: ContigInterval<string>) {
     var span = range.length();
     if (span > MAX_BASE_PAIRS_TO_FETCH) {
-      //inform that we won't fetch the data
-      o.trigger('newdatarefused', range);
-      return Q.when();  // empty promise
+      // trigger header collection to get information about this chromosome,
+      // but don't fetch the actual data.
+      return remoteSource._getSequenceHeader(range.contig).then(header => remoteSource.getContigList()).then(c => {
+        contigList = c;
+        o.trigger('contigs', contigList);
+        o.trigger('newdatarefused', range);
+      }).done();
     }
     //now we can add region to covered regions
     //doing it earlier would provide inconsistency
@@ -81,18 +85,26 @@ var createFromTwoBitFile = function(remoteSource: TwoBit): TwoBitSource {
                                      range.start() + letters.length - 1);
         }
         store.setRange(range, letters);
-      }).then(() => {
+      }).then(() => remoteSource.getContigList()).then(c => {
+        contigList = c;
+        o.trigger('contigs', contigList);
         o.trigger('newdata', range);
       }).done();
   }
 
   // This either adds or removes a 'chr' as needed.
   function normalizeRangeSync(range: GenomeRange): GenomeRange {
-    if (contigList.indexOf(range.contig) >= 0) {
+
+    var contigIdx = _.findIndex(contigList, ref => utils.isChrMatch(range.contig, ref.contig));
+
+    if (contigIdx >= 0) {
       return range;
     }
     var altContig = utils.altContigName(range.contig);
-    if (contigList.indexOf(altContig) >= 0) {
+
+    var contigIdx = _.findIndex(contigList, ref => utils.isChrMatch(altContig, ref.contig));
+
+    if (contigIdx >= 0) {
       return {
         contig: altContig,
         start: range.start,

--- a/src/main/viz/GeneTrack.js
+++ b/src/main/viz/GeneTrack.js
@@ -28,6 +28,7 @@ import utils from '../utils';
 import dataCanvas from 'data-canvas';
 import style from '../style';
 
+
 // Draw an arrow in the middle of the visible portion of range.
 function drawArrow(ctx: CanvasRenderingContext2D,
                    clampedScale: (x: number)=>number,

--- a/src/main/viz/GeneTrack.js
+++ b/src/main/viz/GeneTrack.js
@@ -28,7 +28,6 @@ import utils from '../utils';
 import dataCanvas from 'data-canvas';
 import style from '../style';
 
-
 // Draw an arrow in the middle of the visible portion of range.
 function drawArrow(ctx: CanvasRenderingContext2D,
                    clampedScale: (x: number)=>number,

--- a/src/test/FakeAlignment.js
+++ b/src/test/FakeAlignment.js
@@ -76,7 +76,7 @@ var fakeSource = {
   rangeChanged: dieFn,
   getRange: function(): any { return {}; },
   getRangeAsString: function(): string { return ''; },
-  contigList: function(): string[] { return []; },
+  contigList: function(): ContigInterval<string>[] { return []; },
   normalizeRange: function(range: GenomeRange): Q.Promise<GenomeRange> { return Q.when(range); },
   on: dieFn,
   off: dieFn,

--- a/src/test/FakeTwoBit.js
+++ b/src/test/FakeTwoBit.js
@@ -1,0 +1,32 @@
+/**
+ * fake TwoBit file.
+ * Used to query regions that extend the bounds in
+ * the test twobit files.
+ *
+ * @flow
+ */
+import Q from 'q';
+import TwoBit from '../main/data/TwoBit';
+import RemoteFile from '../main/RemoteFile';
+
+
+class FakeTwoBit extends TwoBit {
+  deferred: Object;
+
+  constructor(remoteFile: RemoteFile) {
+    super(remoteFile);
+    this.deferred = Q.defer();
+  }
+
+  getFeaturesInRange(contig: string, start: number, stop: number): Q.Promise<string> {
+    return this.deferred.promise;
+  }
+
+  release(sequence: string) {
+    this.deferred.resolve(sequence);
+  }
+}
+
+module.exports = {
+  FakeTwoBit
+};

--- a/src/test/components-test.js
+++ b/src/test/components-test.js
@@ -95,7 +95,7 @@ describe('pileup', function() {
     hasCanvasAndObjects(testDiv, '.pileup')
   );
 
-  var rangeChanged = ((): boolean =>
+  var rangeChanged = ((range): boolean =>
     // $FlowIgnore: TODO remove flow suppression
     initialRange != p.getRange()
   );
@@ -178,6 +178,41 @@ describe('pileup', function() {
               .filter(x => x.span.intersects(cRange));
         expect(visibleReads).to.have.length(4);
         done();
+      });
+  });
+
+  it('should restrict viewing region outside of chromosome', function(done): any {
+    this.timeout(5000);
+
+    makePileup();
+
+    waitFor(ready, 5000)
+      .then(() => {
+
+        expect(p.getRange()).to.deep.equal({
+          contig: 'chr17',
+          start: 100,
+          stop: 150
+        });
+
+        // out of bounds for chromosome
+        var range = {
+          contig: 'chr17',
+          start: 100000000,
+          stop:  100000200
+        };
+
+        p.setRange(range);
+
+        waitFor(rangeChanged, 5000)
+          .then(() => {
+            expect(p.getRange()).to.deep.equal({
+              contig: 'chr17',
+              start: 0,
+              stop: 19198
+            });
+            done();
+          });
       });
   });
 

--- a/src/test/data/TwoBit-test.js
+++ b/src/test/data/TwoBit-test.js
@@ -15,7 +15,8 @@ describe('TwoBit', function() {
   it('should have the right contigs', function(): any {
     var twoBit = getTestTwoBit();
     return twoBit.getContigList()
-      .then(contigs => {
+      .then(contigList => {
+        var contigs = contigList.map(c => c.contig);
         expect(contigs).to.deep.equal(['chr1', 'chr17', 'chr22']);
       });
   });

--- a/src/test/sources/TwoBitDataSource-test.js
+++ b/src/test/sources/TwoBitDataSource-test.js
@@ -25,7 +25,8 @@ describe('TwoBitDataSource', function() {
 
   it('should fetch contigs', function(done) {
     var source = getTestSource();
-    source.on('contigs', contigs => {
+    source.on('contigs', contigList => {
+      var contigs = contigList.map(c => c.contig);
       expect(contigs).to.deep.equal(['chr1', 'chr17', 'chr22']);
       done();
     });

--- a/src/test/viz/FeatureTrack-test.js
+++ b/src/test/viz/FeatureTrack-test.js
@@ -10,6 +10,10 @@ import {expect} from 'chai';
 
 import _ from 'underscore';
 import RemoteFile from '../../main/RemoteFile';
+import TwoBit from '../../main/data/TwoBit';
+import TwoBitDataSource from '../../main/sources/TwoBitDataSource';
+import MappedRemoteFile from '../MappedRemoteFile';
+import {FakeTwoBit} from '../FakeTwoBit';
 import pileup from '../../main/pileup';
 import dataCanvas from 'data-canvas';
 import {waitFor} from '../async';
@@ -18,26 +22,6 @@ import {yForRow} from '../../main/viz/pileuputils';
 
 import ReactTestUtils from 'react-dom/test-utils';
 
-// We need a fake TwoBit file to query regions that extend the bounds in test.2bit
-class FakeTwoBit extends TwoBit {
-  deferred: Object;
-
-  constructor(remoteFile: RemoteFile) {
-    super(remoteFile);
-    this.deferred = Q.defer();
-  }
-
-  getFeaturesInRange(contig: string, start: number, stop: number): Q.Promise<string> {
-    expect(contig).to.equal('chr17');
-    expect(start).to.equal(7500000);
-    expect(stop).to.equal(7510000);
-    return this.deferred.promise;
-  }
-
-  release(sequence: string) {
-    this.deferred.resolve(sequence);
-  }
-}
 
 describe('FeatureTrack', function() {
   var testDiv= document.getElementById('testdiv');
@@ -51,8 +35,12 @@ describe('FeatureTrack', function() {
           drawnObjects(testDiv, '.features').length > 0;
   }
 
+  // Test data files
+  var twoBitFile = new MappedRemoteFile(
+          '/test-data/hg19.2bit.mapped',
+          [[0, 16383], [691179834, 691183928], [694008946, 694011447]]);
+
   describe('jsonFeatures', function() {
-    var json;
 
     beforeEach(() => {
       testDiv.style.width = '800px';
@@ -65,8 +53,16 @@ describe('FeatureTrack', function() {
       testDiv.innerHTML = '';
     });
 
+    var reference: string = '';
+    var json;
+
     before(function(): any {
-      return new RemoteFile('/test-data/features.ga4gh.chr1.120000-125000.chr17.7500000-7515100.json').getAllString().then(data => {
+      var twoBit = new TwoBit(twoBitFile);
+      return twoBit.getFeaturesInRange('chr17', 7500000, 7510000).then(seq => {
+        reference = seq;
+        return new RemoteFile('/test-data/features.ga4gh.chr1.120000-125000.chr17.7500000-7515100.json').getAllString();
+      }).then(data => {
+        expect(data).to.have.length.above(0);
         json = data;
       });
     });
@@ -80,6 +76,8 @@ describe('FeatureTrack', function() {
       var fakeTwoBit = new FakeTwoBit(twoBitFile),
           referenceSource = TwoBitDataSource.createFromTwoBitFile(fakeTwoBit);
 
+      // Release the reference first.
+      fakeTwoBit.release(reference);
 
       var p = pileup.create(testDiv, {
         range: {contig: 'chr1', start: 130000, stop: 135000},
@@ -142,9 +140,21 @@ describe('FeatureTrack', function() {
       testDiv.innerHTML = '';
     });
 
+    var reference: string = '';
+
+    before(function(): any {
+      var twoBit = new TwoBit(twoBitFile);
+      return twoBit.getFeaturesInRange('chr17', 7500000, 7510000).then(seq => {
+        reference = seq;
+      });
+    });
+
     it('should render features with bigBed file', function(): any {
       var fakeTwoBit = new FakeTwoBit(twoBitFile),
           referenceSource = TwoBitDataSource.createFromTwoBitFile(fakeTwoBit);
+
+      // Release the reference first.
+      fakeTwoBit.release(reference);
 
       var p = pileup.create(testDiv, {
         range: {contig: 'chr17', start: 10000, stop: 16500},

--- a/src/test/viz/GeneTrack-test.js
+++ b/src/test/viz/GeneTrack-test.js
@@ -10,13 +10,11 @@
 import sinon from 'sinon';
 import {expect} from 'chai';
 
-import Q from 'q';
 import pileup from '../../main/pileup';
 import dataCanvas from 'data-canvas';
 import {waitFor} from '../async';
 
 import RemoteFile from '../../main/RemoteFile';
-import TwoBit from '../../main/data/TwoBit';
 import TwoBitDataSource from '../../main/sources/TwoBitDataSource';
 import MappedRemoteFile from '../MappedRemoteFile';
 import {FakeTwoBit} from '../FakeTwoBit';

--- a/src/test/viz/GeneTrack-test.js
+++ b/src/test/viz/GeneTrack-test.js
@@ -10,18 +10,32 @@
 import sinon from 'sinon';
 import {expect} from 'chai';
 
+import Q from 'q';
 import pileup from '../../main/pileup';
 import dataCanvas from 'data-canvas';
 import {waitFor} from '../async';
 
 import RemoteFile from '../../main/RemoteFile';
-
+import TwoBit from '../../main/data/TwoBit';
+import TwoBitDataSource from '../../main/sources/TwoBitDataSource';
+import MappedRemoteFile from '../MappedRemoteFile';
+import {FakeTwoBit} from '../FakeTwoBit';
 
 describe('GeneTrack', function() {
   var testDiv = document.getElementById('testdiv');
   if (!testDiv) throw new Error("Failed to match: testdiv");
 
   var server: any = null, response;
+
+  // Test data files
+  var twoBitFile = new MappedRemoteFile(
+          '/test-data/hg19.2bit.mapped',
+          [[0, 16383], [691179834, 691183928], [694008946, 694011447]]);
+
+
+  var fakeTwoBit = new FakeTwoBit(twoBitFile),
+      referenceSource = TwoBitDataSource.createFromTwoBitFile(fakeTwoBit);
+
 
   before((): any => {
     // server for genes
@@ -31,11 +45,8 @@ describe('GeneTrack', function() {
 
       server.autoRespond = true;
 
-      // Sinon should ignore 2bit request. RemoteFile handles this request.
+      // // Sinon should ignore 2bit request. RemoteFile handles this request.
       sinon.fakeServer.xhr.useFilters = true;
-      sinon.fakeServer.xhr.addFilter(function (method, url) {
-          return url === '/test-data/test.2bit';
-      });
       sinon.fakeServer.xhr.addFilter(function (method, url) {
           return url === '/test-data/hg19.2bit.mapped';
       });
@@ -72,9 +83,7 @@ describe('GeneTrack', function() {
       tracks: [
         {
           viz: pileup.viz.genome(),
-          data: pileup.formats.twoBit({
-            url: '/test-data/test.2bit'
-          }),
+          data: referenceSource,
           isReference: true
         },
         {
@@ -110,9 +119,7 @@ describe('GeneTrack', function() {
       tracks: [
         {
           viz: pileup.viz.genome(),
-          data: pileup.formats.twoBit({
-            url: '/test-data/test.2bit'
-          }),
+          data: referenceSource,
           isReference: true
         },
         {
@@ -142,9 +149,7 @@ describe('GeneTrack', function() {
       tracks: [
         {
           viz: pileup.viz.genome(),
-          data: pileup.formats.twoBit({
-            url: '/test-data/test.2bit'
-          }),
+          data: referenceSource,
           isReference: true
         },
         {

--- a/src/test/viz/GeneTrack-test.js
+++ b/src/test/viz/GeneTrack-test.js
@@ -43,7 +43,7 @@ describe('GeneTrack', function() {
 
       server.autoRespond = true;
 
-      // // Sinon should ignore 2bit request. RemoteFile handles this request.
+      // Sinon should ignore 2bit request. RemoteFile handles this request.
       sinon.fakeServer.xhr.useFilters = true;
       sinon.fakeServer.xhr.addFilter(function (method, url) {
           return url === '/test-data/hg19.2bit.mapped';

--- a/src/test/viz/PileupTrack-test.js
+++ b/src/test/viz/PileupTrack-test.js
@@ -208,13 +208,17 @@ describe('PileupTrack', function() {
   });
 
   it('should hide alignments', function(): any {
+
+    // The fake sources allow precise control over when they give up their data.
+    var fakeTwoBit = new FakeTwoBit(twoBitFile),
+        referenceSource = TwoBitDataSource.createFromTwoBitFile(fakeTwoBit);
+
+
     var p = pileup.create(testDiv, {
       range: {contig: 'chr17', start: 7500734, stop: 7500796},
       tracks: [
         {
-          data: pileup.formats.twoBit({
-            url: '/test-data/test.2bit'
-          }),
+          data: referenceSource,
           viz: pileup.viz.genome(),
           isReference: true
         },
@@ -238,13 +242,17 @@ describe('PileupTrack', function() {
   });
 
   it('should sort reads', function(): any {
+
+    // The fake sources allow precise control over when they give up their data.
+    var fakeTwoBit = new FakeTwoBit(twoBitFile),
+        referenceSource = TwoBitDataSource.createFromTwoBitFile(fakeTwoBit);
+
+
     var p = pileup.create(testDiv, {
       range: {contig: 'chr17', start: 7500734, stop: 7500796},
       tracks: [
         {
-          data: pileup.formats.twoBit({
-            url: '/test-data/test.2bit'
-          }),
+          data: referenceSource,
           viz: pileup.viz.genome(),
           isReference: true
         },

--- a/style/pileup.css
+++ b/style/pileup.css
@@ -110,6 +110,12 @@
   border: 1px solid #bcbbbb;
   vertical-align: middle;
 }
+.controls button:active {
+  background-color: #bcbbbb;       /* make button interactive */
+}
+.controls button:focus {
+  outline: none !important;         /* remove blue line from buttons */
+}
 .zoom-slider {
   margin-left: 10px;                /* leave space between slider and zoom buttons */
   display: inline-block !important; /* imporant overrides input[type="range"] from forms.less */


### PR DESCRIPTION
Previously, the browser could scroll past the end of contigs. We now grab the number of bases from the current contig being viewed, and restrict viewing to this region. This required a substantial rebase of viz tests, that previously used a twobit file with short contigs. We now use a fake twobit file so all regions can be accessed during testing.

TODOs:
- [x] fix slider in controls.js