### PR TITLE
Coverage rendering and maxCoverage

### DIFF
--- a/src/main/viz/CoverageCache.js
+++ b/src/main/viz/CoverageCache.js
@@ -102,7 +102,7 @@ class CoverageCache<T: (Alignment | Feature)> {
         this.refToCounts[utils.altContigName(range.contig)] ||
         {};
 
-    var max = 10; // minimum coverage
+    var max = 0; // minimum coverage
     for (var i = range.start(); i < range.stop(); i++) {
       if (bins[i] != undefined) {
         if (bins[i].count > max) {

--- a/src/main/viz/CoverageTrack.js
+++ b/src/main/viz/CoverageTrack.js
@@ -59,7 +59,7 @@ class CoverageTiledCanvas extends TiledCanvas {
 
   yScaleForRef(bottomPadding: number, topPadding:number): (y: number) => number {
     return scale.linear()
-      .domain([this.maxCoverage, 0])
+      .domain([Math.max(10, this.maxCoverage), 0]) // minimum coverage = 10
       .range([bottomPadding, this.height - topPadding])
       .nice();
   }

--- a/src/main/viz/CoverageTrack.js
+++ b/src/main/viz/CoverageTrack.js
@@ -36,6 +36,7 @@ class CoverageTiledCanvas extends TiledCanvas {
   height: number;
   options: Object;
   cache: CoverageCache< Alignment | Feature> ;
+  maxCoverage: number;
 
   constructor(cache: CoverageCache<(Alignment | Feature)>, height: number, options: Object) {
     super();
@@ -43,6 +44,7 @@ class CoverageTiledCanvas extends TiledCanvas {
     this.cache = cache;
     this.height = Math.max(1, height);
     this.options = options;
+    this.maxCoverage = 0;
   }
 
   heightForRef(ref: string): number {
@@ -55,10 +57,9 @@ class CoverageTiledCanvas extends TiledCanvas {
     this.options = options;
   }
 
-  yScaleForRef(ref: string, bottomPadding: number, topPadding:number): (y: number) => number {
-    var maxCoverage = this.cache.maxCoverageForRef(ref);
+  yScaleForRef(bottomPadding: number, topPadding:number): (y: number) => number {
     return scale.linear()
-      .domain([maxCoverage, 0])
+      .domain([this.maxCoverage, 0])
       .range([bottomPadding, this.height - topPadding])
       .nice();
   }
@@ -67,7 +68,7 @@ class CoverageTiledCanvas extends TiledCanvas {
          xScale: (x: number)=>number,
          range: ContigInterval<string>) {
     var bins = this.cache.binsForRef(range.contig);
-    var yScale = this.yScaleForRef(range.contig, 10, 10);
+    var yScale = this.yScaleForRef(10, 10);
     var relaxedRange = new ContigInterval(
         range.contig, range.start() - 1, range.stop() + 1);
     renderBars(ctx, xScale, yScale, relaxedRange, bins, this.options);
@@ -108,8 +109,8 @@ function renderBars(ctx: DataCanvasRenderingContext2D,
     var bin = bins[pos];
     if (!bin) continue;
 
-
-    if (!lastPos) {
+    // Restart path if first position or no bins before
+    if (!lastPos || !bins[pos-1]) {
       let {barX1} = binPos(pos, bin.count);
       ctx.fillStyle = `rgba(${options.color.rgb.r}, ${options.color.rgb.g}, ${options.color.rgb.b}, ${options.color.rgb.a})`;
       ctx.beginPath();
@@ -123,6 +124,12 @@ function renderBars(ctx: DataCanvasRenderingContext2D,
     if (showPadding) {
       ctx.lineTo(barX2, vBasePosY);
       ctx.lineTo(barX2 + 1, vBasePosY);
+    }
+    // close current path if next bin is going to be undefined
+    if (!bins[pos+1]) {
+      ctx.lineTo(barX2, vBasePosY);  // right edge of the right bar.
+      ctx.closePath();
+      ctx.fill();
     }
 
     if (SHOW_MISMATCHES && !_.isEmpty(bin.mismatches)) {
@@ -207,12 +214,12 @@ class CoverageTrack extends React.Component<VizProps<DataSource<Alignment | Feat
     this.tiles = new CoverageTiledCanvas(this.cache, this.props.height, this.props.options);
 
     this.props.source.on('newdata', range => {
-      var oldMax = this.cache.maxCoverageForRef(range.contig);
+      var oldMax = this.tiles.maxCoverage;
       this.props.source.getFeaturesInRange(range)
                        .forEach(read => this.cache.addItem(read));
-      var newMax = this.cache.maxCoverageForRef(range.contig);
+      this.tiles.maxCoverage = this.cache.maxCoverageForRange(range);
 
-      if (oldMax != newMax) {
+      if (oldMax != this.tiles.maxCoverage) {
         this.tiles.invalidateAll();
       } else {
         this.tiles.invalidateRange(range);
@@ -232,6 +239,7 @@ class CoverageTrack extends React.Component<VizProps<DataSource<Alignment | Feat
         !shallowEquals(this.state, prevState)) {
       if (this.props.height != prevProps.height ||
           this.props.options != prevProps.options) {
+        this.tiles.maxCoverage = this.cache.maxCoverageForRange(ContigInterval.fromGenomeRange(this.props.range));
         this.tiles.update(this.props.height, this.props.options);
         this.tiles.invalidateAll();
       }
@@ -289,7 +297,7 @@ class CoverageTrack extends React.Component<VizProps<DataSource<Alignment | Feat
     ctx.reset();
     ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
 
-    var yScale = this.tiles.yScaleForRef(range.contig, 10, 10);
+    var yScale = this.tiles.yScaleForRef(10, 10);
 
     this.tiles.renderToScreen(ctx, range, this.getScale());
     this.renderTicks(ctx, yScale);

--- a/src/test/viz/CoverageCache-test.js
+++ b/src/test/viz/CoverageCache-test.js
@@ -41,7 +41,7 @@ describe('CoverageCache', function() {
     expect(bins[800]).to.deep.equal({count: 2});
     expect(bins[850]).to.deep.equal({count: 2});
     expect(bins[851]).to.deep.equal({count: 1});
-    expect(cache.maxCoverageForRef('chr1')).to.equal(2);
+    expect(cache.maxCoverageForRange(new ContigInterval("chr1", 100, 900))).to.equal(2);
     done();
   });
 
@@ -61,7 +61,7 @@ describe('CoverageCache', function() {
     expect(bins[800]).to.deep.equal({count: 2});
     expect(bins[850]).to.deep.equal({count: 2});
     expect(bins[851]).to.deep.equal({count: 1});
-    expect(cache.maxCoverageForRef('chr1')).to.equal(2);
+    expect(cache.maxCoverageForRange(new ContigInterval('chr1', 100, 900))).to.equal(2);
     done();
   });
 
@@ -107,7 +107,7 @@ describe('CoverageCache', function() {
     expect(bins[18]).to.deep.equal({count: 3});
     expect(bins[19]).to.deep.equal({count: 2});
     expect(bins[20]).to.deep.equal({count: 1});
-    expect(cache.maxCoverageForRef('chr1')).to.equal(6);
+    expect(cache.maxCoverageForRange(new ContigInterval('chr1',10,16))).to.equal(6);
 
     // Now change the reference
     letter = 'C';
@@ -117,7 +117,7 @@ describe('CoverageCache', function() {
     expect(bins[12]).to.deep.equal({count: 3, ref: 'C', mismatches: {A: 2}});
     expect(bins[15]).to.deep.equal({count: 6, ref: 'C', mismatches: {A: 4, T: 1, G: 1}});
     expect(bins[17]).to.deep.equal({count: 4, ref: 'C', mismatches: {A: 2}});
-    expect(cache.maxCoverageForRef('chr1')).to.equal(6);
+    expect(cache.maxCoverageForRange(new ContigInterval('chr1',1,20))).to.equal(6);
     done();
   });
 

--- a/src/test/viz/CoverageTrack-test.js
+++ b/src/test/viz/CoverageTrack-test.js
@@ -195,11 +195,11 @@ describe('CoverageTrack', function() {
       // These are the objects being used to draw labels
       var labelTexts = findCoverageLabels();
       expect(labelTexts[0].label).to.equal('0X');
-      expect(labelTexts[labelTexts.length-1].label).to.equal('1X');
+      expect(labelTexts[labelTexts.length-1].label).to.equal('10X');
 
       // Now let's test if they are actually being put on the screen
       var texts = callsOf(testDiv, '.coverage', 'fillText');
-      expect(texts.map(t => t[1])).to.deep.equal(['0X', '1X', '1X']);
+      expect(texts.map(t => t[1])).to.deep.equal(['0X', '5X', '10X']);
     });
 
   });


### PR DESCRIPTION
There were two issues with coverage:
1. bars were being rendering incorrectly when there were undefined bins before a bar
2. max coverage was set to the max of the whole chromosome, making it hard to see coverage in regions with low coverage